### PR TITLE
Add dark mode as default with a configurable light toggle

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -4,6 +4,7 @@ import { DashboardNav } from "@/components/dashboard/nav";
 import { OrgSwitcher } from "@/components/dashboard/org-switcher";
 import { SignOutButton } from "@/components/dashboard/signout";
 import { TrialBanner } from "@/components/dashboard/trial-banner";
+import { ThemeSwitch, ThemeToggle } from "@/components/theme";
 import { createClient } from "@/lib/supabase/server";
 import { getProject, getProjects, getConfiguredProviders } from "@/lib/data";
 import { trialEnabled, trialRunLimit, getTrialRunsUsed } from "@/lib/trial";
@@ -64,7 +65,8 @@ export default async function DashboardLayout({
 
           <DashboardNav />
 
-          <div className="mt-auto hidden flex-col gap-2 border-t border-ink/10 pt-4 md:flex">
+          <div className="mt-auto hidden flex-col gap-3 border-t border-ink/10 pt-4 md:flex">
+            <ThemeSwitch />
             <p className="truncate text-xs text-ink-faint" title={user.email ?? undefined}>
               {user.email}
             </p>
@@ -75,7 +77,10 @@ export default async function DashboardLayout({
             <p className="truncate text-xs text-ink-faint" title={user.email ?? undefined}>
               {user.email}
             </p>
-            <SignOutButton />
+            <div className="flex items-center gap-2">
+              <ThemeToggle />
+              <SignOutButton />
+            </div>
           </div>
         </div>
       </aside>

--- a/app/dashboard/settings/keys-manager.tsx
+++ b/app/dashboard/settings/keys-manager.tsx
@@ -33,7 +33,7 @@ const PROVIDER_STYLE: Record<
     title: "ChatGPT",
     subtitle: "OpenAI API key",
     mark: "G",
-    markClass: "bg-teal/15 text-teal-900",
+    markClass: "bg-teal/15 text-teal-dark",
   },
 };
 

--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -1,7 +1,8 @@
-import { KeyRound, Building2 } from "lucide-react";
+import { KeyRound, Building2, Palette } from "lucide-react";
 import { createClient } from "@/lib/supabase/server";
 import { getProject, getProviderKeysPublic } from "@/lib/data";
 import { Card, CardBody, SectionHeading } from "@/components/ui";
+import { ThemeSwitch } from "@/components/theme";
 import KeysManager from "./keys-manager";
 import ProjectForm from "./project-form";
 
@@ -29,7 +30,7 @@ export default async function SettingsPage() {
       <Card>
         <CardBody className="space-y-5">
           <div className="flex items-start gap-3">
-            <span className="mt-0.5 rounded-xl bg-mint/50 p-2 text-emerald-800">
+            <span className="mt-0.5 rounded-xl bg-mint-tint p-2 text-mint-ink">
               <KeyRound className="h-5 w-5" />
             </span>
             <div>
@@ -48,7 +49,7 @@ export default async function SettingsPage() {
       <Card>
         <CardBody className="space-y-5">
           <div className="flex items-start gap-3">
-            <span className="mt-0.5 rounded-xl bg-butter/60 p-2 text-yellow-900">
+            <span className="mt-0.5 rounded-xl bg-butter-tint p-2 text-butter-ink">
               <Building2 className="h-5 w-5" />
             </span>
             <div>
@@ -61,6 +62,26 @@ export default async function SettingsPage() {
             </div>
           </div>
           <ProjectForm project={project} />
+        </CardBody>
+      </Card>
+
+      <Card>
+        <CardBody className="space-y-5">
+          <div className="flex items-start gap-3">
+            <span className="mt-0.5 rounded-xl bg-sand-tint p-2 text-ink-soft">
+              <Palette className="h-5 w-5" />
+            </span>
+            <div>
+              <h3 className="text-lg font-semibold text-ink">Appearance</h3>
+              <p className="mt-1 text-sm text-ink-faint">
+                Lettertrace defaults to dark. Switch to light if you prefer, your
+                choice is remembered on this device.
+              </p>
+            </div>
+          </div>
+          <div className="max-w-xs">
+            <ThemeSwitch />
+          </div>
         </CardBody>
       </Card>
     </div>

--- a/app/dashboard/settings/project-form.tsx
+++ b/app/dashboard/settings/project-form.tsx
@@ -202,7 +202,7 @@ export default function ProjectForm({ project }: { project: Project | null }) {
         </Button>
         {saved && !saving && (
           <span className="inline-flex items-center gap-1.5 text-sm text-ink-soft">
-            <Check className="h-4 w-4 text-emerald-600" />
+            <Check className="h-4 w-4 text-teal-dark" />
             Saved
           </span>
         )}

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,8 +2,103 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
+/* ------------------------------------------------------------------
+   Theme tokens. Dark is the default; `[data-theme="light"]` opts out.
+   Values are space-separated "R G B" triples so Tailwind can apply its
+   own opacity modifiers via rgb(var(--x) / <alpha-value>).
+   ------------------------------------------------------------------ */
+
+:root,
+:root[data-theme="dark"] {
+  color-scheme: dark;
+
+  /* neutrals — warm near-black canvas, warm off-white ink */
+  --c-paper: 19 18 17;
+  --c-paper-shade: 27 26 24;
+  --c-paper-deep: 38 36 33;
+  --c-surface: 31 29 26;
+  --c-ink: 244 243 239;
+  --c-ink-soft: 190 186 178;
+  --c-ink-faint: 138 134 125;
+
+  /* brand accents — hues shared across themes */
+  --c-terracotta: 224 120 80;
+  --c-terracotta-soft: 240 173 144;
+  --c-terracotta-ink: 240 173 144; /* light shade so it reads on dark tints */
+
+  --c-teal: 25 176 148;
+  --c-teal-soft: 116 201 183;
+  --c-teal-ink: 116 201 183;
+
+  --c-mint: 168 240 220;
+  --c-mint-bright: 130 234 209;
+  --c-mint-soft: 214 246 238;
+  --c-mint-tint: 22 51 43; /* subtle dark chip fill */
+  --c-mint-ink: 130 234 209;
+
+  --c-butter: 232 198 124;
+  --c-butter-tint: 51 43 24;
+  --c-butter-ink: 232 198 124;
+
+  --c-sand: 203 185 160;
+  --c-sand-soft: 228 218 201;
+  --c-sand-tint: 43 38 32;
+
+  /* always-dark code/terminal panel */
+  --c-terminal: 32 30 26;
+  --c-terminal-ink: 244 243 239;
+
+  /* effect tints */
+  --grid-line: 255 255 255;
+  --grid-alpha: 0.05;
+  --dot-alpha: 0.06;
+  --shimmer-base: 255 255 255;
+  --shimmer-base-alpha: 0.06;
+  --shimmer-sweep-alpha: 0.09;
+}
+
+:root[data-theme="light"] {
   color-scheme: light;
+
+  --c-paper: 245 244 240;
+  --c-paper-shade: 237 234 225;
+  --c-paper-deep: 225 221 209;
+  --c-surface: 255 255 255;
+  --c-ink: 26 25 23;
+  --c-ink-soft: 69 66 60;
+  --c-ink-faint: 124 120 111;
+
+  --c-terracotta: 224 120 80;
+  --c-terracotta-soft: 240 173 144;
+  --c-terracotta-ink: 185 85 47; /* deep shade for text on light tints */
+
+  --c-teal: 18 156 130;
+  --c-teal-soft: 116 201 183;
+  --c-teal-ink: 12 110 91;
+
+  --c-mint: 168 240 220;
+  --c-mint-bright: 130 234 209;
+  --c-mint-soft: 214 246 238;
+  --c-mint-tint: 199 242 228; /* matches the previous mint/60 chip on paper */
+  --c-mint-ink: 6 95 70;
+
+  --c-butter: 232 198 124;
+  --c-butter-tint: 237 216 170;
+  --c-butter-ink: 113 63 18;
+
+  --c-sand: 203 185 160;
+  --c-sand-soft: 228 218 201;
+  --c-sand-tint: 228 220 208;
+
+  --c-terminal: 26 25 23;
+  --c-terminal-ink: 245 244 240;
+
+  --grid-line: 20 20 24;
+  --grid-alpha: 0.05;
+  --dot-alpha: 0.06;
+  --shimmer-base: 26 25 23;
+  --shimmer-base-alpha: 0.05;
+  --shimmer-sweep-alpha: 0.55;
 }
 
 @layer base {
@@ -30,16 +125,16 @@
 }
 
 @layer components {
-  /* Fine engineering grid, the light-mode take on phantom's dark canvas. */
+  /* Fine engineering grid — dark lines in light mode, light lines in dark. */
   .bg-grid {
     background-image:
-      linear-gradient(to right, rgba(20, 20, 24, 0.05) 1px, transparent 1px),
-      linear-gradient(to bottom, rgba(20, 20, 24, 0.05) 1px, transparent 1px);
+      linear-gradient(to right, rgb(var(--grid-line) / var(--grid-alpha)) 1px, transparent 1px),
+      linear-gradient(to bottom, rgb(var(--grid-line) / var(--grid-alpha)) 1px, transparent 1px);
     background-size: 44px 44px;
   }
 
   .bg-dotted {
-    background-image: radial-gradient(rgba(20, 20, 24, 0.06) 1px, transparent 1px);
+    background-image: radial-gradient(rgb(var(--grid-line) / var(--dot-alpha)) 1px, transparent 1px);
     background-size: 22px 22px;
   }
 
@@ -59,12 +154,21 @@
   }
 }
 
-/* Skeleton shimmer: warm ink-tint base with a soft light sweep. Rounded
+/* Brand lockup swaps with the theme (see components/logo.tsx). Anything that
+   isn't explicitly light is treated as dark, matching the dark default. */
+:root[data-theme="light"] .logo-for-dark {
+  display: none;
+}
+:root:not([data-theme="light"]) .logo-for-light {
+  display: none;
+}
+
+/* Skeleton shimmer: tint base with a soft sweep, both theme-aware. Rounded
    corners come from the element's own radius (overflow hidden clips the sweep). */
 .shimmer {
   position: relative;
   overflow: hidden;
-  background-color: rgba(26, 25, 23, 0.05);
+  background-color: rgb(var(--shimmer-base) / var(--shimmer-base-alpha));
 }
 .shimmer::after {
   content: "";
@@ -74,9 +178,9 @@
   background-image: linear-gradient(
     90deg,
     transparent 0%,
-    rgba(255, 255, 255, 0.5) 45%,
-    rgba(255, 255, 255, 0.65) 50%,
-    rgba(255, 255, 255, 0.5) 55%,
+    rgb(var(--shimmer-base) / calc(var(--shimmer-sweep-alpha) * 0.85)) 45%,
+    rgb(var(--shimmer-base) / var(--shimmer-sweep-alpha)) 50%,
+    rgb(var(--shimmer-base) / calc(var(--shimmer-sweep-alpha) * 0.85)) 55%,
     transparent 100%
   );
   animation: shimmer-sweep 1.8s ease-in-out infinite;
@@ -87,18 +191,18 @@
   }
 }
 
-/* Recharts: keep tooltips/axes on-brand. */
+/* Recharts: keep tooltips/axes on-brand in both themes. */
 .recharts-cartesian-axis-tick-value {
-  fill: #7c786f;
+  fill: rgb(var(--c-ink-faint));
   font-size: 12px;
 }
 .recharts-default-tooltip {
   border-radius: 12px !important;
-  border: 1px solid rgba(20, 20, 24, 0.1) !important;
-  box-shadow: 0 8px 24px rgba(20, 20, 24, 0.08) !important;
+  border: 1px solid rgb(var(--c-ink) / 0.1) !important;
+  box-shadow: 0 8px 24px rgb(0 0 0 / 0.18) !important;
   font-family: var(--font-dm-sans), sans-serif !important;
 }
 .recharts-legend-item-text {
-  color: #45423c !important;
+  color: rgb(var(--c-ink-soft)) !important;
   font-size: 13px;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { DM_Sans, DM_Mono, Ibarra_Real_Nova } from "next/font/google";
 import "./globals.css";
+import { ThemeProvider, themeInitScript } from "@/components/theme";
 
 const dmSans = DM_Sans({
   subsets: ["latin"],
@@ -60,8 +61,19 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" className={`${dmSans.variable} ${dmMono.variable} ${ibarra.variable}`}>
-      <body>{children}</body>
+    <html
+      lang="en"
+      data-theme="dark"
+      className={`${dmSans.variable} ${dmMono.variable} ${ibarra.variable}`}
+      suppressHydrationWarning
+    >
+      <head>
+        {/* Applies the saved theme before first paint to avoid a flash. */}
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+      </head>
+      <body>
+        <ThemeProvider>{children}</ThemeProvider>
+      </body>
     </html>
   );
 }

--- a/app/login/auth-form.tsx
+++ b/app/login/auth-form.tsx
@@ -74,7 +74,7 @@ export function AuthForm({ next, mode }: { next?: string; mode?: string }) {
   if (confirmSent) {
     return (
       <div className="space-y-5 text-center">
-        <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-mint/50 text-emerald-800">
+        <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-mint-tint text-mint-ink">
           <CheckCircle2 className="h-6 w-6" aria-hidden />
         </div>
         <div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 import { Badge, Button, Card } from "@/components/ui";
 import { Logo } from "@/components/logo";
+import { ThemeToggle } from "@/components/theme";
 
 const GITHUB_URL = "https://github.com";
 
@@ -33,7 +34,7 @@ function TerminalDots() {
 
 function Terminal() {
   return (
-    <div className="overflow-hidden rounded-2xl border border-ink/10 bg-ink text-paper shadow-lift">
+    <div className="overflow-hidden rounded-2xl border border-ink/10 bg-terminal text-terminal-ink shadow-lift">
       <div className="flex items-center justify-between border-b border-white/10 px-4 py-3">
         <TerminalDots />
         <span className="font-mono text-[11px] text-white/40">lettertrace · monitor</span>
@@ -64,7 +65,7 @@ function Terminal() {
         </p>
         <p className="pt-1 text-white/40">
           <span className="text-mint-bright">$</span>{" "}
-          <span className="inline-block h-4 w-2 translate-y-0.5 animate-blink bg-paper/80" />
+          <span className="inline-block h-4 w-2 translate-y-0.5 animate-blink bg-terminal-ink/80" />
         </p>
       </div>
     </div>
@@ -139,10 +140,10 @@ const FEATURES = [
 
 const toneBg: Record<string, string> = {
   terracotta: "bg-terracotta/12 text-terracotta-dark",
-  teal: "bg-teal/20 text-teal-900",
-  sand: "bg-sand/40 text-ink-soft",
-  mint: "bg-mint/60 text-emerald-800",
-  butter: "bg-butter/60 text-yellow-900",
+  teal: "bg-teal/20 text-teal-dark",
+  sand: "bg-sand-tint text-ink-soft",
+  mint: "bg-mint-tint text-mint-ink",
+  butter: "bg-butter-tint text-butter-ink",
 };
 
 export default function LandingPage() {
@@ -158,6 +159,7 @@ export default function LandingPage() {
             <a href="#open-source" className="transition hover:text-ink">Open source</a>
           </nav>
           <div className="flex items-center gap-2">
+            <ThemeToggle />
             <Button href="/login" variant="ghost" size="sm">Sign in</Button>
             <Button href="/login" size="sm">Start free</Button>
           </div>
@@ -308,7 +310,7 @@ export default function LandingPage() {
               <OSPoint icon={Layers}>Your data lives in your own Supabase, no vendor lock-in.</OSPoint>
             </ul>
           </div>
-          <div className="overflow-hidden rounded-2xl border border-ink/10 bg-ink text-paper shadow-lift">
+          <div className="overflow-hidden rounded-2xl border border-ink/10 bg-terminal text-terminal-ink shadow-lift">
             <div className="flex items-center gap-2 border-b border-white/10 px-4 py-3">
               <TerminalDots />
               <span className="ml-2 font-mono text-[11px] text-white/40">self-host</span>
@@ -371,7 +373,8 @@ export default function LandingPage() {
 // --- tiny local components ---------------------------------------
 
 function Mark({ children }: { children: React.ReactNode }) {
-  return <mark className="rounded bg-butter px-1 text-ink">{children}</mark>;
+  // butter is a light amber in both themes, so the highlight text stays dark.
+  return <mark className="rounded bg-butter px-1 text-[#1A1917]">{children}</mark>;
 }
 
 function PreviewStat({ label, value, dot }: { label: string; value: string; dot: string }) {
@@ -404,7 +407,7 @@ function ShareRow({ name, pct, brand = false }: { name: string; pct: number; bra
 function OSPoint({ icon: Icon, children }: { icon: typeof ShieldCheck; children: React.ReactNode }) {
   return (
     <li className="flex items-start gap-3">
-      <span className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-lg bg-mint/60 text-emerald-800">
+      <span className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-lg bg-mint-tint text-mint-ink">
         <Icon className="h-3.5 w-3.5" />
       </span>
       <span className="text-sm">{children}</span>

--- a/components/dashboard/charts.tsx
+++ b/components/dashboard/charts.tsx
@@ -17,29 +17,55 @@ import {
 } from "recharts";
 import { SENTIMENT_COLORS } from "@/lib/metrics";
 import type { Sentiment } from "@/lib/types";
+import { useTheme } from "@/components/theme";
 
 // ------------------------------------------------------------------
 // Recharts wrappers for the overview dashboard. All numeric inputs are
 // plain values already scaled 0..100 where noted. Each chart degrades to
 // a muted placeholder instead of crashing on empty data.
+//
+// Recharts takes colors as literal props/attributes (CSS variables don't
+// resolve inside SVG presentation attributes), so we resolve the palette
+// from the active theme here and re-render when the user flips it.
 // ------------------------------------------------------------------
 
-const INK = "#1A1917";
-const INK_FAINT = "#7C786F";
-const GRID = "rgba(26,25,23,0.08)";
-const BRAND = "#E07850"; // terracotta (you)
+const BRAND = "#E07850"; // terracotta (you) — pops on both themes
 const TEAL = "#129C82"; // aqua (share / competitors)
 
-const axisTick = { fill: INK_FAINT, fontSize: 12 };
-
-const tooltipStyle = {
-  borderRadius: 12,
-  border: "1px solid rgba(26,25,23,0.10)",
-  background: "#FFFFFF",
-  boxShadow: "0 8px 24px rgba(26,25,23,0.10)",
-  fontSize: 12,
-  color: INK,
+const PALETTE = {
+  light: {
+    ink: "#1A1917",
+    faint: "#7C786F",
+    grid: "rgba(26,25,23,0.08)",
+    surface: "#FFFFFF",
+    cursor: "rgba(26,25,23,0.04)",
+  },
+  dark: {
+    ink: "#F4F3EF",
+    faint: "#8A867D",
+    grid: "rgba(255,255,255,0.10)",
+    surface: "#1F1D1A",
+    cursor: "rgba(255,255,255,0.05)",
+  },
 } as const;
+
+function useChartTheme() {
+  const { theme } = useTheme();
+  const p = PALETTE[theme];
+  return {
+    ...p,
+    axisTick: { fill: p.faint, fontSize: 12 },
+    tooltipStyle: {
+      borderRadius: 12,
+      border: `1px solid ${p.grid}`,
+      background: p.surface,
+      boxShadow: "0 8px 24px rgba(0,0,0,0.18)",
+      fontSize: 12,
+      color: p.ink,
+    } as const,
+    legendStyle: { fontSize: 12, color: p.faint },
+  };
+}
 
 function Placeholder({ label, height }: { label: string; height: number }) {
   return (
@@ -57,24 +83,25 @@ export function TrendChart({
 }: {
   data: { date: string; visibility: number; share: number }[];
 }) {
+  const t = useChartTheme();
   if (!data || data.length === 0) {
     return <Placeholder label="No runs to chart yet" height={280} />;
   }
   return (
     <ResponsiveContainer width="100%" height={280}>
       <LineChart data={data} margin={{ top: 8, right: 12, bottom: 4, left: -8 }}>
-        <CartesianGrid stroke={GRID} vertical={false} />
-        <XAxis dataKey="date" tick={axisTick} tickLine={false} axisLine={{ stroke: GRID }} />
+        <CartesianGrid stroke={t.grid} vertical={false} />
+        <XAxis dataKey="date" tick={t.axisTick} tickLine={false} axisLine={{ stroke: t.grid }} />
         <YAxis
           domain={[0, 100]}
-          tick={axisTick}
+          tick={t.axisTick}
           tickLine={false}
           axisLine={false}
           tickFormatter={(v: number) => `${v}%`}
           width={44}
         />
         <Tooltip
-          contentStyle={tooltipStyle}
+          contentStyle={t.tooltipStyle}
           formatter={(value: number, name: string) => [
             `${Math.round(value)}%`,
             name === "visibility" ? "Visibility" : "Share of voice",
@@ -82,7 +109,7 @@ export function TrendChart({
         />
         <Legend
           iconType="plainline"
-          wrapperStyle={{ fontSize: 12, color: INK_FAINT }}
+          wrapperStyle={t.legendStyle}
           formatter={(value: string) =>
             value === "visibility" ? "Visibility" : "Share of voice"
           }
@@ -113,6 +140,7 @@ export function ShareBars({
 }: {
   data: { name: string; value: number; isBrand: boolean }[];
 }) {
+  const t = useChartTheme();
   if (!data || data.length === 0) {
     return <Placeholder label="No share of voice yet" height={180} />;
   }
@@ -125,26 +153,26 @@ export function ShareBars({
         margin={{ top: 4, right: 16, bottom: 4, left: 8 }}
         barCategoryGap={12}
       >
-        <CartesianGrid stroke={GRID} horizontal={false} />
+        <CartesianGrid stroke={t.grid} horizontal={false} />
         <XAxis
           type="number"
           domain={[0, 100]}
-          tick={axisTick}
+          tick={t.axisTick}
           tickLine={false}
-          axisLine={{ stroke: GRID }}
+          axisLine={{ stroke: t.grid }}
           tickFormatter={(v: number) => `${v}%`}
         />
         <YAxis
           type="category"
           dataKey="name"
-          tick={axisTick}
+          tick={t.axisTick}
           tickLine={false}
           axisLine={false}
           width={110}
         />
         <Tooltip
-          cursor={{ fill: "rgba(26,25,23,0.04)" }}
-          contentStyle={tooltipStyle}
+          cursor={{ fill: t.cursor }}
+          contentStyle={t.tooltipStyle}
           formatter={(value: number) => [`${Math.round(value)}%`, "Share of voice"]}
         />
         <Bar dataKey="value" radius={[0, 8, 8, 0]}>
@@ -162,13 +190,14 @@ export function SentimentDonut({
 }: {
   data: { name: string; value: number }[];
 }) {
+  const t = useChartTheme();
   const total = (data ?? []).reduce((s, d) => s + (d.value || 0), 0);
   if (total === 0) {
     return <Placeholder label="No sentiment yet" height={240} />;
   }
   const colorFor = (name: string): string => {
     const key = name.toLowerCase() as Sentiment;
-    return SENTIMENT_COLORS[key] ?? INK_FAINT;
+    return SENTIMENT_COLORS[key] ?? t.faint;
   };
   return (
     <ResponsiveContainer width="100%" height={240}>
@@ -182,7 +211,7 @@ export function SentimentDonut({
           innerRadius={54}
           outerRadius={84}
           paddingAngle={2}
-          stroke="#FFFFFF"
+          stroke={t.surface}
           strokeWidth={2}
         >
           {data.map((entry, i) => (
@@ -190,12 +219,12 @@ export function SentimentDonut({
           ))}
         </Pie>
         <Tooltip
-          contentStyle={tooltipStyle}
+          contentStyle={t.tooltipStyle}
           formatter={(value: number, name: string) => [`${value}`, name]}
         />
         <Legend
           iconType="circle"
-          wrapperStyle={{ fontSize: 12, color: INK_FAINT }}
+          wrapperStyle={t.legendStyle}
         />
       </PieChart>
     </ResponsiveContainer>

--- a/components/dashboard/trial-banner.tsx
+++ b/components/dashboard/trial-banner.tsx
@@ -31,7 +31,7 @@ export function TrialBanner({
           <span
             className={cn(
               "mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg",
-              exhausted ? "bg-terracotta/15 text-terracotta-dark" : "bg-teal/15 text-teal-900",
+              exhausted ? "bg-terracotta/15 text-terracotta-dark" : "bg-teal/15 text-teal-dark",
             )}
           >
             {exhausted ? <KeyRound className="h-4 w-4" /> : <Sparkles className="h-4 w-4" />}

--- a/components/logo.tsx
+++ b/components/logo.tsx
@@ -2,16 +2,18 @@ import Image from "next/image";
 import { cn } from "@/lib/utils";
 
 // The Lettertrace brand lockup. Real brand assets live in /public/images.
-// Every in-app placement sits on a light surface, so the black wordmark is the
-// default; pass variant="light" on dark backgrounds. showWord={false} renders
-// just the petal mark.
+// By default the wordmark follows the active theme: the black lockup shows in
+// light mode, the white lockup in dark mode. The swap is pure CSS keyed off
+// html[data-theme] (see the .logo-for-* rules in globals.css), so it reacts to
+// the runtime toggle with no flash and no client JS. Pass an explicit
+// variant to pin one asset. showWord={false} renders just the petal mark.
 //
 // The <Image> is wrapped in an inline-flex, width-fit span so it never gets
 // stretched when it's a direct flex child (e.g. the flex-col dashboard sidebar,
 // where align-items:stretch would otherwise distort a w-auto image).
 export function Logo({
   className,
-  variant = "dark",
+  variant,
   showWord = true,
 }: {
   className?: string;
@@ -26,15 +28,32 @@ export function Logo({
     );
   }
 
-  const src = variant === "light" ? "/images/logo_white.png" : "/images/logo_black.png";
+  // Explicit override: render a single asset.
+  if (variant) {
+    const src = variant === "light" ? "/images/logo_white.png" : "/images/logo_black.png";
+    return (
+      <span className={cn("inline-flex w-fit shrink-0", className)}>
+        <Image src={src} alt="Lettertrace" width={705} height={138} className="h-7 w-auto" />
+      </span>
+    );
+  }
+
+  // Auto (default): render both; CSS reveals the one matching the theme.
   return (
     <span className={cn("inline-flex w-fit shrink-0", className)}>
       <Image
-        src={src}
+        src="/images/logo_black.png"
         alt="Lettertrace"
         width={705}
         height={138}
-        className="h-7 w-auto"
+        className="logo-for-light h-7 w-auto"
+      />
+      <Image
+        src="/images/logo_white.png"
+        alt="Lettertrace"
+        width={705}
+        height={138}
+        className="logo-for-dark h-7 w-auto"
       />
     </span>
   );

--- a/components/theme.tsx
+++ b/components/theme.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+import { Moon, Sun } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+// ------------------------------------------------------------------
+// Theme system. Dark is the default; the user can switch to light and
+// the choice persists in localStorage. The initial attribute is set by
+// an inline script in the root layout (see themeInitScript) so there is
+// no flash before hydration.
+// ------------------------------------------------------------------
+
+export type Theme = "dark" | "light";
+
+export const THEME_STORAGE_KEY = "lettertrace-theme";
+export const DEFAULT_THEME: Theme = "dark";
+
+// Runs before paint (injected in <head>). Reads the saved choice and applies
+// it to <html> so the first frame already matches. Kept dependency-free and
+// stringified — it must run without React.
+export const themeInitScript = `(function(){try{var k="${THEME_STORAGE_KEY}";var s=localStorage.getItem(k);var t=s==="light"||s==="dark"?s:"${DEFAULT_THEME}";var r=document.documentElement;r.dataset.theme=t;r.style.colorScheme=t;}catch(e){}})();`;
+
+function readTheme(): Theme {
+  if (typeof document !== "undefined") {
+    const attr = document.documentElement.dataset.theme;
+    if (attr === "light" || attr === "dark") return attr;
+  }
+  return DEFAULT_THEME;
+}
+
+function applyTheme(theme: Theme) {
+  const root = document.documentElement;
+  root.dataset.theme = theme;
+  root.style.colorScheme = theme;
+  try {
+    localStorage.setItem(THEME_STORAGE_KEY, theme);
+  } catch {
+    // ignore write failures (private mode, blocked storage)
+  }
+}
+
+interface ThemeContextValue {
+  theme: Theme;
+  mounted: boolean;
+  setTheme: (theme: Theme) => void;
+  toggle: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  // Initialise to the default for a stable server/first-client render; the
+  // effect below syncs to whatever the inline script already applied.
+  const [theme, setThemeState] = useState<Theme>(DEFAULT_THEME);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setThemeState(readTheme());
+    setMounted(true);
+  }, []);
+
+  const setTheme = useCallback((next: Theme) => {
+    setThemeState(next);
+    applyTheme(next);
+  }, []);
+
+  const toggle = useCallback(() => {
+    setThemeState((prev) => {
+      const next = prev === "dark" ? "light" : "dark";
+      applyTheme(next);
+      return next;
+    });
+  }, []);
+
+  return (
+    <ThemeContext.Provider value={{ theme, mounted, setTheme, toggle }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext);
+  if (ctx) return ctx;
+  // Fallback for any consumer rendered outside the provider.
+  return {
+    theme: readTheme(),
+    mounted: true,
+    setTheme: () => {},
+    toggle: () => {},
+  };
+}
+
+// Compact icon button — for pre-auth headers (landing, login).
+export function ThemeToggle({ className }: { className?: string }) {
+  const { theme, mounted, toggle } = useTheme();
+  const isDark = theme === "dark";
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
+      title={isDark ? "Switch to light mode" : "Switch to dark mode"}
+      className={cn(
+        "inline-flex h-9 w-9 items-center justify-center rounded-xl border border-ink/15 text-ink-soft transition hover:border-ink/35 hover:text-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-terracotta/40",
+        className,
+      )}
+    >
+      {/* Render a stable icon until mounted to avoid hydration mismatch. */}
+      {mounted && !isDark ? (
+        <Sun className="h-4 w-4" aria-hidden />
+      ) : (
+        <Moon className="h-4 w-4" aria-hidden />
+      )}
+    </button>
+  );
+}
+
+// Labeled switch — for the sidebar and the settings "Appearance" card.
+export function ThemeSwitch({
+  className,
+  showLabel = true,
+}: {
+  className?: string;
+  showLabel?: boolean;
+}) {
+  const { theme, mounted, toggle } = useTheme();
+  const isDark = theme === "dark";
+  return (
+    <div className={cn("flex items-center justify-between gap-3", className)}>
+      {showLabel && (
+        <span className="inline-flex items-center gap-2 text-sm font-medium text-ink-soft">
+          {isDark ? <Moon className="h-4 w-4" aria-hidden /> : <Sun className="h-4 w-4" aria-hidden />}
+          {mounted ? (isDark ? "Dark" : "Light") : "Theme"}
+        </span>
+      )}
+      <button
+        type="button"
+        role="switch"
+        aria-checked={!isDark}
+        aria-label="Toggle light mode"
+        onClick={toggle}
+        className={cn(
+          "relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition focus:outline-none focus-visible:ring-2 focus-visible:ring-terracotta/40",
+          isDark ? "bg-ink/15" : "bg-terracotta",
+        )}
+      >
+        <span
+          className={cn(
+            "inline-block h-4 w-4 transform rounded-full bg-white shadow-sm transition",
+            isDark ? "translate-x-1" : "translate-x-6",
+          )}
+        />
+      </button>
+    </div>
+  );
+}

--- a/components/ui.tsx
+++ b/components/ui.tsx
@@ -105,10 +105,10 @@ type BadgeTone = "neutral" | "terracotta" | "mint" | "teal" | "butter" | "sand";
 const badgeTones: Record<BadgeTone, string> = {
   neutral: "bg-ink/[0.06] text-ink-soft",
   terracotta: "bg-terracotta/15 text-terracotta-dark",
-  mint: "bg-mint/60 text-emerald-800",
-  teal: "bg-teal/15 text-teal-900",
-  butter: "bg-butter/50 text-yellow-900",
-  sand: "bg-sand/40 text-ink-soft",
+  mint: "bg-mint-tint text-mint-ink",
+  teal: "bg-teal/15 text-teal-dark",
+  butter: "bg-butter-tint text-butter-ink",
+  sand: "bg-sand-tint text-ink-soft",
 };
 
 export function Badge({

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -11,39 +11,58 @@ const config: Config = {
       colors: {
         // Lettertrace palette, resampled directly from the brand mark:
         // cream #F5F4F0, aqua-mint petals #A8F0DC, terracotta petal #E07850.
+        //
+        // Every token resolves to a CSS variable (an "R G B" triple) so the
+        // whole UI can flip between the dark default and the light theme by
+        // swapping the variables in globals.css. `<alpha-value>` keeps Tailwind
+        // opacity modifiers (e.g. `text-ink/60`) working.
         ink: {
-          DEFAULT: "#1A1917", // warm near-black (wordmark)
-          soft: "#45423C",
-          faint: "#7C786F",
+          DEFAULT: "rgb(var(--c-ink) / <alpha-value>)", // primary text
+          soft: "rgb(var(--c-ink-soft) / <alpha-value>)",
+          faint: "rgb(var(--c-ink-faint) / <alpha-value>)",
         },
         paper: {
-          DEFAULT: "#F5F4F0", // sampled cream background
-          shade: "#EDEAE1",
-          deep: "#E1DDD1",
+          DEFAULT: "rgb(var(--c-paper) / <alpha-value>)", // page background
+          shade: "rgb(var(--c-paper-shade) / <alpha-value>)",
+          deep: "rgb(var(--c-paper-deep) / <alpha-value>)",
         },
-        surface: "#FFFFFF",
-        // Brand accent (the standout petal).
+        surface: "rgb(var(--c-surface) / <alpha-value>)", // cards / raised
+        // Brand accent (the standout petal). `dark` is the text-on-tint role:
+        // a deep shade in light mode, a light shade in dark mode.
         terracotta: {
-          DEFAULT: "#E07850",
-          dark: "#B9552F",
-          soft: "#F0AD90",
+          DEFAULT: "rgb(var(--c-terracotta) / <alpha-value>)",
+          dark: "rgb(var(--c-terracotta-ink) / <alpha-value>)",
+          soft: "rgb(var(--c-terracotta-soft) / <alpha-value>)",
         },
         // Deep aqua, the readable sibling of the mint petals.
         teal: {
-          DEFAULT: "#129C82",
-          dark: "#0C6E5B",
-          soft: "#74C9B7",
+          DEFAULT: "rgb(var(--c-teal) / <alpha-value>)",
+          dark: "rgb(var(--c-teal-ink) / <alpha-value>)",
+          soft: "rgb(var(--c-teal-soft) / <alpha-value>)",
         },
         // The mint petal itself (fills, positive sentiment, glows).
+        // `tint` is a solid chip background, `ink` the paired text role.
         mint: {
-          DEFAULT: "#A8F0DC",
-          bright: "#82EAD1",
-          soft: "#D6F6EE",
+          DEFAULT: "rgb(var(--c-mint) / <alpha-value>)",
+          bright: "rgb(var(--c-mint-bright) / <alpha-value>)",
+          soft: "rgb(var(--c-mint-soft) / <alpha-value>)",
+          tint: "rgb(var(--c-mint-tint) / <alpha-value>)",
+          ink: "rgb(var(--c-mint-ink) / <alpha-value>)",
         },
-        butter: "#E8C67C", // warm amber support
+        butter: {
+          DEFAULT: "rgb(var(--c-butter) / <alpha-value>)", // warm amber support
+          tint: "rgb(var(--c-butter-tint) / <alpha-value>)",
+          ink: "rgb(var(--c-butter-ink) / <alpha-value>)",
+        },
         sand: {
-          DEFAULT: "#CBB9A0", // warm neutral
-          soft: "#E4DAC9",
+          DEFAULT: "rgb(var(--c-sand) / <alpha-value>)", // warm neutral
+          soft: "rgb(var(--c-sand-soft) / <alpha-value>)",
+          tint: "rgb(var(--c-sand-tint) / <alpha-value>)",
+        },
+        // Always-dark code/terminal surface (kept dark in both themes).
+        terminal: {
+          DEFAULT: "rgb(var(--c-terminal) / <alpha-value>)",
+          ink: "rgb(var(--c-terminal-ink) / <alpha-value>)",
         },
       },
       fontFamily: {


### PR DESCRIPTION
Makes the app dark by default while preserving the original light look behind a user toggle. The entire UI is driven by CSS-variable theme tokens (`--c-*` "R G B" triples in `globals.css`, resolved through Tailwind's semantic colors), so most surfaces flip automatically; a `ThemeProvider` with `ThemeToggle`/`ThemeSwitch` controls (in the landing header, dashboard sidebar, and a new Settings "Appearance" card) persists the choice in `localStorage`, and an inline pre-paint script applies it with no flash. It also handles the cases that do not flip on their own: always-dark terminal panels, theme-aware accent chip and text tokens so every badge stays legible, recharts colors resolved from the active theme, and a brand lockup that swaps to the white logo in dark mode via CSS. Verified with `tsc`, the test suite, a clean `next build`, and screenshots of both themes across the landing, login, and dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)