### PR TITLE
Multi-org support + free tier as 5 free runs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,19 +27,22 @@ CRON_SECRET=replace-with-a-random-secret
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
 
 # --- Free trial (optional) ---
-# Let users run their first searches against YOUR shared keys, then prompt them
-# to add their own key once they cross the token threshold below. Leave the
+# Let users run their first monitors against YOUR shared keys, then prompt them
+# to add their own key once they've used their free runs. Leave the
 # TRIAL_*_API_KEY values unset to require bring-your-own-key from the start
 # (that is the default). Set a shared key for each provider you want to offer.
 TRIAL_ANTHROPIC_API_KEY=
 TRIAL_OPENAI_API_KEY=
-# Per-user token allowance before they must add their own key (default 100000).
-# THIS is the configurable trial threshold.
-TRIAL_TOKEN_LIMIT=100000
+# Free monitoring runs per user before they must add their own key (default 5).
+# THIS is the configurable trial threshold. Failed runs don't count.
+TRIAL_RUN_LIMIT=5
 # Optional: force a cheaper model during the trial to cap your cost.
 # Defaults to the project's selected model when unset.
 TRIAL_ANTHROPIC_MODEL=claude-haiku-4-5
 TRIAL_OPENAI_MODEL=gpt-4o-mini
+# Optional: embeddable video URL (e.g. a YouTube embed link) explaining the
+# bring-your-own-key model, shown when a user's free runs are used up.
+NEXT_PUBLIC_BYOK_VIDEO_URL=
 
 # ------------------------------------------------------------------
 # NOTE: This app is Bring-Your-Own-Key (BYOK). Users add their own

--- a/README.md
+++ b/README.md
@@ -17,13 +17,14 @@ Lettertrace is a self-hostable clone of tools like Profound / AthenaHQ / AirOps,
 - 🧩 **Topics → variations**, auto-generate the different questions people ask AI about each topic.
 - 📈 **Trends over time**, visibility, share of voice, prominence, and sentiment across runs.
 - ⚔️ **Competitor benchmarking**, ingest competitors and see how often each shows up.
+- 🏢 **Multiple organizations**, one account can track many brands/domains and switch between them from the sidebar.
 - ⏱️ **Scheduled monitoring**, daily/weekly runs via a cron endpoint.
 
 ## Core concepts
 
 | Concept | What it is |
 |---|---|
-| **Project** | Your brand's workspace: brand name, aliases, domain, default model, schedule. |
+| **Organization (project)** | A brand's workspace: brand name, aliases, domain, default model, schedule. An account can have several, the sidebar selector switches the whole dashboard between them, and **＋ New organization** re-opens the setup wizard. |
 | **Competitors** | Brands you benchmark against (name + aliases). |
 | **Topics** | Subjects you want to monitor (e.g. "project management software"). |
 | **Prompts (variations)** | Natural questions generated for a topic, the queries actually sent to the model. |
@@ -109,17 +110,18 @@ The endpoint uses the Supabase **service role** to find due projects across all 
 
 ## Free trial (optional)
 
-By default Lettertrace is bring-your-own-key: a user must add a key before running anything. You can optionally let people try it on **your** shared keys first, then prompt them to add their own once they cross a configurable token threshold.
+By default Lettertrace is bring-your-own-key: a user must add a key before running anything. You can optionally let people try it on **your** shared keys first — a configurable number of free monitoring runs (default **5**) — then prompt them to add their own.
 
 Set in your environment:
 
 - `TRIAL_ANTHROPIC_API_KEY` / `TRIAL_OPENAI_API_KEY`: the shared key(s) to lend out (set the provider(s) you want to offer). Leave unset to keep the app BYOK-only.
-- `TRIAL_TOKEN_LIMIT`: per-user token allowance before they must add their own key (default `100000`). **This is the configurable threshold.**
+- `TRIAL_RUN_LIMIT`: free monitoring runs per user before they must add their own key (default `5`). **This is the configurable threshold.** Failed runs don't count against it.
 - `TRIAL_ANTHROPIC_MODEL` / `TRIAL_OPENAI_MODEL`: optional cheaper models to cap your cost during the trial (default to the user's selected model).
+- `NEXT_PUBLIC_BYOK_VIDEO_URL`: optional embeddable video URL explaining the BYOK model, shown once the free runs are used up.
 
-While a user is under the threshold and has no key of their own, runs and variation generation use the shared key, and their token usage is metered on `profiles.trial_tokens_used`. A banner in the dashboard shows how much of the trial is left; once it's used up they're blocked with a clear prompt to add their own key. Adding a key removes the limit entirely. Scheduled (cron) runs always use the owner's own key, never the trial.
+While a user has free runs left and no key of their own, monitoring runs and variation generation use the shared key. Completed runs are counted on `profiles.trial_runs_used` (token spend is also recorded on `profiles.trial_tokens_used` so you can watch cost). A banner in the dashboard shows how many free runs are left; once they're gone, data collection stops with a clear prompt (and optional video) to add their own key. Adding a key removes the limit entirely. Scheduled (cron) runs always use the owner's own key, never the trial.
 
-> After upgrading, re-run `supabase/schema.sql`. It adds the `trial_tokens_used` column and the `increment_trial_tokens` function (safe to re-run).
+> After upgrading, re-run `supabase/schema.sql`. It adds the trial columns (`trial_runs_used`, `trial_tokens_used`), their increment functions, and the multi-organization column `profiles.active_project_id` (all safe to re-run).
 
 ## Deployment
 

--- a/app/api/onboarding/complete/route.ts
+++ b/app/api/onboarding/complete/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
-import { getProject } from "@/lib/data";
+import { setActiveProject } from "@/lib/data";
 import { executeRun } from "@/lib/engine";
 import { humanError } from "@/lib/llm";
-import { resolveRunKey, recordTrialUsage, pickDefaultProvider } from "@/lib/trial";
+import { resolveRunKey, recordTrialRun, recordTrialUsage, pickDefaultProvider } from "@/lib/trial";
 import { defaultModelFor } from "@/lib/models";
 import type { Project } from "@/lib/types";
 
@@ -29,19 +29,15 @@ function toStringArray(value: unknown): string[] {
 }
 
 // POST /api/onboarding/complete
-// Creates the project + topics + prompts, then immediately runs the first
-// monitor so the user lands on results. Returns { projectId, ran, runId }.
+// Creates an organization (project) + topics + prompts, makes it the active
+// one, then immediately runs the first monitor so the user lands on results.
+// Also used to add additional organizations. Returns { projectId, ran, runId }.
 export async function POST(request: Request) {
   const supabase = createClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
-  // Never create a second project for a user.
-  if (await getProject(supabase, user.id)) {
-    return NextResponse.json({ error: "You already have a project." }, { status: 400 });
-  }
 
   let body: Record<string, unknown> = {};
   try {
@@ -105,6 +101,9 @@ export async function POST(request: Request) {
   }
   const project = projRow as Project;
 
+  // The freshly created organization becomes the one the dashboard shows.
+  await setActiveProject(supabase, user.id, project.id);
+
   // Persist topics + their prompts.
   for (const topic of topics) {
     const { data: topicRow } = await supabase
@@ -141,7 +140,10 @@ export async function POST(request: Request) {
       model: key.model,
       apiKey: key.apiKey,
     });
-    if (key.source === "trial") await recordTrialUsage(supabase, result.tokensUsed);
+    if (key.source === "trial") {
+      await recordTrialUsage(supabase, result.tokensUsed);
+      if (result.status === "completed") await recordTrialRun(supabase);
+    }
     return NextResponse.json({
       projectId: project.id,
       ran: true,

--- a/app/api/project/route.ts
+++ b/app/api/project/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
-import { getProject } from "@/lib/data";
+import { getProject, setActiveProject } from "@/lib/data";
 import { isProvider, defaultModelFor } from "@/lib/models";
 import { pickDefaultProvider } from "@/lib/trial";
 import { humanError } from "@/lib/llm";
@@ -127,6 +127,7 @@ export async function POST(request: Request) {
     if (error) {
       return NextResponse.json({ error: humanError(error) }, { status: 500 });
     }
+    await setActiveProject(supabase, user.id, (data as { id: string }).id);
     return NextResponse.json(data);
   } catch (e) {
     return NextResponse.json({ error: humanError(e) }, { status: 500 });

--- a/app/api/project/switch/route.ts
+++ b/app/api/project/switch/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { setActiveProject } from "@/lib/data";
+
+// POST /api/project/switch { projectId }
+// Point the dashboard at another of the signed-in user's organizations.
+export async function POST(request: Request) {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  const projectId = (body as { projectId?: unknown })?.projectId;
+  if (typeof projectId !== "string" || !projectId) {
+    return NextResponse.json({ error: "projectId is required" }, { status: 400 });
+  }
+
+  // Only switch to an organization the user actually owns.
+  const { data: project } = await supabase
+    .from("projects")
+    .select("id")
+    .eq("id", projectId)
+    .eq("user_id", user.id)
+    .maybeSingle();
+  if (!project) {
+    return NextResponse.json({ error: "Organization not found" }, { status: 404 });
+  }
+
+  await setActiveProject(supabase, user.id, projectId);
+  return NextResponse.json({ ok: true, projectId });
+}

--- a/app/api/runs/route.ts
+++ b/app/api/runs/route.ts
@@ -4,7 +4,7 @@ import { getProject } from "@/lib/data";
 import { executeRun } from "@/lib/engine";
 import { humanError } from "@/lib/llm";
 import { PROVIDERS } from "@/lib/models";
-import { resolveRunKey, recordTrialUsage } from "@/lib/trial";
+import { resolveRunKey, recordTrialRun, recordTrialUsage } from "@/lib/trial";
 
 export const maxDuration = 300;
 export const dynamic = "force-dynamic";
@@ -37,7 +37,7 @@ export async function POST() {
   if (key.source === "exhausted") {
     return NextResponse.json(
       {
-        error: `You've used all ${key.limit?.toLocaleString()} free trial tokens. Add your own ${providerLabel} key in Settings to keep running.`,
+        error: `You've used all ${key.limit ?? 0} free runs. Add your own ${providerLabel} key in Settings to keep monitoring.`,
         trialExhausted: true,
       },
       { status: 402 },
@@ -53,9 +53,12 @@ export async function POST() {
       apiKey: key.apiKey!,
     });
 
-    // Meter trial usage against the operator's shared key.
+    // Meter trial usage against the operator's shared key. Only a run that
+    // actually completed burns one of the free runs; tokens are recorded
+    // either way so the operator can watch spend.
     if (key.source === "trial") {
       await recordTrialUsage(supabase, result.tokensUsed);
+      if (result.status === "completed") await recordTrialRun(supabase);
     }
 
     return NextResponse.json({ ...result, keySource: key.source });

--- a/app/api/topics/[id]/generate/route.ts
+++ b/app/api/topics/[id]/generate/route.ts
@@ -59,7 +59,7 @@ export async function POST(
   if (key.source === "exhausted") {
     return NextResponse.json(
       {
-        error: `You've used all ${key.limit?.toLocaleString()} free trial tokens. Add your own ${providerLabel} key in Settings to keep generating.`,
+        error: `You've used all ${key.limit ?? 0} free runs. Add your own ${providerLabel} key in Settings to keep generating.`,
         trialExhausted: true,
       },
       { status: 402 },

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,11 +1,12 @@
 import type { ReactNode } from "react";
 import { Logo } from "@/components/logo";
 import { DashboardNav } from "@/components/dashboard/nav";
+import { OrgSwitcher } from "@/components/dashboard/org-switcher";
 import { SignOutButton } from "@/components/dashboard/signout";
 import { TrialBanner } from "@/components/dashboard/trial-banner";
 import { createClient } from "@/lib/supabase/server";
-import { getProject, getConfiguredProviders } from "@/lib/data";
-import { trialEnabled, trialTokenLimit, getTrialUsage } from "@/lib/trial";
+import { getProject, getProjects, getConfiguredProviders } from "@/lib/data";
+import { trialEnabled, trialRunLimit, getTrialRunsUsed } from "@/lib/trial";
 
 export const dynamic = "force-dynamic";
 
@@ -20,16 +21,19 @@ export default async function DashboardLayout({
   } = await supabase.auth.getUser();
   if (!user) return null;
 
-  const project = await getProject(supabase, user.id);
+  const [project, projects] = await Promise.all([
+    getProject(supabase, user.id),
+    getProjects(supabase, user.id),
+  ]);
 
   // Trial banner state: only when a trial is offered and the user is relying on
-  // shared keys (no own key for their default provider).
+  // shared keys (no own key for their default provider). Metered in free runs.
   let trial: { used: number; limit: number; exhausted: boolean } | null = null;
   if (project && trialEnabled()) {
     const providers = await getConfiguredProviders(supabase, user.id);
     if (!providers.includes(project.default_provider)) {
-      const used = await getTrialUsage(supabase, user.id);
-      const limit = trialTokenLimit();
+      const used = await getTrialRunsUsed(supabase, user.id);
+      const limit = trialRunLimit();
       trial = { used, limit, exhausted: used >= limit };
     }
   }
@@ -40,20 +44,20 @@ export default async function DashboardLayout({
         <div className="flex flex-col gap-6 px-5 py-6 md:h-full">
           <Logo />
 
-          <div className="rounded-2xl border border-ink/10 bg-paper-shade/50 px-4 py-3">
-            {project ? (
-              <>
-                <p className="truncate font-serif text-sm font-semibold text-ink">
-                  {project.brand_name}
-                </p>
-                <p className="mt-0.5 truncate text-xs text-ink-faint">
-                  {project.name}
-                </p>
-              </>
-            ) : (
-              <p className="text-sm text-ink-faint">No project yet</p>
-            )}
-          </div>
+          {project ? (
+            <OrgSwitcher
+              orgs={projects.map((p) => ({
+                id: p.id,
+                name: p.name,
+                brandName: p.brand_name,
+              }))}
+              activeId={project.id}
+            />
+          ) : (
+            <div className="rounded-2xl border border-ink/10 bg-paper-shade/50 px-4 py-3">
+              <p className="text-sm text-ink-faint">No organization yet</p>
+            </div>
+          )}
 
           <DashboardNav />
 

--- a/app/dashboard/new/page.tsx
+++ b/app/dashboard/new/page.tsx
@@ -1,0 +1,9 @@
+import { Onboarding } from "../onboarding";
+
+export const dynamic = "force-dynamic";
+
+// Add another organization to the account: same wizard as first-run onboarding.
+// Completing it creates the org, makes it active, and runs its first monitor.
+export default function NewOrganizationPage() {
+  return <Onboarding />;
+}

--- a/app/dashboard/onboarding.tsx
+++ b/app/dashboard/onboarding.tsx
@@ -151,7 +151,10 @@ export function Onboarding() {
         setBusy(false);
         return;
       }
-      // Project (and, ideally, the first run) now exist. Reveal the dashboard.
+      // The org (and, ideally, its first run) now exist and it's the active
+      // one. Land on the overview whether we came from first-run onboarding
+      // or from "New organization".
+      router.push("/dashboard");
       router.refresh();
     } catch {
       setError("Network error while starting your first search.");

--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -51,10 +51,10 @@ export default async function SettingsPage() {
               <Building2 className="h-5 w-5" />
             </span>
             <div>
-              <h3 className="text-lg font-semibold text-ink">Brand &amp; project</h3>
+              <h3 className="text-lg font-semibold text-ink">Organization</h3>
               <p className="mt-1 text-sm text-ink-faint">
                 {project
-                  ? "Tune how we recognize your brand across AI answers."
+                  ? `Settings for ${project.brand_name}, the organization selected in the sidebar. Tune how we recognize this brand across AI answers.`
                   : "Fill this in to get started, it powers prompt generation and mention detection."}
               </p>
             </div>

--- a/components/dashboard/org-switcher.tsx
+++ b/components/dashboard/org-switcher.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState, useTransition } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { Check, ChevronsUpDown, Plus } from "lucide-react";
+import { ArrowLeftRight, Check, ChevronsUpDown, Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 export interface OrgOption {
@@ -15,34 +15,48 @@ export interface OrgOption {
 }
 
 // Sidebar organization switcher: pick which of the account's organizations the
-// dashboard shows, or jump to creating a new one.
+// dashboard shows, or jump to creating a new one. Switching is optimistic: the
+// menu closes and the button shows the new org immediately, while a full-screen
+// loader covers the server round-trip + dashboard re-render.
 export function OrgSwitcher({ orgs, activeId }: { orgs: OrgOption[]; activeId: string }) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
-  const [busy, setBusy] = useState(false);
+  const [pendingOrg, setPendingOrg] = useState<OrgOption | null>(null);
+  const [isPending, startTransition] = useTransition();
 
   const active = orgs.find((o) => o.id === activeId) ?? orgs[0];
+  // What the button shows: the org we're switching to wins until the server
+  // catches up (activeId prop updates after the refresh).
+  const shown = pendingOrg ?? active;
 
-  async function switchTo(id: string) {
-    if (!active || id === active.id) {
-      setOpen(false);
-      return;
+  // The switch is done once the re-rendered layout hands us the new activeId.
+  useEffect(() => {
+    if (pendingOrg && activeId === pendingOrg.id && !isPending) {
+      setPendingOrg(null);
     }
-    setBusy(true);
+  }, [pendingOrg, activeId, isPending]);
+
+  async function switchTo(org: OrgOption) {
+    setOpen(false);
+    if (!active || org.id === active.id) return;
+    setPendingOrg(org);
     try {
       const res = await fetch("/api/project/switch", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ projectId: id }),
+        body: JSON.stringify({ projectId: org.id }),
       });
-      if (res.ok) {
-        setOpen(false);
+      if (!res.ok) {
+        setPendingOrg(null);
+        return;
+      }
+      startTransition(() => {
         // Land on the overview so the whole view belongs to the new org.
         router.push("/dashboard");
         router.refresh();
-      }
-    } finally {
-      setBusy(false);
+      });
+    } catch {
+      setPendingOrg(null);
     }
   }
 
@@ -51,17 +65,16 @@ export function OrgSwitcher({ orgs, activeId }: { orgs: OrgOption[]; activeId: s
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
-        disabled={busy}
         aria-haspopup="listbox"
         aria-expanded={open}
-        className="flex w-full items-center justify-between gap-2 rounded-2xl border border-ink/10 bg-paper-shade/50 px-4 py-3 text-left transition hover:border-ink/25 disabled:opacity-60"
+        className="flex w-full items-center justify-between gap-2 rounded-2xl border border-ink/10 bg-paper-shade/50 px-4 py-3 text-left transition hover:border-ink/25"
       >
         <span className="min-w-0">
           <span className="block truncate font-serif text-sm font-semibold text-ink">
-            {active?.brandName ?? "Select organization"}
+            {shown?.brandName ?? "Select organization"}
           </span>
           <span className="mt-0.5 block truncate text-xs text-ink-faint">
-            {active?.name}
+            {shown?.name}
           </span>
         </span>
         <ChevronsUpDown className="h-4 w-4 shrink-0 text-ink-faint" aria-hidden />
@@ -93,8 +106,7 @@ export function OrgSwitcher({ orgs, activeId }: { orgs: OrgOption[]; activeId: s
                       type="button"
                       role="option"
                       aria-selected={isActive}
-                      onClick={() => switchTo(org.id)}
-                      disabled={busy}
+                      onClick={() => switchTo(org)}
                       className={cn(
                         "flex w-full items-center justify-between gap-2 px-4 py-2 text-left text-sm transition",
                         isActive ? "bg-terracotta/10 text-terracotta-dark" : "text-ink hover:bg-ink/5",
@@ -122,6 +134,26 @@ export function OrgSwitcher({ orgs, activeId }: { orgs: OrgOption[]; activeId: s
             </Link>
           </div>
         </>
+      )}
+
+      {/* Full-screen loader while the dashboard re-renders as the new org. */}
+      {pendingOrg && (
+        <div
+          className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-paper/85 backdrop-blur-sm"
+          role="status"
+          aria-live="polite"
+        >
+          <div className="relative flex h-16 w-16 items-center justify-center">
+            <span className="absolute inset-0 animate-ping rounded-full bg-terracotta/20" />
+            <span className="flex h-16 w-16 items-center justify-center rounded-2xl bg-terracotta/10 text-terracotta">
+              <ArrowLeftRight className="h-7 w-7" aria-hidden />
+            </span>
+          </div>
+          <p className="mt-5 font-serif text-lg font-semibold text-ink">
+            {pendingOrg.brandName}
+          </p>
+          <p className="mt-1 text-sm text-ink-faint">Switching organization…</p>
+        </div>
       )}
     </div>
   );

--- a/components/dashboard/org-switcher.tsx
+++ b/components/dashboard/org-switcher.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { Check, ChevronsUpDown, Plus } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface OrgOption {
+  id: string;
+  /** Workspace name (projects.name). */
+  name: string;
+  /** Brand being monitored (projects.brand_name). */
+  brandName: string;
+}
+
+// Sidebar organization switcher: pick which of the account's organizations the
+// dashboard shows, or jump to creating a new one.
+export function OrgSwitcher({ orgs, activeId }: { orgs: OrgOption[]; activeId: string }) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  const active = orgs.find((o) => o.id === activeId) ?? orgs[0];
+
+  async function switchTo(id: string) {
+    if (!active || id === active.id) {
+      setOpen(false);
+      return;
+    }
+    setBusy(true);
+    try {
+      const res = await fetch("/api/project/switch", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ projectId: id }),
+      });
+      if (res.ok) {
+        setOpen(false);
+        // Land on the overview so the whole view belongs to the new org.
+        router.push("/dashboard");
+        router.refresh();
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        disabled={busy}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        className="flex w-full items-center justify-between gap-2 rounded-2xl border border-ink/10 bg-paper-shade/50 px-4 py-3 text-left transition hover:border-ink/25 disabled:opacity-60"
+      >
+        <span className="min-w-0">
+          <span className="block truncate font-serif text-sm font-semibold text-ink">
+            {active?.brandName ?? "Select organization"}
+          </span>
+          <span className="mt-0.5 block truncate text-xs text-ink-faint">
+            {active?.name}
+          </span>
+        </span>
+        <ChevronsUpDown className="h-4 w-4 shrink-0 text-ink-faint" aria-hidden />
+      </button>
+
+      {open && (
+        <>
+          {/* Click-away layer */}
+          <button
+            type="button"
+            aria-label="Close organization menu"
+            onClick={() => setOpen(false)}
+            className="fixed inset-0 z-10 cursor-default"
+            tabIndex={-1}
+          />
+          <div
+            role="listbox"
+            className="absolute left-0 right-0 z-20 mt-2 overflow-hidden rounded-2xl border border-ink/10 bg-paper shadow-card"
+          >
+            <p className="px-4 pb-1 pt-3 text-[11px] font-medium uppercase tracking-wide text-ink-faint">
+              Organizations
+            </p>
+            <ul className="max-h-64 overflow-y-auto pb-1">
+              {orgs.map((org) => {
+                const isActive = org.id === active?.id;
+                return (
+                  <li key={org.id}>
+                    <button
+                      type="button"
+                      role="option"
+                      aria-selected={isActive}
+                      onClick={() => switchTo(org.id)}
+                      disabled={busy}
+                      className={cn(
+                        "flex w-full items-center justify-between gap-2 px-4 py-2 text-left text-sm transition",
+                        isActive ? "bg-terracotta/10 text-terracotta-dark" : "text-ink hover:bg-ink/5",
+                      )}
+                    >
+                      <span className="min-w-0">
+                        <span className="block truncate font-medium">{org.brandName}</span>
+                        {org.name !== org.brandName && (
+                          <span className="block truncate text-xs text-ink-faint">{org.name}</span>
+                        )}
+                      </span>
+                      {isActive && <Check className="h-4 w-4 shrink-0" aria-hidden />}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+            <Link
+              href="/dashboard/new"
+              onClick={() => setOpen(false)}
+              className="flex items-center gap-2 border-t border-ink/10 px-4 py-2.5 text-sm font-medium text-terracotta-dark transition hover:bg-ink/5"
+            >
+              <Plus className="h-4 w-4" aria-hidden />
+              New organization
+            </Link>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/components/dashboard/trial-banner.tsx
+++ b/components/dashboard/trial-banner.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/lib/utils";
 
 // Shown in the dashboard when a user is running on the operator's shared (trial)
 // keys instead of their own. Nudges them toward BYOK, and hard-stops the message
-// once they've crossed the configurable token threshold.
+// once their free runs are used up. `used`/`limit` are monitoring runs.
 export function TrialBanner({
   used,
   limit,
@@ -15,48 +15,74 @@ export function TrialBanner({
   exhausted: boolean;
 }) {
   const remaining = Math.max(0, limit - used);
-  const pctUsed = limit > 0 ? Math.min(100, Math.round((used / limit) * 100)) : 100;
+  // Optional walkthrough explaining the BYOK model, shown once the free runs
+  // are gone. Any embeddable player URL (e.g. a YouTube embed link).
+  const videoUrl = process.env.NEXT_PUBLIC_BYOK_VIDEO_URL;
 
   return (
     <div
       className={cn(
-        "mb-6 flex flex-col gap-3 rounded-2xl border px-5 py-4 sm:flex-row sm:items-center sm:justify-between",
+        "mb-6 rounded-2xl border px-5 py-4",
         exhausted ? "border-terracotta/30 bg-terracotta/[0.07]" : "border-teal/25 bg-teal/[0.06]",
       )}
     >
-      <div className="flex items-start gap-3">
-        <span
-          className={cn(
-            "mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg",
-            exhausted ? "bg-terracotta/15 text-terracotta-dark" : "bg-teal/15 text-teal-900",
-          )}
-        >
-          {exhausted ? <KeyRound className="h-4 w-4" /> : <Sparkles className="h-4 w-4" />}
-        </span>
-        <div>
-          <p className="text-sm font-medium text-ink">
-            {exhausted ? "Free trial used up" : "You're on the free trial"}
-          </p>
-          <p className="mt-0.5 text-xs text-ink-faint">
-            {exhausted
-              ? "Add your own API key to keep running searches and generating variations."
-              : `Running on shared keys. ${remaining.toLocaleString()} of ${limit.toLocaleString()} trial tokens left. Add your own key to scale.`}
-          </p>
-          {!exhausted && (
-            <div className="mt-2 h-1.5 w-48 max-w-full overflow-hidden rounded-full bg-ink/[0.08]">
-              <div className="h-full rounded-full bg-teal" style={{ width: `${pctUsed}%` }} />
-            </div>
-          )}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-start gap-3">
+          <span
+            className={cn(
+              "mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg",
+              exhausted ? "bg-terracotta/15 text-terracotta-dark" : "bg-teal/15 text-teal-900",
+            )}
+          >
+            {exhausted ? <KeyRound className="h-4 w-4" /> : <Sparkles className="h-4 w-4" />}
+          </span>
+          <div>
+            <p className="text-sm font-medium text-ink">
+              {exhausted ? "Your free runs are used up" : "You're on the free trial"}
+            </p>
+            <p className="mt-0.5 text-xs text-ink-faint">
+              {exhausted
+                ? "Monitoring is paused. Add your own API key to keep collecting data."
+                : `Running on our keys, on the house. ${remaining} of ${limit} free ${
+                    limit === 1 ? "run" : "runs"
+                  } left, then you bring your own key.`}
+            </p>
+            {!exhausted && limit <= 12 && (
+              <div className="mt-2 flex items-center gap-1.5">
+                {Array.from({ length: limit }, (_, i) => (
+                  <span
+                    key={i}
+                    className={cn(
+                      "h-1.5 w-6 rounded-full",
+                      i < used ? "bg-teal" : "bg-ink/[0.08]",
+                    )}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
         </div>
+        <Button
+          href="/dashboard/settings"
+          size="sm"
+          variant={exhausted ? "primary" : "secondary"}
+          className="shrink-0"
+        >
+          Add your key
+        </Button>
       </div>
-      <Button
-        href="/dashboard/settings"
-        size="sm"
-        variant={exhausted ? "primary" : "secondary"}
-        className="shrink-0"
-      >
-        Add your key
-      </Button>
+
+      {exhausted && videoUrl && (
+        <div className="mt-4 overflow-hidden rounded-xl border border-ink/10">
+          <iframe
+            src={videoUrl}
+            title="Why you bring your own key"
+            className="aspect-video w-full"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -5,11 +5,47 @@ import type { Project, Provider, ProviderKeyPublic } from "@/lib/types";
 // Server-side data helpers shared across pages and route handlers.
 // All expect a Supabase client already scoped to the request (RLS).
 
-/** The user's active project (the earliest one they created), or null. */
+/** All of the user's projects (organizations), oldest first. */
+export async function getProjects(
+  supabase: SupabaseClient,
+  userId: string,
+): Promise<Project[]> {
+  const { data } = await supabase
+    .from("projects")
+    .select("*")
+    .eq("user_id", userId)
+    .order("created_at", { ascending: true });
+  return (data as Project[] | null) ?? [];
+}
+
+/**
+ * The user's active project (organization): the one selected via the org
+ * switcher (profiles.active_project_id), falling back to the earliest project
+ * they created. Null when they have no projects yet.
+ */
 export async function getProject(
   supabase: SupabaseClient,
   userId: string,
 ): Promise<Project | null> {
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("active_project_id")
+    .eq("id", userId)
+    .maybeSingle();
+  const activeId = (profile as { active_project_id?: string | null } | null)
+    ?.active_project_id;
+
+  if (activeId) {
+    const { data } = await supabase
+      .from("projects")
+      .select("*")
+      .eq("id", activeId)
+      .eq("user_id", userId)
+      .maybeSingle();
+    if (data) return data as Project;
+    // Stale pointer (project deleted / not the user's): fall through.
+  }
+
   const { data } = await supabase
     .from("projects")
     .select("*")
@@ -18,6 +54,18 @@ export async function getProject(
     .limit(1)
     .maybeSingle();
   return (data as Project | null) ?? null;
+}
+
+/** Point the dashboard at another of the user's organizations. */
+export async function setActiveProject(
+  supabase: SupabaseClient,
+  userId: string,
+  projectId: string,
+): Promise<void> {
+  await supabase
+    .from("profiles")
+    .update({ active_project_id: projectId })
+    .eq("id", userId);
 }
 
 /** Safe (no ciphertext) list of the user's stored provider keys. */

--- a/lib/trial.ts
+++ b/lib/trial.ts
@@ -5,18 +5,19 @@ import { defaultModelFor } from "@/lib/models";
 
 // ------------------------------------------------------------------
 // Free-trial layer. When the operator configures a shared (trial) key, users
-// who haven't added their own key may run against it until they cross a
-// CONFIGURABLE token threshold, after which they're prompted to bring their own
-// key to scale. With no trial keys set, the app is bring-your-own-key from the
-// start (the default).
+// who haven't added their own key get a CONFIGURABLE number of free monitoring
+// runs on it (default 5). After that, data collection stops until they bring
+// their own key. With no trial keys set, the app is bring-your-own-key from
+// the start (the default). Token usage is still recorded per user so the
+// operator can watch spend, but the gate is runs.
 // ------------------------------------------------------------------
 
-const DEFAULT_TRIAL_LIMIT = 100_000;
+const DEFAULT_TRIAL_RUN_LIMIT = 5;
 
-/** The configurable per-user trial token allowance (env: TRIAL_TOKEN_LIMIT). */
-export function trialTokenLimit(): number {
-  const raw = Number(process.env.TRIAL_TOKEN_LIMIT);
-  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : DEFAULT_TRIAL_LIMIT;
+/** The configurable per-user free-run allowance (env: TRIAL_RUN_LIMIT). */
+export function trialRunLimit(): number {
+  const raw = Number(process.env.TRIAL_RUN_LIMIT);
+  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : DEFAULT_TRIAL_RUN_LIMIT;
 }
 
 /** The operator's shared key for a provider, if configured. */
@@ -42,17 +43,17 @@ export function trialEnabled(): boolean {
   return Boolean(trialKeyFor("anthropic") || trialKeyFor("openai"));
 }
 
-/** How many trial tokens this user has already consumed. */
-export async function getTrialUsage(
+/** How many free trial runs this user has already consumed. */
+export async function getTrialRunsUsed(
   supabase: SupabaseClient,
   userId: string,
 ): Promise<number> {
   const { data } = await supabase
     .from("profiles")
-    .select("trial_tokens_used")
+    .select("trial_runs_used")
     .eq("id", userId)
     .maybeSingle();
-  return Number((data as { trial_tokens_used?: number } | null)?.trial_tokens_used ?? 0);
+  return Number((data as { trial_runs_used?: number } | null)?.trial_runs_used ?? 0);
 }
 
 export type KeySource = "own" | "trial" | "none" | "exhausted";
@@ -62,8 +63,8 @@ export interface ResolvedKey {
   apiKey?: string;
   provider: Provider;
   model: string; // model to run with (own -> project model; trial -> trial override)
-  remaining?: number; // trial tokens left (for 'trial'/'exhausted')
-  limit?: number;
+  remaining?: number; // free runs left (for 'trial'/'exhausted')
+  limit?: number; // the free-run allowance
 }
 
 /** The provider new projects default to: one we can actually serve (has a trial key), else anthropic. */
@@ -80,11 +81,11 @@ const PROVIDER_ORDER: Record<Provider, Provider[]> = {
 
 /**
  * Resolve the best available key for a task, preferring `preferred` then falling
- * back to the other provider. Own key beats trial; trial requires being under the
- * token threshold. This is what lets users never pick a provider themselves.
+ * back to the other provider. Own key beats trial; trial requires free runs
+ * remaining. This is what lets users never pick a provider themselves.
  * - 'own'       the user's own key (unlimited by us)
- * - 'trial'     the operator's shared key, still under the token threshold
- * - 'exhausted' had trial access but crossed the threshold -> must add own key
+ * - 'trial'     the operator's shared key, free runs still remaining
+ * - 'exhausted' had trial access but used up their free runs -> must add own key
  * - 'none'      no own key and no trial configured -> must add own key
  */
 export async function resolveKey(
@@ -103,9 +104,9 @@ export async function resolveKey(
     if (own) return { source: "own", apiKey: own, provider: p, model: modelFor(p) };
   }
 
-  // 2. A trial key, if still under the token threshold.
-  const limit = trialTokenLimit();
-  const used = await getTrialUsage(supabase, userId);
+  // 2. A trial key, if free runs remain.
+  const limit = trialRunLimit();
+  const used = await getTrialRunsUsed(supabase, userId);
   let trialConfigured = false;
   for (const p of order) {
     const tk = trialKeyFor(p);
@@ -138,11 +139,17 @@ export async function resolveRunKey(
   return resolveKey(supabase, userId, project.default_provider, project.default_model);
 }
 
-/** Add consumed tokens to the caller's trial tally (atomic, self-scoped rpc). */
+/** Add consumed tokens to the caller's trial tally (atomic, self-scoped rpc).
+ * Recording only; the free tier is gated on runs, not tokens. */
 export async function recordTrialUsage(
   supabase: SupabaseClient,
   tokens: number,
 ): Promise<void> {
   if (!tokens || tokens <= 0) return;
   await supabase.rpc("increment_trial_tokens", { amount: Math.round(tokens) });
+}
+
+/** Count one monitoring run against the caller's free-run allowance. */
+export async function recordTrialRun(supabase: SupabaseClient): Promise<void> {
+  await supabase.rpc("increment_trial_runs");
 }

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -50,6 +50,23 @@ as $$
     returning trial_tokens_used;
 $$;
 
+-- Free-trial gating is per RUN: monitoring runs executed on the operator's
+-- shared keys before the user brings their own (tokens above are still
+-- recorded so the operator can watch spend). Safe to re-run.
+alter table public.profiles
+  add column if not exists trial_runs_used integer not null default 0;
+
+create or replace function public.increment_trial_runs()
+returns integer
+language sql
+security definer set search_path = public
+as $$
+  update public.profiles
+    set trial_runs_used = trial_runs_used + 1
+    where id = auth.uid()
+    returning trial_runs_used;
+$$;
+
 -- ---------- provider_keys (BYOK, encrypted) -------------------------
 create table if not exists public.provider_keys (
   id uuid primary key default gen_random_uuid(),
@@ -78,6 +95,12 @@ create table if not exists public.projects (
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now()
 );
+
+-- Multi-org: which of the user's projects (organizations) the dashboard is
+-- currently showing. Falls back to the earliest project when unset. Safe to
+-- re-run; lives here because it references projects, created just above.
+alter table public.profiles
+  add column if not exists active_project_id uuid references public.projects (id) on delete set null;
 
 -- ---------- competitors ----------------------------------------------
 create table if not exists public.competitors (


### PR DESCRIPTION
## Overview

Implements the first two roadmap items from the July 23 kickoff:

**1. Multi-organization support** — one account can now track multiple organizations (brands/domains). A sidebar switcher flips the entire dashboard between orgs (optimistic UI with a loading overlay), and “＋ New organization” reuses the onboarding wizard. Selection persists per account via `profiles.active_project_id`.

**2. Free tier: 5 free runs, then BYOK** — trial gating moves from a token threshold to `TRIAL_RUN_LIMIT` (default 5) free monitoring runs per user; only completed runs count, and token spend is still recorded for cost visibility. When runs are used up, data collection stops with a clear prompt (and a slot for the BYOK explainer video via `NEXT_PUBLIC_BYOK_VIDEO_URL`).

Schema changes are additive/idempotent and already applied to the shared Supabase project. Verified end-to-end against live Supabase + shared trial keys (org creation/switching, a real trial run, simulated exhaustion). `typecheck` / `lint` / `build` clean.
<img width="1706" height="981" alt="Screenshot 2026-07-23 at 1 54 58 PM" src="https://github.com/user-attachments/assets/307396af-b9cd-44cc-b320-91ec8f5d8b52" />

<img width="1710" height="983" alt="Screenshot 2026-07-23 at 1 55 10 PM" src="https://github.com/user-attachments/assets/b283e3be-ac15-401c-98d4-067d71403319" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)