### PR TITLE
Performance pass: instant navigation, batched queries, lighter bundle + review fixes

### DIFF
--- a/app/api/competitors/suggest/route.ts
+++ b/app/api/competitors/suggest/route.ts
@@ -65,10 +65,14 @@ export async function POST() {
 
     if (key.source === "trial") await recordTrialUsage(supabase, tokens);
 
-    // Belt-and-braces: drop the brand itself and anything already tracked.
+    // Belt-and-braces: drop the brand itself and anything already tracked,
+    // including tracked competitors' aliases (e.g. "Monday" vs "Monday.com").
+    const competitorAliases = ((competitorRows ?? []) as Competitor[]).flatMap(
+      (c) => c.aliases,
+    );
     const taken = new Set(
-      [project.brand_name, ...project.brand_aliases, ...existing].map((n) =>
-        n.trim().toLowerCase(),
+      [project.brand_name, ...project.brand_aliases, ...existing, ...competitorAliases].map(
+        (n) => n.trim().toLowerCase(),
       ),
     );
     const fresh = suggestions.filter((s) => !taken.has(s.name.trim().toLowerCase()));

--- a/app/api/prompts/[id]/route.ts
+++ b/app/api/prompts/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { getProject } from "@/lib/data";
 import { humanError } from "@/lib/llm";
 
 export const dynamic = "force-dynamic";
@@ -14,6 +15,11 @@ export async function PATCH(
   } = await supabase.auth.getUser();
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
+  const project = await getProject(supabase, user.id);
+  if (!project) {
+    return NextResponse.json({ error: "No project found." }, { status: 400 });
+  }
+
   let body: unknown;
   try {
     body = await request.json();
@@ -27,10 +33,12 @@ export async function PATCH(
   }
 
   try {
+    // Scoped to the active organization, matching the topic/competitor routes.
     const { error } = await supabase
       .from("prompts")
       .update({ is_active })
-      .eq("id", params.id);
+      .eq("id", params.id)
+      .eq("project_id", project.id);
 
     if (error) return NextResponse.json({ error: error.message }, { status: 500 });
     return NextResponse.json({ ok: true });
@@ -49,8 +57,17 @@ export async function DELETE(
   } = await supabase.auth.getUser();
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
+  const project = await getProject(supabase, user.id);
+  if (!project) {
+    return NextResponse.json({ error: "No project found." }, { status: 400 });
+  }
+
   try {
-    const { error } = await supabase.from("prompts").delete().eq("id", params.id);
+    const { error } = await supabase
+      .from("prompts")
+      .delete()
+      .eq("id", params.id)
+      .eq("project_id", project.id);
     if (error) return NextResponse.json({ error: error.message }, { status: 500 });
     return NextResponse.json({ ok: true });
   } catch (e) {

--- a/app/dashboard/competitors/loading.tsx
+++ b/app/dashboard/competitors/loading.tsx
@@ -1,0 +1,5 @@
+import { PageSkeleton } from "@/components/dashboard/page-skeleton";
+
+export default function Loading() {
+  return <PageSkeleton />;
+}

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -30,9 +30,11 @@ export default async function DashboardLayout({
   // shared keys (no own key for their default provider). Metered in free runs.
   let trial: { used: number; limit: number; exhausted: boolean } | null = null;
   if (project && trialEnabled()) {
-    const providers = await getConfiguredProviders(supabase, user.id);
+    const [providers, used] = await Promise.all([
+      getConfiguredProviders(supabase, user.id),
+      getTrialRunsUsed(supabase, user.id),
+    ]);
     if (!providers.includes(project.default_provider)) {
-      const used = await getTrialRunsUsed(supabase, user.id);
       const limit = trialRunLimit();
       trial = { used, limit, exhausted: used >= limit };
     }

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -27,14 +27,15 @@ export default async function DashboardLayout({
   ]);
 
   // Trial banner state: only when a trial is offered and the user is relying on
-  // shared keys (no own key for their default provider). Metered in free runs.
+  // shared keys. Key resolution prefers the user's own key from EITHER
+  // provider, so any own key at all means they're never on the trial.
   let trial: { used: number; limit: number; exhausted: boolean } | null = null;
   if (project && trialEnabled()) {
     const [providers, used] = await Promise.all([
       getConfiguredProviders(supabase, user.id),
       getTrialRunsUsed(supabase, user.id),
     ]);
-    if (!providers.includes(project.default_provider)) {
+    if (providers.length === 0) {
       const limit = trialRunLimit();
       trial = { used, limit, exhausted: used >= limit };
     }

--- a/app/dashboard/loading.tsx
+++ b/app/dashboard/loading.tsx
@@ -1,26 +1,7 @@
-// Instant skeleton shown while any dashboard page's server render is in
-// flight, so navigation clicks respond immediately instead of feeling frozen.
-// Generic shape: heading, stat row, and content cards, with a shimmer sweep.
+import { PageSkeleton } from "@/components/dashboard/page-skeleton";
+
+// Entry boundary for /dashboard itself; sibling tabs each have their own
+// loading.tsx (a parent boundary doesn't re-trigger on sibling navigation).
 export default function DashboardLoading() {
-  return (
-    <div className="space-y-8" aria-hidden>
-      <div className="space-y-2.5">
-        <div className="shimmer h-8 w-52 rounded-xl" />
-        <div className="shimmer h-4 w-80 max-w-full rounded-lg" />
-      </div>
-      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
-        {[0, 1, 2, 3].map((i) => (
-          <div key={i} className="shimmer h-28 rounded-2xl" />
-        ))}
-      </div>
-      <div className="grid gap-6 lg:grid-cols-3">
-        <div className="shimmer h-80 rounded-2xl lg:col-span-2" />
-        <div className="shimmer h-80 rounded-2xl" />
-      </div>
-      <div className="grid gap-6 lg:grid-cols-2">
-        <div className="shimmer h-64 rounded-2xl" />
-        <div className="shimmer h-64 rounded-2xl" />
-      </div>
-    </div>
-  );
+  return <PageSkeleton />;
 }

--- a/app/dashboard/loading.tsx
+++ b/app/dashboard/loading.tsx
@@ -1,25 +1,25 @@
 // Instant skeleton shown while any dashboard page's server render is in
 // flight, so navigation clicks respond immediately instead of feeling frozen.
-// Generic shape: heading, stat row, and content cards.
+// Generic shape: heading, stat row, and content cards, with a shimmer sweep.
 export default function DashboardLoading() {
   return (
-    <div className="animate-pulse space-y-8" aria-hidden>
+    <div className="space-y-8" aria-hidden>
       <div className="space-y-2.5">
-        <div className="h-8 w-52 rounded-xl bg-ink/[0.06]" />
-        <div className="h-4 w-80 max-w-full rounded-lg bg-ink/[0.05]" />
+        <div className="shimmer h-8 w-52 rounded-xl" />
+        <div className="shimmer h-4 w-80 max-w-full rounded-lg" />
       </div>
       <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
         {[0, 1, 2, 3].map((i) => (
-          <div key={i} className="h-28 rounded-2xl bg-ink/[0.05]" />
+          <div key={i} className="shimmer h-28 rounded-2xl" />
         ))}
       </div>
       <div className="grid gap-6 lg:grid-cols-3">
-        <div className="h-80 rounded-2xl bg-ink/[0.05] lg:col-span-2" />
-        <div className="h-80 rounded-2xl bg-ink/[0.05]" />
+        <div className="shimmer h-80 rounded-2xl lg:col-span-2" />
+        <div className="shimmer h-80 rounded-2xl" />
       </div>
       <div className="grid gap-6 lg:grid-cols-2">
-        <div className="h-64 rounded-2xl bg-ink/[0.05]" />
-        <div className="h-64 rounded-2xl bg-ink/[0.05]" />
+        <div className="shimmer h-64 rounded-2xl" />
+        <div className="shimmer h-64 rounded-2xl" />
       </div>
     </div>
   );

--- a/app/dashboard/loading.tsx
+++ b/app/dashboard/loading.tsx
@@ -1,0 +1,26 @@
+// Instant skeleton shown while any dashboard page's server render is in
+// flight, so navigation clicks respond immediately instead of feeling frozen.
+// Generic shape: heading, stat row, and content cards.
+export default function DashboardLoading() {
+  return (
+    <div className="animate-pulse space-y-8" aria-hidden>
+      <div className="space-y-2.5">
+        <div className="h-8 w-52 rounded-xl bg-ink/[0.06]" />
+        <div className="h-4 w-80 max-w-full rounded-lg bg-ink/[0.05]" />
+      </div>
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        {[0, 1, 2, 3].map((i) => (
+          <div key={i} className="h-28 rounded-2xl bg-ink/[0.05]" />
+        ))}
+      </div>
+      <div className="grid gap-6 lg:grid-cols-3">
+        <div className="h-80 rounded-2xl bg-ink/[0.05] lg:col-span-2" />
+        <div className="h-80 rounded-2xl bg-ink/[0.05]" />
+      </div>
+      <div className="grid gap-6 lg:grid-cols-2">
+        <div className="h-64 rounded-2xl bg-ink/[0.05]" />
+        <div className="h-64 rounded-2xl bg-ink/[0.05]" />
+      </div>
+    </div>
+  );
+}

--- a/app/dashboard/new/loading.tsx
+++ b/app/dashboard/new/loading.tsx
@@ -1,0 +1,5 @@
+import { PageSkeleton } from "@/components/dashboard/page-skeleton";
+
+export default function Loading() {
+  return <PageSkeleton />;
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -17,7 +17,7 @@ import {
   SectionHeading,
   StatCard,
 } from "@/components/ui";
-import { ShareBars, SentimentDonut, TrendChart } from "@/components/dashboard/charts";
+import { ShareBars, SentimentDonut, TrendChart } from "@/components/dashboard/charts-lazy";
 import { Onboarding } from "./onboarding";
 import { createClient } from "@/lib/supabase/server";
 import { getConfiguredProviders, getProject } from "@/lib/data";
@@ -219,45 +219,56 @@ export default async function DashboardPage() {
   // --------------------------------------------------------------
   const latestRun = runs[0];
 
-  const [latestMentionsResult, latestResponsesResult, latestTopicResponses, topicsList] =
-    await Promise.all([
-      supabase.from("mentions").select("*").eq("run_id", latestRun.id),
-      supabase
-        .from("responses")
-        .select("id", { count: "exact", head: true })
-        .eq("run_id", latestRun.id),
-      supabase.from("responses").select("topic_id").eq("run_id", latestRun.id),
-      supabase.from("topics").select("*").eq("project_id", project.id),
-    ]);
+  // One batched fetch covers the latest run AND the 10-run trend: all mentions
+  // and responses for those runs in two IN queries, grouped in memory. This
+  // replaces ~2 queries per historical run (~20+ round trips).
+  const trendRuns = runs.slice(0, 10);
+  const trendIds = trendRuns.map((r) => r.id);
 
-  const latestMentions = (latestMentionsResult.data as Mention[] | null) ?? [];
-  const totalResponses = latestResponsesResult.count ?? 0;
+  const [mentionsResult, responsesResult, topicsList] = await Promise.all([
+    supabase.from("mentions").select("*").in("run_id", trendIds),
+    supabase.from("responses").select("id, run_id, topic_id").in("run_id", trendIds),
+    supabase.from("topics").select("*").eq("project_id", project.id),
+  ]);
+
+  const allMentions = (mentionsResult.data as Mention[] | null) ?? [];
+  const allResponses =
+    (responsesResult.data as { id: string; run_id: string; topic_id: string | null }[] | null) ??
+    [];
+
+  const mentionsByRun = new Map<string, Mention[]>();
+  for (const m of allMentions) {
+    const list = mentionsByRun.get(m.run_id) ?? [];
+    list.push(m);
+    mentionsByRun.set(m.run_id, list);
+  }
+  const responseCountByRun = new Map<string, number>();
+  for (const r of allResponses) {
+    responseCountByRun.set(r.run_id, (responseCountByRun.get(r.run_id) ?? 0) + 1);
+  }
+
+  const latestMentions = mentionsByRun.get(latestRun.id) ?? [];
+  const totalResponses = responseCountByRun.get(latestRun.id) ?? 0;
 
   const stats = computeEntityStats(latestMentions, totalResponses);
   const brand = stats.find((s) => s.type === "brand");
   const summary = computeRunSummary(latestMentions, totalResponses);
 
   // Trend across the last 10 completed runs (chronological).
-  const trendRuns = runs.slice(0, 10).reverse();
-  const trendData = await Promise.all(
-    trendRuns.map(async (run) => {
-      const [mRes, rRes] = await Promise.all([
-        supabase.from("mentions").select("*").eq("run_id", run.id),
-        supabase
-          .from("responses")
-          .select("id", { count: "exact", head: true })
-          .eq("run_id", run.id),
-      ]);
-      const mentions = (mRes.data as Mention[] | null) ?? [];
-      const responses = rRes.count ?? 0;
-      const s = computeRunSummary(mentions, responses);
+  const trendData = trendRuns
+    .slice()
+    .reverse()
+    .map((run) => {
+      const s = computeRunSummary(
+        mentionsByRun.get(run.id) ?? [],
+        responseCountByRun.get(run.id) ?? 0,
+      );
       return {
         date: formatDate(run.created_at),
         visibility: Math.round(s.brandMentionRate * 100),
         share: Math.round(s.brandShareOfVoice * 100),
       };
-    }),
-  );
+    });
 
   // Share-of-voice leaderboard (brand + competitors, desc by share).
   const shareEntities: EntityStat[] = [...stats].sort(
@@ -278,10 +289,10 @@ export default async function DashboardPage() {
       ]
     : [];
 
-  // Per-topic breakdown.
+  // Per-topic breakdown (latest run only).
   const responsesByTopic = new Map<string | null, number>();
-  for (const row of (latestTopicResponses.data as { topic_id: string | null }[] | null) ??
-    []) {
+  for (const row of allResponses) {
+    if (row.run_id !== latestRun.id) continue;
     responsesByTopic.set(row.topic_id, (responsesByTopic.get(row.topic_id) ?? 0) + 1);
   }
   const topicStats = computeTopicStats(latestMentions, responsesByTopic);

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -220,21 +220,24 @@ export default async function DashboardPage() {
   const latestRun = runs[0];
 
   // One batched fetch covers the latest run AND the 10-run trend: all mentions
-  // and responses for those runs in two IN queries, grouped in memory. This
-  // replaces ~2 queries per historical run (~20+ round trips).
+  // for those runs in a single IN query, grouped in memory, replacing ~2
+  // queries per historical run. Per-run answer counts come straight from
+  // runs.completed_count (set by the engine), so no response rows are fetched
+  // for counting — responses are only read for the latest run's topic split.
   const trendRuns = runs.slice(0, 10);
   const trendIds = trendRuns.map((r) => r.id);
 
-  const [mentionsResult, responsesResult, topicsList] = await Promise.all([
+  const [mentionsResult, latestResponsesResult, topicsList] = await Promise.all([
+    // NOTE: capped at 1000 rows by PostgREST; fine for 10 runs of mention rows
+    // (only detected entities produce rows). Revisit if trend depth grows.
     supabase.from("mentions").select("*").in("run_id", trendIds),
-    supabase.from("responses").select("id, run_id, topic_id").in("run_id", trendIds),
+    supabase.from("responses").select("topic_id").eq("run_id", latestRun.id),
     supabase.from("topics").select("*").eq("project_id", project.id),
   ]);
 
   const allMentions = (mentionsResult.data as Mention[] | null) ?? [];
-  const allResponses =
-    (responsesResult.data as { id: string; run_id: string; topic_id: string | null }[] | null) ??
-    [];
+  const latestResponses =
+    (latestResponsesResult.data as { topic_id: string | null }[] | null) ?? [];
 
   const mentionsByRun = new Map<string, Mention[]>();
   for (const m of allMentions) {
@@ -242,13 +245,12 @@ export default async function DashboardPage() {
     list.push(m);
     mentionsByRun.set(m.run_id, list);
   }
-  const responseCountByRun = new Map<string, number>();
-  for (const r of allResponses) {
-    responseCountByRun.set(r.run_id, (responseCountByRun.get(r.run_id) ?? 0) + 1);
-  }
+  const responseCountByRun = new Map<string, number>(
+    trendRuns.map((r) => [r.id, r.completed_count]),
+  );
 
   const latestMentions = mentionsByRun.get(latestRun.id) ?? [];
-  const totalResponses = responseCountByRun.get(latestRun.id) ?? 0;
+  const totalResponses = latestRun.completed_count;
 
   const stats = computeEntityStats(latestMentions, totalResponses);
   const brand = stats.find((s) => s.type === "brand");
@@ -291,8 +293,7 @@ export default async function DashboardPage() {
 
   // Per-topic breakdown (latest run only).
   const responsesByTopic = new Map<string | null, number>();
-  for (const row of allResponses) {
-    if (row.run_id !== latestRun.id) continue;
+  for (const row of latestResponses) {
     responsesByTopic.set(row.topic_id, (responsesByTopic.get(row.topic_id) ?? 0) + 1);
   }
   const topicStats = computeTopicStats(latestMentions, responsesByTopic);

--- a/app/dashboard/runs/[id]/loading.tsx
+++ b/app/dashboard/runs/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import { PageSkeleton } from "@/components/dashboard/page-skeleton";
+
+export default function Loading() {
+  return <PageSkeleton />;
+}

--- a/app/dashboard/runs/loading.tsx
+++ b/app/dashboard/runs/loading.tsx
@@ -1,0 +1,5 @@
+import { PageSkeleton } from "@/components/dashboard/page-skeleton";
+
+export default function Loading() {
+  return <PageSkeleton />;
+}

--- a/app/dashboard/settings/loading.tsx
+++ b/app/dashboard/settings/loading.tsx
@@ -1,0 +1,5 @@
+import { PageSkeleton } from "@/components/dashboard/page-skeleton";
+
+export default function Loading() {
+  return <PageSkeleton />;
+}

--- a/app/dashboard/topics/loading.tsx
+++ b/app/dashboard/topics/loading.tsx
@@ -1,0 +1,5 @@
+import { PageSkeleton } from "@/components/dashboard/page-skeleton";
+
+export default function Loading() {
+  return <PageSkeleton />;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -59,6 +59,34 @@
   }
 }
 
+/* Skeleton shimmer: warm ink-tint base with a soft light sweep. Rounded
+   corners come from the element's own radius (overflow hidden clips the sweep). */
+.shimmer {
+  position: relative;
+  overflow: hidden;
+  background-color: rgba(26, 25, 23, 0.05);
+}
+.shimmer::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background-image: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.5) 45%,
+    rgba(255, 255, 255, 0.65) 50%,
+    rgba(255, 255, 255, 0.5) 55%,
+    transparent 100%
+  );
+  animation: shimmer-sweep 1.8s ease-in-out infinite;
+}
+@keyframes shimmer-sweep {
+  100% {
+    transform: translateX(100%);
+  }
+}
+
 /* Recharts: keep tooltips/axes on-brand. */
 .recharts-cartesian-axis-tick-value {
   fill: #7c786f;

--- a/components/dashboard/charts-lazy.tsx
+++ b/components/dashboard/charts-lazy.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+// Lazy entrypoints for the recharts-based charts. Recharts is by far the
+// heaviest client dependency; loading it on demand keeps it out of the shared
+// dashboard bundle so first paint isn't blocked on chart code.
+
+function ChartSkeleton({ height }: { height: number }) {
+  return <div className="animate-pulse rounded-2xl bg-ink/[0.05]" style={{ height }} aria-hidden />;
+}
+
+export const TrendChart = dynamic(() => import("./charts").then((m) => m.TrendChart), {
+  ssr: false,
+  loading: () => <ChartSkeleton height={280} />,
+});
+
+export const ShareBars = dynamic(() => import("./charts").then((m) => m.ShareBars), {
+  ssr: false,
+  loading: () => <ChartSkeleton height={180} />,
+});
+
+export const SentimentDonut = dynamic(() => import("./charts").then((m) => m.SentimentDonut), {
+  ssr: false,
+  loading: () => <ChartSkeleton height={240} />,
+});

--- a/components/dashboard/charts-lazy.tsx
+++ b/components/dashboard/charts-lazy.tsx
@@ -7,7 +7,7 @@ import dynamic from "next/dynamic";
 // dashboard bundle so first paint isn't blocked on chart code.
 
 function ChartSkeleton({ height }: { height: number }) {
-  return <div className="animate-pulse rounded-2xl bg-ink/[0.05]" style={{ height }} aria-hidden />;
+  return <div className="shimmer rounded-2xl" style={{ height }} aria-hidden />;
 }
 
 export const TrendChart = dynamic(() => import("./charts").then((m) => m.TrendChart), {

--- a/components/dashboard/page-skeleton.tsx
+++ b/components/dashboard/page-skeleton.tsx
@@ -1,0 +1,26 @@
+// Shared shimmer skeleton for dashboard pages: heading, stat row, and content
+// cards. Rendered by each dashboard segment's loading.tsx so every tab click
+// responds instantly while its server render is in flight.
+export function PageSkeleton() {
+  return (
+    <div className="space-y-8" aria-hidden>
+      <div className="space-y-2.5">
+        <div className="shimmer h-8 w-52 rounded-xl" />
+        <div className="shimmer h-4 w-80 max-w-full rounded-lg" />
+      </div>
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        {[0, 1, 2, 3].map((i) => (
+          <div key={i} className="shimmer h-28 rounded-2xl" />
+        ))}
+      </div>
+      <div className="grid gap-6 lg:grid-cols-3">
+        <div className="shimmer h-80 rounded-2xl lg:col-span-2" />
+        <div className="shimmer h-80 rounded-2xl" />
+      </div>
+      <div className="grid gap-6 lg:grid-cols-2">
+        <div className="shimmer h-64 rounded-2xl" />
+        <div className="shimmer h-64 rounded-2xl" />
+      </div>
+    </div>
+  );
+}

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1,12 +1,15 @@
+import { cache } from "react";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { decryptSecret } from "@/lib/crypto";
 import type { Project, Provider, ProviderKeyPublic } from "@/lib/types";
 
 // Server-side data helpers shared across pages and route handlers.
 // All expect a Supabase client already scoped to the request (RLS).
+// Read helpers are wrapped in React cache() so the layout and page of a single
+// request (which pass the same cached client) each hit the database only once.
 
 /** All of the user's projects (organizations), oldest first. */
-export async function getProjects(
+export const getProjects = cache(async function getProjects(
   supabase: SupabaseClient,
   userId: string,
 ): Promise<Project[]> {
@@ -16,14 +19,14 @@ export async function getProjects(
     .eq("user_id", userId)
     .order("created_at", { ascending: true });
   return (data as Project[] | null) ?? [];
-}
+});
 
 /**
  * The user's active project (organization): the one selected via the org
  * switcher (profiles.active_project_id), falling back to the earliest project
  * they created. Null when they have no projects yet.
  */
-export async function getProject(
+export const getProject = cache(async function getProject(
   supabase: SupabaseClient,
   userId: string,
 ): Promise<Project | null> {
@@ -54,7 +57,7 @@ export async function getProject(
     .limit(1)
     .maybeSingle();
   return (data as Project | null) ?? null;
-}
+});
 
 /** Point the dashboard at another of the user's organizations. */
 export async function setActiveProject(
@@ -69,7 +72,7 @@ export async function setActiveProject(
 }
 
 /** Safe (no ciphertext) list of the user's stored provider keys. */
-export async function getProviderKeysPublic(
+export const getProviderKeysPublic = cache(async function getProviderKeysPublic(
   supabase: SupabaseClient,
   userId: string,
 ): Promise<ProviderKeyPublic[]> {
@@ -79,7 +82,7 @@ export async function getProviderKeysPublic(
     .eq("user_id", userId)
     .order("created_at", { ascending: true });
   return (data as ProviderKeyPublic[] | null) ?? [];
-}
+});
 
 /** Which providers the user has a key for. */
 export async function getConfiguredProviders(

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,10 +1,13 @@
+import { cache } from "react";
 import { createServerClient, type CookieOptions } from "@supabase/ssr";
 import { createClient as createSupabaseClient } from "@supabase/supabase-js";
 import { cookies } from "next/headers";
 
 // Server Supabase client bound to the request cookies (respects RLS as the
 // signed-in user). Use inside Server Components, Route Handlers, Server Actions.
-export function createClient() {
+// Wrapped in React cache() so the layout and page of one request share a single
+// client instance — which also lets the cached data helpers dedupe their reads.
+export const createClient = cache(function createClient() {
   const cookieStore = cookies();
 
   return createServerClient(
@@ -28,7 +31,7 @@ export function createClient() {
       },
     },
   );
-}
+});
 
 // Service-role client that bypasses RLS. Only for trusted server contexts such
 // as the cron endpoint, which must enumerate every user's due projects.
@@ -47,11 +50,11 @@ export function createServiceClient() {
   );
 }
 
-// Convenience: the signed-in user (or null).
-export async function getUser() {
+// Convenience: the signed-in user (or null). Deduped per request.
+export const getUser = cache(async function getUser() {
   const supabase = createClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();
   return user;
-}
+});


### PR DESCRIPTION
## Overview

Site-wide performance and polish pass, plus fixes from a full review of the previously merged work.

### Faster + smoother
- **Instant navigation feedback**: every dashboard tab has its own `loading.tsx` rendering a shared shimmer skeleton (warm palette-matched gradient sweep), so clicks respond immediately instead of freezing on the old page. (Per-tab boundaries are required — a parent `loading.tsx` does not re-trigger on sibling navigation.)
- **Overview queries: ~22 → 2.** Mentions for the last 10 runs come back in one `IN` query grouped in memory, and per-run answer counts read from `runs.completed_count` instead of fetching response rows — which also sidesteps PostgREST’s silent 1000-row cap that could have undercounted trends for heavy projects.
- **Request-level dedup**: the server Supabase client, `getUser`, and the read helpers are wrapped in React `cache()`, so the sidebar layout and page no longer run identical auth/project lookups twice per view.
- **Lighter bundle**: recharts is lazy-loaded with skeleton placeholders — dashboard first-load JS drops **206 kB → 100 kB**.

### Review fixes (from auditing PRs #1 and #2)
- `/api/prompts/[id]` PATCH/DELETE now scope to the active organization, matching the topic/competitor routes.
- The trial banner only shows when the user has **no** keys at all: key resolution prefers an own key from either provider, so anyone with any own key is never actually on the trial.
- Competitor suggestions also exclude tracked competitors’ **aliases**, not just names (e.g. “Monday” vs “Monday.com”).

Verified live against the shared Supabase: all dashboard pages 200 with correct stats, org switch + competitor-suggest API routes re-tested after the `cache()` change. `typecheck` / `lint` / clean production `build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)