### PR TITLE
Native web search + source attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Lettertrace is a self-hostable clone of tools like Profound / AthenaHQ / AirOps,
 - 📈 **Trends over time**, visibility, share of voice, prominence, and sentiment across runs.
 - ⚔️ **Competitor benchmarking**, ingest competitors and see how often each shows up.
 - 🏢 **Multiple organizations**, one account can track many brands/domains and switch between them from the sidebar.
+- 🔎 **Web search + source attribution**, query the models with their native web search on and capture the exact sources they cite, so you can see which posts drove an answer, and whether your own site is being used, even when you aren't named.
 - ⏱️ **Scheduled monitoring**, daily/weekly runs via a cron endpoint.
 
 ## Core concepts

--- a/app/api/project/route.ts
+++ b/app/api/project/route.ts
@@ -83,6 +83,7 @@ export async function POST(request: Request) {
     brand_domain: toNullableString(b.brand_domain),
     description: toNullableString(b.description),
     schedule,
+    ...(typeof b.use_web_search === "boolean" ? { use_web_search: b.use_web_search } : {}),
   };
 
   try {

--- a/app/dashboard/runs/[id]/page.tsx
+++ b/app/dashboard/runs/[id]/page.tsx
@@ -1,11 +1,11 @@
 import { notFound } from "next/navigation";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, ExternalLink, Globe } from "lucide-react";
 import { createClient } from "@/lib/supabase/server";
 import { getProject } from "@/lib/data";
 import { modelLabel } from "@/lib/models";
 import { pct, timeAgo } from "@/lib/utils";
 import { computeEntityStats, SENTIMENT_COLORS } from "@/lib/metrics";
-import type { Mention, Prompt, Response, Run, RunStatus, Sentiment } from "@/lib/types";
+import type { Mention, Prompt, Response, Run, RunStatus, Sentiment, Source } from "@/lib/types";
 import {
   Card,
   CardBody,
@@ -74,6 +74,12 @@ export default async function RunDetailPage({ params }: { params: { id: string }
     .eq("run_id", run.id);
   const mentions = (mentionRows ?? []) as Mention[];
 
+  const { data: sourceRows } = await supabase
+    .from("sources")
+    .select("*")
+    .eq("run_id", run.id);
+  const sources = (sourceRows ?? []) as Source[];
+
   const { data: promptRows } = await supabase
     .from("prompts")
     .select("*")
@@ -88,9 +94,20 @@ export default async function RunDetailPage({ params }: { params: { id: string }
     mentionsByResponse.set(m.response_id, list);
   }
 
+  const sourcesByResponse = new Map<string, Source[]>();
+  for (const s of sources) {
+    const list = sourcesByResponse.get(s.response_id) ?? [];
+    list.push(s);
+    sourcesByResponse.set(s.response_id, list);
+  }
+
   const stats = computeEntityStats(mentions, responses.length);
   const brand = stats.find((s) => s.type === "brand");
   const topCompetitor = stats.find((s) => s.type === "competitor");
+
+  // Was the brand's own site cited? A leading indicator independent of mentions.
+  const ownedResponseIds = new Set(sources.filter((s) => s.is_owned).map((s) => s.response_id));
+  const anySources = sources.length > 0;
 
   return (
     <div className="space-y-8">
@@ -136,6 +153,26 @@ export default async function RunDetailPage({ params }: { params: { id: string }
         />
       </div>
 
+      {anySources && (
+        <div className="flex flex-wrap items-center gap-2 rounded-2xl border border-ink/10 bg-paper-shade/50 px-5 py-4 text-sm">
+          <Globe className="h-4 w-4 text-ink-faint" />
+          {ownedResponseIds.size > 0 ? (
+            <p className="text-ink">
+              Your site was cited in{" "}
+              <span className="font-semibold text-terracotta-dark">
+                {ownedResponseIds.size} of {responses.length}
+              </span>{" "}
+              answers, even where you weren&apos;t named.
+            </p>
+          ) : (
+            <p className="text-ink-faint">
+              Your site wasn&apos;t cited as a source in this run. {sources.length} sources were
+              pulled across {responses.length} answers.
+            </p>
+          )}
+        </div>
+      )}
+
       {responses.length === 0 ? (
         <EmptyState
           title="No answers recorded"
@@ -147,6 +184,7 @@ export default async function RunDetailPage({ params }: { params: { id: string }
           {responses.map((response) => {
             const question = promptText.get(response.prompt_id) ?? "(prompt removed)";
             const rMentions = mentionsByResponse.get(response.id) ?? [];
+            const rSources = sourcesByResponse.get(response.id) ?? [];
             return (
               <Card key={response.id}>
                 <CardBody className="space-y-4">
@@ -186,6 +224,39 @@ export default async function RunDetailPage({ params }: { params: { id: string }
                       </div>
                     )}
                   </div>
+
+                  {rSources.length > 0 && (
+                    <div className="border-t border-ink/10 pt-4">
+                      <p className="mb-2 text-xs font-medium uppercase tracking-wide text-ink-faint">
+                        Sources cited ({rSources.length})
+                      </p>
+                      <ul className="space-y-1.5">
+                        {rSources.map((s) => (
+                          <li key={s.id} className="flex items-start gap-2 text-sm">
+                            <Globe
+                              className={
+                                "mt-0.5 h-3.5 w-3.5 shrink-0 " +
+                                (s.is_owned ? "text-terracotta" : "text-ink-faint")
+                              }
+                            />
+                            <span className="min-w-0">
+                              <a
+                                href={s.url}
+                                target="_blank"
+                                rel="noreferrer"
+                                className="inline-flex items-center gap-1 font-medium text-ink hover:text-terracotta-dark"
+                              >
+                                <span className="truncate">{s.title || s.domain}</span>
+                                <ExternalLink className="h-3 w-3 shrink-0 text-ink-faint" />
+                              </a>
+                              {s.is_owned && <Badge tone="terracotta">Your site</Badge>}
+                              <span className="ml-1 text-xs text-ink-faint">{s.domain}</span>
+                            </span>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
                 </CardBody>
               </Card>
             );

--- a/app/dashboard/settings/project-form.tsx
+++ b/app/dashboard/settings/project-form.tsx
@@ -23,6 +23,7 @@ export default function ProjectForm({ project }: { project: Project | null }) {
   const [brandDomain, setBrandDomain] = useState(project?.brand_domain ?? "");
   const [description, setDescription] = useState(project?.description ?? "");
   const [schedule, setSchedule] = useState<Schedule>(project?.schedule ?? "off");
+  const [useWebSearch, setUseWebSearch] = useState(project?.use_web_search ?? true);
 
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
@@ -49,6 +50,7 @@ export default function ProjectForm({ project }: { project: Project | null }) {
           brand_domain: brandDomain,
           description,
           schedule,
+          use_web_search: useWebSearch,
         }),
       });
       const data = await res.json();
@@ -156,6 +158,40 @@ export default function ProjectForm({ project }: { project: Project | null }) {
           placeholder="What does your brand do? This helps generate better monitoring prompts."
         />
       </div>
+
+      <label
+        htmlFor="p-websearch"
+        className="flex cursor-pointer items-start justify-between gap-4 rounded-2xl border border-ink/10 bg-paper-shade/40 p-4"
+      >
+        <span>
+          <span className="text-sm font-medium text-ink">Web search</span>
+          <span className="mt-0.5 block text-xs text-ink-faint">
+            Query the models with their native web search on and capture the sources they
+            cite. More realistic answers and source attribution; costs a bit more per run.
+          </span>
+        </span>
+        <button
+          type="button"
+          role="switch"
+          id="p-websearch"
+          aria-checked={useWebSearch}
+          onClick={() => {
+            setUseWebSearch((v) => !v);
+            setSaved(false);
+          }}
+          className={
+            "relative mt-0.5 inline-flex h-6 w-11 shrink-0 items-center rounded-full transition " +
+            (useWebSearch ? "bg-terracotta" : "bg-ink/15")
+          }
+        >
+          <span
+            className={
+              "inline-block h-4 w-4 transform rounded-full bg-white transition " +
+              (useWebSearch ? "translate-x-6" : "translate-x-1")
+            }
+          />
+        </button>
+      </label>
 
       {error && <p className="text-sm text-terracotta">{error}</p>}
 

--- a/lib/engine.test.ts
+++ b/lib/engine.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { hostOf, isOwnedDomain } from "@/lib/engine";
+
+describe("hostOf", () => {
+  it("normalizes a messy brand_domain to a registrable host", () => {
+    expect(hostOf("https://www.notion.so/pricing")).toBe("notion.so");
+    expect(hostOf("Notion.so")).toBe("notion.so");
+    expect(hostOf("http://acme.co.uk/path?x=1")).toBe("acme.co.uk");
+  });
+
+  it("returns empty for null/blank", () => {
+    expect(hostOf(null)).toBe("");
+    expect(hostOf("")).toBe("");
+  });
+});
+
+describe("isOwnedDomain", () => {
+  it("matches the exact host", () => {
+    expect(isOwnedDomain("notion.so", "notion.so")).toBe(true);
+  });
+
+  it("matches subdomains of the owned host", () => {
+    expect(isOwnedDomain("blog.notion.so", "notion.so")).toBe(true);
+    expect(isOwnedDomain("help.docs.notion.so", "notion.so")).toBe(true);
+  });
+
+  it("does not match unrelated or look-alike hosts", () => {
+    expect(isOwnedDomain("notnotion.so", "notion.so")).toBe(false);
+    expect(isOwnedDomain("evil-notion.so", "notion.so")).toBe(false);
+    expect(isOwnedDomain("notion.so.evil.com", "notion.so")).toBe(false);
+  });
+
+  it("is false when either side is empty", () => {
+    expect(isOwnedDomain("notion.so", "")).toBe(false);
+    expect(isOwnedDomain("", "notion.so")).toBe(false);
+  });
+});

--- a/lib/engine.ts
+++ b/lib/engine.ts
@@ -6,6 +6,22 @@ import { detectMention, brandTerms } from "@/lib/mentions";
 // Run at most this many queries at once to stay under provider rate limits.
 const CONCURRENCY = 4;
 
+// The brand's registrable web host, e.g. "notion.so" from a messy brand_domain.
+function hostOf(domain: string | null): string {
+  if (!domain) return "";
+  return domain
+    .replace(/^https?:\/\//i, "")
+    .split("/")[0]
+    .replace(/^www\./i, "")
+    .toLowerCase();
+}
+
+// A cited source is "owned" when its domain is, or is a subdomain of, the host.
+function isOwnedDomain(sourceDomain: string, ownedHost: string): boolean {
+  if (!ownedHost || !sourceDomain) return false;
+  return sourceDomain === ownedHost || sourceDomain.endsWith(`.${ownedHost}`);
+}
+
 async function mapPool<T, R>(
   items: T[],
   limit: number,
@@ -87,6 +103,8 @@ export async function executeRun(params: {
   }
 
   const bTerms = brandTerms(project.brand_name, project.brand_aliases, project.brand_domain);
+  // The brand's own web host, for flagging cited sources as "yours".
+  const ownedHost = hostOf(project.brand_domain);
   let processed = 0; // prompts attempted (success or failure)
   let succeeded = 0; // answers actually stored
   let tokensUsed = 0; // total provider tokens consumed (for trial metering)
@@ -94,11 +112,12 @@ export async function executeRun(params: {
 
   await mapPool(prompts, CONCURRENCY, async (prompt) => {
     try {
-      const { text: answer, tokens: qTokens } = await runQuery({
+      const { text: answer, tokens: qTokens, sources } = await runQuery({
         provider,
         model,
         apiKey,
         prompt: prompt.text,
+        webSearch: project.use_web_search,
       });
       tokensUsed += qTokens;
 
@@ -119,6 +138,21 @@ export async function executeRun(params: {
       if (!respRow) return;
       const responseId = respRow.id as string;
       succeeded++;
+
+      // Store the web sources the model cited (native web search).
+      if (sources.length > 0) {
+        const sourceRows = sources.map((s) => ({
+          response_id: responseId,
+          run_id: runId,
+          project_id: project.id,
+          url: s.url,
+          domain: s.domain,
+          title: s.title,
+          snippet: s.snippet,
+          is_owned: isOwnedDomain(s.domain, ownedHost),
+        }));
+        await supabase.from("sources").insert(sourceRows);
+      }
 
       // Deterministic detection: brand + each competitor.
       const detected: {

--- a/lib/engine.ts
+++ b/lib/engine.ts
@@ -7,7 +7,7 @@ import { detectMention, brandTerms } from "@/lib/mentions";
 const CONCURRENCY = 4;
 
 // The brand's registrable web host, e.g. "notion.so" from a messy brand_domain.
-function hostOf(domain: string | null): string {
+export function hostOf(domain: string | null): string {
   if (!domain) return "";
   return domain
     .replace(/^https?:\/\//i, "")
@@ -17,7 +17,7 @@ function hostOf(domain: string | null): string {
 }
 
 // A cited source is "owned" when its domain is, or is a subdomain of, the host.
-function isOwnedDomain(sourceDomain: string, ownedHost: string): boolean {
+export function isOwnedDomain(sourceDomain: string, ownedHost: string): boolean {
   if (!ownedHost || !sourceDomain) return false;
   return sourceDomain === ownedHost || sourceDomain.endsWith(`.${ownedHost}`);
 }

--- a/lib/llm/index.ts
+++ b/lib/llm/index.ts
@@ -48,17 +48,27 @@ export interface QueryResult extends ChatResult {
 // How many web searches a single monitored query may run.
 const WEB_SEARCH_MAX_USES = 5;
 
-// Pull the registrable host out of a URL, lowercased, no leading "www.".
-function domainOf(url: string): string {
+// Parse a citation URL, keeping only safe http(s) links (guards against a
+// model citing a javascript:/data: URL that would later render as an href).
+// Returns the cleaned url + its registrable host, or null to drop the source.
+export function safeSource(url: string, title: string | null, snippet: string | null): CitedSource | null {
+  let parsed: URL;
   try {
-    return new URL(url).hostname.replace(/^www\./i, "").toLowerCase();
+    parsed = new URL(url);
   } catch {
-    return "";
+    return null;
   }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+  return {
+    url,
+    domain: parsed.hostname.replace(/^www\./i, "").toLowerCase(),
+    title,
+    snippet,
+  };
 }
 
 // Collapse cited sources to one row per URL, keeping the first title/snippet.
-function dedupeSources(raw: CitedSource[]): CitedSource[] {
+export function dedupeSources(raw: CitedSource[]): CitedSource[] {
   const seen = new Map<string, CitedSource>();
   for (const s of raw) {
     if (!s.url) continue;
@@ -199,31 +209,31 @@ async function anthropicWebSearch(
     content?: { url?: string; title?: string }[];
   };
   let text = "";
-  const raw: CitedSource[] = [];
+  const cited: CitedSource[] = [];
+  const retrieved: CitedSource[] = [];
   const blocks = (msg.content ?? []) as unknown as Block[];
   for (const block of blocks) {
     if (block.type === "text") {
       text += (text ? "\n" : "") + (block.text ?? "");
+      // Sources the answer actually cited — the primary signal.
       for (const c of block.citations ?? []) {
-        if (c.url) {
-          raw.push({
-            url: c.url,
-            domain: domainOf(c.url),
-            title: c.title ?? null,
-            snippet: c.cited_text ?? null,
-          });
-        }
+        const s = c.url ? safeSource(c.url, c.title ?? null, c.cited_text ?? null) : null;
+        if (s) cited.push(s);
       }
     } else if (block.type === "web_search_tool_result" && Array.isArray(block.content)) {
-      // Fallback: results retrieved even if not inline-cited.
+      // Retrieved but maybe not cited — used only as a fallback below.
       for (const r of block.content) {
-        if (r.url) raw.push({ url: r.url, domain: domainOf(r.url), title: r.title ?? null, snippet: null });
+        const s = r.url ? safeSource(r.url, r.title ?? null, null) : null;
+        if (s) retrieved.push(s);
       }
     }
   }
 
+  // Prefer inline citations (what the answer used); fall back to retrieved
+  // results only when the model searched but cited nothing inline.
+  const sources = dedupeSources(cited.length > 0 ? cited : retrieved);
   const tokens = (msg.usage?.input_tokens ?? 0) + (msg.usage?.output_tokens ?? 0);
-  return { text: text.trim(), tokens, sources: dedupeSources(raw) };
+  return { text: text.trim(), tokens, sources };
 }
 
 // OpenAI native web search via the Responses API. Uses raw fetch so it doesn't
@@ -267,7 +277,8 @@ async function openaiWebSearch(
         for (const c of item.content ?? []) {
           if (typeof c.text === "string") text += (text ? "\n" : "") + c.text;
           for (const a of c.annotations ?? []) {
-            if (a?.url) raw.push({ url: a.url, domain: domainOf(a.url), title: a.title ?? null, snippet: null });
+            const s = a?.url ? safeSource(a.url, a.title ?? null, null) : null;
+            if (s) raw.push(s);
           }
         }
       }

--- a/lib/llm/index.ts
+++ b/lib/llm/index.ts
@@ -33,6 +33,42 @@ export interface ChatResult {
   tokens: number;
 }
 
+// A web source the model cited while answering (native provider web search).
+export interface CitedSource {
+  url: string;
+  domain: string;
+  title: string | null;
+  snippet: string | null;
+}
+
+export interface QueryResult extends ChatResult {
+  sources: CitedSource[];
+}
+
+// How many web searches a single monitored query may run.
+const WEB_SEARCH_MAX_USES = 5;
+
+// Pull the registrable host out of a URL, lowercased, no leading "www.".
+function domainOf(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./i, "").toLowerCase();
+  } catch {
+    return "";
+  }
+}
+
+// Collapse cited sources to one row per URL, keeping the first title/snippet.
+function dedupeSources(raw: CitedSource[]): CitedSource[] {
+  const seen = new Map<string, CitedSource>();
+  for (const s of raw) {
+    if (!s.url) continue;
+    const existing = seen.get(s.url);
+    if (!existing) seen.set(s.url, s);
+    else if (!existing.snippet && s.snippet) existing.snippet = s.snippet;
+  }
+  return Array.from(seen.values());
+}
+
 // --- Low-level chat helpers -----------------------------------------------
 
 async function anthropicChat(
@@ -113,12 +149,135 @@ export async function verifyKey(
   }
 }
 
-/** Ask the model a monitored question and return its natural answer + token usage. */
-export async function runQuery(opts: BaseCall & { prompt: string }): Promise<ChatResult> {
-  if (opts.provider === "anthropic") {
-    return anthropicChat(opts.apiKey, opts.model, undefined, opts.prompt, ANSWER_MAX_TOKENS);
+/**
+ * Ask the model a monitored question and return its natural answer, token
+ * usage, and (when `webSearch` is on) the web sources it cited. Web search uses
+ * each provider's NATIVE browsing via the user's own key — no third-party
+ * search service — so it stays fully self-hostable.
+ */
+export async function runQuery(
+  opts: BaseCall & { prompt: string; webSearch?: boolean },
+): Promise<QueryResult> {
+  if (!opts.webSearch) {
+    const res =
+      opts.provider === "anthropic"
+        ? await anthropicChat(opts.apiKey, opts.model, undefined, opts.prompt, ANSWER_MAX_TOKENS)
+        : await openaiChat(opts.apiKey, opts.model, undefined, opts.prompt, ANSWER_MAX_TOKENS);
+    return { ...res, sources: [] };
   }
-  return openaiChat(opts.apiKey, opts.model, undefined, opts.prompt, ANSWER_MAX_TOKENS);
+  return opts.provider === "anthropic"
+    ? anthropicWebSearch(opts.apiKey, opts.model, opts.prompt)
+    : openaiWebSearch(opts.apiKey, opts.model, opts.prompt);
+}
+
+// --- Native web-search query paths ---------------------------------------
+
+async function anthropicWebSearch(
+  apiKey: string,
+  model: string,
+  prompt: string,
+): Promise<QueryResult> {
+  const client = new Anthropic({ apiKey, ...CLIENT_OPTS });
+  // web_search is a server-side tool not in older SDK typings; cast the params.
+  const params = {
+    model,
+    max_tokens: ANSWER_MAX_TOKENS,
+    tools: [{ type: "web_search_20250305", name: "web_search", max_uses: WEB_SEARCH_MAX_USES }],
+    messages: [{ role: "user", content: prompt }],
+  };
+  const msg = await client.messages.create(
+    params as unknown as Anthropic.MessageCreateParamsNonStreaming,
+  );
+
+  // The web_search block/citation shapes aren't in older SDK types; read them
+  // structurally.
+  type Cite = { url?: string; title?: string; cited_text?: string };
+  type Block = {
+    type?: string;
+    text?: string;
+    citations?: Cite[];
+    content?: { url?: string; title?: string }[];
+  };
+  let text = "";
+  const raw: CitedSource[] = [];
+  const blocks = (msg.content ?? []) as unknown as Block[];
+  for (const block of blocks) {
+    if (block.type === "text") {
+      text += (text ? "\n" : "") + (block.text ?? "");
+      for (const c of block.citations ?? []) {
+        if (c.url) {
+          raw.push({
+            url: c.url,
+            domain: domainOf(c.url),
+            title: c.title ?? null,
+            snippet: c.cited_text ?? null,
+          });
+        }
+      }
+    } else if (block.type === "web_search_tool_result" && Array.isArray(block.content)) {
+      // Fallback: results retrieved even if not inline-cited.
+      for (const r of block.content) {
+        if (r.url) raw.push({ url: r.url, domain: domainOf(r.url), title: r.title ?? null, snippet: null });
+      }
+    }
+  }
+
+  const tokens = (msg.usage?.input_tokens ?? 0) + (msg.usage?.output_tokens ?? 0);
+  return { text: text.trim(), tokens, sources: dedupeSources(raw) };
+}
+
+// OpenAI native web search via the Responses API. Uses raw fetch so it doesn't
+// depend on a newer SDK; retries a couple of transient failures. NOTE: not yet
+// live-verified (the trial OpenAI key was out of quota during development).
+async function openaiWebSearch(
+  apiKey: string,
+  model: string,
+  prompt: string,
+): Promise<QueryResult> {
+  let lastErr: unknown;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      const res = await fetch("https://api.openai.com/v1/responses", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${apiKey}`, "content-type": "application/json" },
+        body: JSON.stringify({
+          model,
+          tools: [{ type: "web_search_preview" }],
+          input: prompt,
+          max_output_tokens: ANSWER_MAX_TOKENS,
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        const err = new OpenAI.APIError(res.status, body, undefined, undefined);
+        // Retry transient server errors; surface auth/quota immediately.
+        if (res.status >= 500) { lastErr = err; continue; }
+        throw err;
+      }
+      const j = (await res.json()) as {
+        output?: { content?: { type?: string; text?: string; annotations?: { url?: string; title?: string }[] }[] }[];
+        usage?: { total_tokens?: number; input_tokens?: number; output_tokens?: number };
+      };
+      let text = "";
+      const raw: CitedSource[] = [];
+      for (const item of j.output ?? []) {
+        for (const c of item.content ?? []) {
+          if (typeof c.text === "string") text += (text ? "\n" : "") + c.text;
+          for (const a of c.annotations ?? []) {
+            if (a?.url) raw.push({ url: a.url, domain: domainOf(a.url), title: a.title ?? null, snippet: null });
+          }
+        }
+      }
+      const tokens =
+        j.usage?.total_tokens ??
+        (j.usage?.input_tokens ?? 0) + (j.usage?.output_tokens ?? 0);
+      return { text: text.trim(), tokens, sources: dedupeSources(raw) };
+    } catch (err) {
+      lastErr = err;
+      if (err instanceof OpenAI.APIError && err.status && err.status < 500) throw err;
+    }
+  }
+  throw lastErr ?? new Error("OpenAI web search failed.");
 }
 
 const VARIATION_SYSTEM = `You generate realistic search-style questions that a real person would type into an AI assistant (like ChatGPT or Claude) when researching a topic. The questions should be the kind of prompt where an AI assistant might naturally recommend, compare, or mention specific brands, products, or tools.

--- a/lib/llm/index.ts
+++ b/lib/llm/index.ts
@@ -227,8 +227,8 @@ async function anthropicWebSearch(
 }
 
 // OpenAI native web search via the Responses API. Uses raw fetch so it doesn't
-// depend on a newer SDK; retries a couple of transient failures. NOTE: not yet
-// live-verified (the trial OpenAI key was out of quota during development).
+// depend on a newer SDK; retries a couple of transient failures. The browse is
+// forced via tool_choice (see below) — verified live for gpt-4o / gpt-4o-mini.
 async function openaiWebSearch(
   apiKey: string,
   model: string,
@@ -243,6 +243,9 @@ async function openaiWebSearch(
         body: JSON.stringify({
           model,
           tools: [{ type: "web_search_preview" }],
+          // Force the browse; left to choose, the model often answers from
+          // memory and cites nothing.
+          tool_choice: { type: "web_search_preview" },
           input: prompt,
           max_output_tokens: ANSWER_MAX_TOKENS,
         }),

--- a/lib/llm/sources.test.ts
+++ b/lib/llm/sources.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { safeSource, dedupeSources, type CitedSource } from "@/lib/llm";
+
+describe("safeSource", () => {
+  it("keeps http(s) URLs and extracts the host", () => {
+    expect(safeSource("https://www.Notion.so/pricing", "Notion", "x")).toEqual({
+      url: "https://www.Notion.so/pricing",
+      domain: "notion.so",
+      title: "Notion",
+      snippet: "x",
+    });
+    expect(safeSource("http://example.com", null, null)?.domain).toBe("example.com");
+  });
+
+  it("strips only a leading www. and lowercases the host", () => {
+    expect(safeSource("https://wwwx.example.com", null, null)?.domain).toBe("wwwx.example.com");
+    expect(safeSource("https://BLOG.Example.COM", null, null)?.domain).toBe("blog.example.com");
+  });
+
+  it("rejects non-http(s) protocols (javascript:, data:, ftp:)", () => {
+    expect(safeSource("javascript:alert(1)", null, null)).toBeNull();
+    expect(safeSource("data:text/html,<script>1</script>", null, null)).toBeNull();
+    expect(safeSource("ftp://example.com/file", null, null)).toBeNull();
+  });
+
+  it("rejects malformed URLs", () => {
+    expect(safeSource("not a url", null, null)).toBeNull();
+    expect(safeSource("", null, null)).toBeNull();
+  });
+});
+
+describe("dedupeSources", () => {
+  it("collapses duplicate URLs and back-fills a missing snippet", () => {
+    const raw: CitedSource[] = [
+      { url: "https://a.com", domain: "a.com", title: "A", snippet: null },
+      { url: "https://a.com", domain: "a.com", title: "A", snippet: "quoted" },
+      { url: "https://b.com", domain: "b.com", title: "B", snippet: null },
+    ];
+    const out = dedupeSources(raw);
+    expect(out).toHaveLength(2);
+    expect(out.find((s) => s.url === "https://a.com")?.snippet).toBe("quoted");
+  });
+
+  it("drops entries with no URL", () => {
+    const raw: CitedSource[] = [{ url: "", domain: "", title: null, snippet: null }];
+    expect(dedupeSources(raw)).toHaveLength(0);
+  });
+});

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -49,6 +49,7 @@ export interface Project {
   default_provider: Provider;
   default_model: string;
   schedule: Schedule;
+  use_web_search: boolean;
   last_run_at: string | null;
   created_at: string;
   updated_at: string;
@@ -104,6 +105,22 @@ export interface Response {
   provider: Provider;
   model: string;
   response_text: string;
+  created_at: string;
+}
+
+// A web source the model cited while answering a monitored prompt (native
+// provider web search). `is_owned` marks sources on the brand's own domain, so
+// you can see when your site influences an answer even without a mention.
+export interface Source {
+  id: string;
+  response_id: string;
+  run_id: string;
+  project_id: string;
+  url: string;
+  domain: string;
+  title: string | null;
+  snippet: string | null;
+  is_owned: boolean;
   created_at: string;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,11 @@
         "eslint-config-next": "14.2.15",
         "postcss": "^8.4.47",
         "tailwindcss": "^3.4.13",
-        "typescript": "^5.6.3"
+        "typescript": "^5.6.3",
+        "vitest": "^2.1.9"
+      },
+      "engines": {
+        "node": ">=20 <23"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -115,6 +119,397 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -378,9 +773,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -396,9 +788,6 @@
       "integrity": "sha512-k5xf/tg1FBv/M4CMd8S+JL3uV9BnnRmoe7F+GWC3DxkTCD9aewFRH1s5rJ1zkzDa+Do4zyN8qD0N8c84Hu96FQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -416,9 +805,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -434,9 +820,6 @@
       "integrity": "sha512-PZ5YE9ouy/IdO7QVJeIcyLn/Rc4ml9M2G4y3kCM9MNf1YKvFY4heg3pVa/jQbMro+tP6yc4G2o9LjAz1zxD7tQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -553,6 +936,356 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -759,6 +1492,13 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json5": {
@@ -1210,9 +1950,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1227,9 +1964,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1244,9 +1978,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1261,9 +1992,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1278,9 +2006,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1295,9 +2020,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1312,9 +2034,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1329,9 +2048,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1346,9 +2062,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1363,9 +2076,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1446,6 +2156,119 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -1742,6 +2565,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -1940,6 +2773,16 @@
         "node": ">=10.16.0"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
@@ -2029,6 +2872,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2044,6 +2904,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -2397,6 +3267,16 @@
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2655,6 +3535,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
@@ -2714,6 +3601,45 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
       }
     },
     "node_modules/escalade": {
@@ -3159,6 +4085,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3183,6 +4119,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4550,6 +5496,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
@@ -4564,6 +5517,16 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/math-intrinsics": {
@@ -5202,6 +6165,23 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5750,6 +6730,51 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -5999,6 +7024,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -6025,6 +7057,20 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
     },
@@ -6452,6 +7498,20 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -6498,6 +7558,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -6809,6 +7899,155 @@
         "d3-timer": "^3.0.1"
       }
     },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "4.0.0-beta.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
@@ -6937,6 +8176,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.30.1",
@@ -34,6 +35,7 @@
     "eslint-config-next": "14.2.15",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.13",
-    "typescript": "^5.6.3"
+    "typescript": "^5.6.3",
+    "vitest": "^2.1.9"
   }
 }

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -114,6 +114,11 @@ create table if not exists public.projects (
   updated_at timestamptz not null default now()
 );
 
+-- Query the models with their native web search on, so we can capture the
+-- sources they cite. Default on. Safe to re-run.
+alter table public.projects
+  add column if not exists use_web_search boolean not null default true;
+
 -- Multi-org: which of the user's projects (organizations) the dashboard is
 -- currently showing. Falls back to the earliest project when unset. Safe to
 -- re-run; lives here because it references projects, created just above.
@@ -196,6 +201,20 @@ create table if not exists public.mentions (
   created_at timestamptz not null default now()
 );
 
+-- ---------- sources (web citations behind an answer) -----------------
+create table if not exists public.sources (
+  id uuid primary key default gen_random_uuid(),
+  response_id uuid not null references public.responses (id) on delete cascade,
+  run_id uuid not null references public.runs (id) on delete cascade,
+  project_id uuid not null references public.projects (id) on delete cascade,
+  url text not null,
+  domain text not null,
+  title text,
+  snippet text,
+  is_owned boolean not null default false,
+  created_at timestamptz not null default now()
+);
+
 -- ---------- indexes --------------------------------------------------
 create index if not exists idx_projects_user on public.projects (user_id);
 create index if not exists idx_competitors_project on public.competitors (project_id);
@@ -207,6 +226,9 @@ create index if not exists idx_responses_run on public.responses (run_id);
 create index if not exists idx_mentions_project on public.mentions (project_id);
 create index if not exists idx_mentions_run on public.mentions (run_id);
 create index if not exists idx_mentions_response on public.mentions (response_id);
+create index if not exists idx_sources_response on public.sources (response_id);
+create index if not exists idx_sources_run on public.sources (run_id);
+create index if not exists idx_sources_project on public.sources (project_id);
 
 -- ==================================================================
 -- Row Level Security
@@ -220,6 +242,7 @@ alter table public.prompts        enable row level security;
 alter table public.runs           enable row level security;
 alter table public.responses      enable row level security;
 alter table public.mentions       enable row level security;
+alter table public.sources        enable row level security;
 
 -- profiles: a user sees/edits only their own row.
 drop policy if exists "profiles_self" on public.profiles;
@@ -315,6 +338,11 @@ create policy "responses_owner" on public.responses
 
 drop policy if exists "mentions_owner" on public.mentions;
 create policy "mentions_owner" on public.mentions
+  for all using (project_id in (select id from public.projects where user_id = auth.uid()))
+  with check (project_id in (select id from public.projects where user_id = auth.uid()));
+
+drop policy if exists "sources_owner" on public.sources;
+create policy "sources_owner" on public.sources
   for all using (project_id in (select id from public.projects where user_id = auth.uid()))
   with check (project_id in (select id from public.projects where user_id = auth.uid()));
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Map the "@/…" import alias to the repo root, matching tsconfig paths.
+const root = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  resolve: { alias: { "@": root } },
+  test: {
+    environment: "node",
+    include: ["lib/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Overview

Native web search + **source attribution**: query Claude/ChatGPT with their own browsing (via the BYOK key — no Exa/You.com, fully self-hostable) and capture the exact sources each answer cited.

- **LLM layer** — `runQuery` gains a `webSearch` flag and returns cited sources (url, domain, title, snippet), deduped by URL. Claude uses the `web_search` server tool; OpenAI uses the Responses API `web_search_preview` with `tool_choice` forcing the browse (else gpt-4o answers from memory and cites nothing).
- **Cited-only** — the source list is the answer’s inline citations (what it actually used); retrieved-but-not-cited search results are a fallback only when a response cited nothing inline.
- **`sources` table** (+ RLS, indexes). The engine stores sources per answer and flags `is_owned` when the source is on the brand’s own domain (incl. subdomains).
- **Run detail UI** — sources under each answer (owned highlighted with a “Your site” badge), plus “Your site was cited in N of M answers” — independent of whether the brand was named.
- **Per-project `use_web_search` toggle** (default on) in Settings, since browsing costs more per query.

### Security
- `safeSource()` drops any citation whose URL isn’t http(s) before it can be stored or rendered as an href (guards a model citing a `javascript:`/`data:` URL).

### Tests
- Adds **vitest** (`npm test`) + 12 unit tests for the pure helpers (`safeSource`, `dedupeSources`, `hostOf`, `isOwnedDomain`), covering subdomain matching, `www.` stripping, `co.uk` hosts, dedupe merge, and the URL-protocol guard.

### Verified live (both providers)
- Claude + ChatGPT (gpt-4o / gpt-4o-mini) return cited sources through the real `runQuery`.
- Full app run: sources stored, mention detected, rendered on the run page; owned-source highlight verified.
- Toggle off → 0 sources; regression checks (suggest competitors, generate variations) still pass; fallback parser confirmed against the real `web_search_tool_result` shape.
- **Product signal noted:** models overwhelmingly cite third-party sites (g2, review/listicle blogs) over a brand’s own domain, even for questions about the brand itself.

### Deploy note
⚠️ Re-run `supabase/schema.sql` (adds `sources` table + `projects.use_web_search`). Already applied to the shared project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)