### PR TITLE
AI competitor suggestions (Claude as judge)

### DIFF
--- a/app/api/competitors/suggest/route.ts
+++ b/app/api/competitors/suggest/route.ts
@@ -1,0 +1,80 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { getProject } from "@/lib/data";
+import { suggestCompetitors, humanError } from "@/lib/llm";
+import { PROVIDERS } from "@/lib/models";
+import { resolveRunKey, recordTrialUsage } from "@/lib/trial";
+import type { Competitor, Topic } from "@/lib/types";
+
+export const maxDuration = 60;
+export const dynamic = "force-dynamic";
+
+// POST /api/competitors/suggest
+// Ask the model for direct competitors of the active org's brand, excluding
+// ones already tracked. Uses the same key resolution (own -> trial) as runs.
+export async function POST() {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const project = await getProject(supabase, user.id);
+  if (!project) {
+    return NextResponse.json({ error: "Create a project first" }, { status: 400 });
+  }
+
+  const [{ data: competitorRows }, { data: topicRows }] = await Promise.all([
+    supabase.from("competitors").select("*").eq("project_id", project.id),
+    supabase.from("topics").select("*").eq("project_id", project.id),
+  ]);
+  const existing = ((competitorRows ?? []) as Competitor[]).map((c) => c.name);
+  const topics = ((topicRows ?? []) as Topic[]).map((t) => t.name);
+
+  const providerLabel = PROVIDERS[project.default_provider].label;
+  const key = await resolveRunKey(supabase, user.id, project);
+
+  if (key.source === "none") {
+    return NextResponse.json(
+      { error: `Add a ${providerLabel} key in Settings first.` },
+      { status: 400 },
+    );
+  }
+  if (key.source === "exhausted") {
+    return NextResponse.json(
+      {
+        error: `You've used all ${key.limit ?? 0} free runs. Add your own ${providerLabel} key in Settings to keep going.`,
+        trialExhausted: true,
+      },
+      { status: 402 },
+    );
+  }
+
+  try {
+    const { suggestions, tokens } = await suggestCompetitors({
+      provider: key.provider,
+      model: key.model,
+      apiKey: key.apiKey!,
+      brandName: project.brand_name,
+      brandDomain: project.brand_domain,
+      description: project.description,
+      topics,
+      existing,
+      count: 6,
+    });
+
+    if (key.source === "trial") await recordTrialUsage(supabase, tokens);
+
+    // Belt-and-braces: drop the brand itself and anything already tracked.
+    const taken = new Set(
+      [project.brand_name, ...project.brand_aliases, ...existing].map((n) =>
+        n.trim().toLowerCase(),
+      ),
+    );
+    const fresh = suggestions.filter((s) => !taken.has(s.name.trim().toLowerCase()));
+
+    return NextResponse.json({ suggestions: fresh });
+  } catch (e) {
+    return NextResponse.json({ error: humanError(e) }, { status: 500 });
+  }
+}

--- a/app/dashboard/competitors/competitors-client.tsx
+++ b/app/dashboard/competitors/competitors-client.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { useState } from "react";
-import { Building2, Trash2, Users } from "lucide-react";
+import { Building2, Plus, Sparkles, Trash2, Users, X } from "lucide-react";
 import {
   Badge,
   Button,
@@ -16,6 +16,13 @@ import {
 import type { Competitor } from "@/lib/types";
 
 const ALIAS_TONES = ["teal", "sand", "mint"] as const;
+
+interface Suggestion {
+  name: string;
+  domain: string | null;
+  aliases: string[];
+  reason: string;
+}
 
 function parseAliases(raw: string): string[] {
   return raw
@@ -32,6 +39,60 @@ export function CompetitorsClient({ competitors }: { competitors: Competitor[] }
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [removingId, setRemovingId] = useState<string | null>(null);
+
+  // AI competitor suggestions. `null` = not asked yet.
+  const [suggestions, setSuggestions] = useState<Suggestion[] | null>(null);
+  const [suggesting, setSuggesting] = useState(false);
+  const [suggestError, setSuggestError] = useState<string | null>(null);
+  const [addingSuggestion, setAddingSuggestion] = useState<string | null>(null);
+
+  async function handleSuggest() {
+    if (suggesting) return;
+    setSuggesting(true);
+    setSuggestError(null);
+    try {
+      const res = await fetch("/api/competitors/suggest", { method: "POST" });
+      const json = await res.json();
+      if (!res.ok) {
+        setSuggestError(json.error ?? "Could not fetch suggestions.");
+        return;
+      }
+      const fresh: Suggestion[] = Array.isArray(json.suggestions) ? json.suggestions : [];
+      setSuggestions(fresh);
+    } catch {
+      setSuggestError("Network error. Please try again.");
+    } finally {
+      setSuggesting(false);
+    }
+  }
+
+  async function handleAddSuggestion(s: Suggestion) {
+    if (addingSuggestion) return;
+    setAddingSuggestion(s.name);
+    setSuggestError(null);
+    try {
+      const res = await fetch("/api/competitors", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: s.name, aliases: s.aliases, domain: s.domain }),
+      });
+      if (!res.ok) {
+        const json = await res.json().catch(() => ({}));
+        setSuggestError(json.error ?? "Could not add competitor.");
+        return;
+      }
+      setSuggestions((prev) => (prev ?? []).filter((x) => x.name !== s.name));
+      router.refresh();
+    } catch {
+      setSuggestError("Network error. Please try again.");
+    } finally {
+      setAddingSuggestion(null);
+    }
+  }
+
+  function dismissSuggestion(name: string) {
+    setSuggestions((prev) => (prev ?? []).filter((x) => x.name !== name));
+  }
 
   async function handleAdd(e: React.FormEvent) {
     e.preventDefault();
@@ -128,6 +189,88 @@ export function CompetitorsClient({ competitors }: { competitors: Competitor[] }
               {error && <p className="text-sm text-terracotta-dark">{error}</p>}
             </div>
           </form>
+        </CardBody>
+      </Card>
+
+      <Card>
+        <CardBody>
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="flex items-start gap-3">
+              <span className="mt-0.5 rounded-xl bg-terracotta/10 p-2 text-terracotta">
+                <Sparkles className="h-5 w-5" />
+              </span>
+              <div>
+                <h3 className="text-lg font-semibold text-ink">Suggested competitors</h3>
+                <p className="mt-1 text-sm text-ink-faint">
+                  Let AI propose direct competitors based on your brand and topics. You decide
+                  which ones to track.
+                </p>
+              </div>
+            </div>
+            <Button variant="secondary" onClick={handleSuggest} disabled={suggesting}>
+              {suggesting ? <Spinner /> : <Sparkles className="h-4 w-4" />}
+              {suggestions === null ? "Suggest competitors" : "Suggest again"}
+            </Button>
+          </div>
+
+          {suggestError && <p className="mt-4 text-sm text-terracotta-dark">{suggestError}</p>}
+
+          {suggestions !== null && !suggesting && suggestions.length === 0 && !suggestError && (
+            <p className="mt-4 text-sm text-ink-faint">
+              No new suggestions right now, you may already be tracking the main players.
+            </p>
+          )}
+
+          {suggestions !== null && suggestions.length > 0 && (
+            <ul className="mt-5 space-y-3">
+              {suggestions.map((s) => (
+                <li
+                  key={s.name}
+                  className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-ink/10 bg-paper p-4"
+                >
+                  <div className="min-w-0">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <p className="font-semibold text-ink">{s.name}</p>
+                      {s.domain && (
+                        <span className="inline-flex items-center gap-1 text-sm text-ink-faint">
+                          <Building2 className="h-3.5 w-3.5" />
+                          {s.domain}
+                        </span>
+                      )}
+                    </div>
+                    {s.reason && <p className="mt-1 text-sm text-ink-faint">{s.reason}</p>}
+                    {s.aliases.length > 0 && (
+                      <div className="mt-2 flex flex-wrap gap-1.5">
+                        {s.aliases.map((alias, i) => (
+                          <Badge key={`${alias}-${i}`} tone={ALIAS_TONES[i % ALIAS_TONES.length]}>
+                            {alias}
+                          </Badge>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                  <div className="flex shrink-0 items-center gap-2">
+                    <Button
+                      size="sm"
+                      onClick={() => handleAddSuggestion(s)}
+                      disabled={addingSuggestion !== null}
+                    >
+                      {addingSuggestion === s.name ? <Spinner /> : <Plus className="h-4 w-4" />}
+                      Track
+                    </Button>
+                    <button
+                      type="button"
+                      onClick={() => dismissSuggestion(s.name)}
+                      className="rounded-lg p-2 text-ink-faint transition hover:bg-ink/5 hover:text-terracotta-dark"
+                      aria-label={`Dismiss ${s.name}`}
+                    >
+                      <X className="h-4 w-4" />
+                    </button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
         </CardBody>
       </Card>
 

--- a/lib/llm/index.ts
+++ b/lib/llm/index.ts
@@ -295,6 +295,96 @@ Provide 3 or 4 topics, each with 4 to 6 natural questions. Never put the company
   }
 }
 
+const COMPETITOR_SYSTEM = `You identify direct competitors of a company for brand monitoring. You act as a strict judge: only name real companies/products you are confident exist and genuinely compete for the same buyers in the same category. Prefer well-known, currently active competitors over obscure or defunct ones.
+
+Rules:
+- Never include the company itself or anything on the already-tracked list.
+- "aliases": other names an AI assistant's answer might use for it (short name, product name, former name). Empty array if none.
+- "domain": its primary website domain, lowercase, no protocol/path. null if unsure.
+- "reason": one short sentence on why it is a direct competitor.
+- Fewer, correct suggestions beat a padded list. Return ONLY JSON.`;
+
+export interface CompetitorSuggestion {
+  name: string;
+  domain: string | null;
+  aliases: string[];
+  reason: string;
+}
+
+/**
+ * Suggest direct competitors for the monitored brand. Today the model proposes
+ * candidates from its own knowledge; when `candidates` is provided (e.g. from a
+ * search provider like Exa / you.com, planned) the model instead judges that
+ * list and keeps only genuine direct competitors.
+ */
+export async function suggestCompetitors(
+  opts: BaseCall & {
+    brandName: string;
+    brandDomain?: string | null;
+    description?: string | null;
+    topics: string[];
+    existing: string[];
+    count: number;
+    candidates?: string[];
+  },
+): Promise<{ suggestions: CompetitorSuggestion[]; tokens: number }> {
+  const lines = [
+    `Company: ${opts.brandName}${opts.brandDomain ? ` (${opts.brandDomain})` : ""}`,
+  ];
+  if (opts.description) lines.push(`What it does: ${opts.description}`);
+  if (opts.topics.length) lines.push(`Topics being monitored: ${opts.topics.join("; ")}`);
+  if (opts.existing.length) lines.push(`Already tracked (exclude these): ${opts.existing.join("; ")}`);
+  if (opts.candidates?.length) {
+    lines.push(
+      `Candidate companies found by search. Judge ONLY these; keep the genuine direct competitors and drop the rest:\n${opts.candidates
+        .map((c) => `- ${c}`)
+        .join("\n")}`,
+    );
+  } else {
+    lines.push(`Propose up to ${opts.count} direct competitors.`);
+  }
+  lines.push(
+    `Return a JSON object: { "competitors": [ { "name": string, "domain": string|null, "aliases": string[], "reason": string } ] }`,
+  );
+  const user = lines.join("\n\n");
+
+  const res =
+    opts.provider === "anthropic"
+      ? await anthropicChat(opts.apiKey, opts.model, COMPETITOR_SYSTEM, user, UTILITY_MAX_TOKENS)
+      : await openaiChat(opts.apiKey, opts.model, COMPETITOR_SYSTEM, user, UTILITY_MAX_TOKENS, true);
+
+  try {
+    let parsed: unknown = extractJson(res.text);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      parsed = (parsed as { competitors?: unknown }).competitors ?? [];
+    }
+    const arr = Array.isArray(parsed) ? parsed : [];
+    const suggestions: CompetitorSuggestion[] = [];
+    for (const item of arr) {
+      if (!item || typeof item !== "object") continue;
+      const o = item as Record<string, unknown>;
+      const name = typeof o.name === "string" ? o.name.trim() : "";
+      if (!name) continue;
+      suggestions.push({
+        name,
+        domain:
+          typeof o.domain === "string" && o.domain.trim().length > 0
+            ? o.domain.trim().toLowerCase().replace(/^https?:\/\//, "").split("/")[0]
+            : null,
+        aliases: Array.isArray(o.aliases)
+          ? o.aliases
+              .map((a) => (typeof a === "string" ? a.trim() : ""))
+              .filter((a) => a.length > 0)
+          : [],
+        reason: typeof o.reason === "string" ? o.reason.trim() : "",
+      });
+    }
+    return { suggestions: suggestions.slice(0, opts.count), tokens: res.tokens };
+  } catch {
+    return { suggestions: [], tokens: res.tokens };
+  }
+}
+
 export function humanError(err: unknown): string {
   if (err instanceof Anthropic.APIError || err instanceof OpenAI.APIError) {
     if (err.status === 401) return "Invalid API key.";


### PR DESCRIPTION
## Overview

Adds **AI competitor suggestions** (Phase 3 from the kickoff roadmap) to the Competitors page.

One click asks the model for direct competitors of the active org, using the brand name, domain, description, and monitored topics as context and excluding anything already tracked. Each suggestion comes back with a domain, aliases, and a one-line reason; the user chooses **Track** (reuses the normal add flow) or dismiss. The prompt is deliberately strict — real, currently-active companies only — so a fictional or ultra-niche brand yields few or no suggestions rather than made-up ones.

Per the kickoff discussion, Claude acts as the judge and search comes later: `suggestCompetitors()` takes an optional `candidates` list, which is the slot for Exa / you.com search results — when provided, the model judges that list instead of proposing from its own knowledge, so the future search integration will not touch the route or UI.

Key resolution and trial metering mirror the existing variation-generation route (own key → trial key → blocked when free runs are exhausted).

Live-tested against the shared Supabase: posing as Notion, it returned Confluence, OneNote, Obsidian, Monday.com, Asana, ClickUp with correct domains. `typecheck` / `lint` / `build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)