### PR TITLE
Programmatic access: REST API v1, MCP server, and API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,44 @@ While a user has free runs left and no key of their own, monitoring runs and var
 
 > After upgrading, re-run `supabase/schema.sql`. It adds the trial columns (`trial_runs_used`, `trial_tokens_used`), their increment functions, and the multi-organization column `profiles.active_project_id` (all safe to re-run).
 
+## Programmatic access (REST API + MCP)
+
+Create an API key in **Settings → API & MCP access** (shown once, stored hashed) and send it as a bearer token.
+
+**REST v1:**
+
+```bash
+# List your organizations
+curl https://your-app.com/api/v1/projects \
+  -H "Authorization: Bearer lt_live_..."
+
+# Recent runs for a project / trigger a run now
+curl https://your-app.com/api/v1/projects/<project-id>/runs \
+  -H "Authorization: Bearer lt_live_..."
+curl -X POST https://your-app.com/api/v1/projects/<project-id>/runs \
+  -H "Authorization: Bearer lt_live_..."
+
+# Share-of-voice report for a run
+curl https://your-app.com/api/v1/runs/<run-id> \
+  -H "Authorization: Bearer lt_live_..."
+```
+
+**MCP:** Lettertrace exposes a [Model Context Protocol](https://modelcontextprotocol.io) server (Streamable HTTP) so Claude and other MCP clients can query your share-of-voice data conversationally:
+
+```bash
+claude mcp add --transport http lettertrace https://your-app.com/api/mcp/mcp \
+  -H "Authorization: Bearer lt_live_..."
+```
+
+Tools: `list_projects`, `list_runs`, `get_share_of_voice_report`, `trigger_run`.
+
+Notes:
+
+- API-triggered runs are **BYOK-only** — the account must have its own provider key; free-trial runs stay dashboard-only.
+- API keys grant access to all of the account's organizations. Revoke them anytime from Settings.
+- Requires `SUPABASE_SERVICE_ROLE_KEY` (the same variable scheduled runs use), since API-key requests carry no browser session.
+- Upgrading an existing deployment? Re-run `supabase/schema.sql` — it adds the `api_keys` table (safe to re-run).
+
 ## Deployment
 
 Deploy anywhere that runs Next.js. On **Vercel**: import the repo, set the env vars from `.env.example`, and deploy. Runs execute synchronously inside the API route, so for large prompt sets prefer a Node server or bump the function's `maxDuration`.
@@ -137,7 +175,8 @@ Deploy anywhere that runs Next.js. On **Vercel**: import the repo, set the env v
 ## Security notes
 
 - Provider API keys are **encrypted with AES-256-GCM** using `ENCRYPTION_KEY` and are never returned to the browser (only a masked hint like `sk-ant-…4a9c`).
-- All data is isolated per user by **Postgres Row Level Security**. The service-role key is used only by the cron endpoint.
+- All data is isolated per user by **Postgres Row Level Security**. The service-role key is used only by the cron endpoint and the API-key-authenticated surface (`/api/v1`, `/api/mcp`), where every query is scoped to the key's owner.
+- Lettertrace API keys are stored as **SHA-256 hashes** (never recoverable); the plaintext is shown once at creation.
 - Nothing is sent to any third party except the AI providers **you** configure, using **your** keys.
 
 ## Project structure

--- a/app/api/api-keys/[id]/route.ts
+++ b/app/api/api-keys/[id]/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+// DELETE /api/api-keys/:id — revoke a Lettertrace API key.
+export async function DELETE(
+  _request: Request,
+  { params }: { params: { id: string } },
+) {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { error } = await supabase
+    .from("api_keys")
+    .delete()
+    .eq("id", params.id)
+    .eq("user_id", user.id);
+  if (error) {
+    return NextResponse.json({ error: "Could not remove that key." }, { status: 500 });
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/api-keys/route.ts
+++ b/app/api/api-keys/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { generateApiKey, hashApiKey, keyHint } from "@/lib/crypto";
+import { humanError } from "@/lib/llm";
+
+// Session-authenticated management of Lettertrace API keys (settings page).
+// The plaintext key is returned exactly once, from POST.
+
+const MAX_KEYS_PER_USER = 10;
+
+export async function GET() {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data } = await supabase
+    .from("api_keys")
+    .select("id, name, key_hint, last_used_at, created_at")
+    .eq("user_id", user.id)
+    .order("created_at", { ascending: true });
+  return NextResponse.json({ keys: data ?? [] });
+}
+
+export async function POST(request: Request) {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  const { name } = (body ?? {}) as { name?: unknown };
+  const cleanName =
+    typeof name === "string" && name.trim().length > 0
+      ? name.trim().slice(0, 80)
+      : "API key";
+
+  try {
+    const { count } = await supabase
+      .from("api_keys")
+      .select("id", { count: "exact", head: true })
+      .eq("user_id", user.id);
+    if ((count ?? 0) >= MAX_KEYS_PER_USER) {
+      return NextResponse.json(
+        { error: `You can have at most ${MAX_KEYS_PER_USER} API keys. Remove one first.` },
+        { status: 400 },
+      );
+    }
+
+    const plaintext = generateApiKey();
+    const { data, error } = await supabase
+      .from("api_keys")
+      .insert({
+        user_id: user.id,
+        name: cleanName,
+        key_hash: hashApiKey(plaintext),
+        key_hint: keyHint(plaintext),
+      })
+      .select("id, name, key_hint, last_used_at, created_at")
+      .single();
+    if (error) {
+      return NextResponse.json({ error: humanError(error) }, { status: 500 });
+    }
+
+    // The one and only time the plaintext leaves the server.
+    return NextResponse.json({ key: data, apiKey: plaintext });
+  } catch (e) {
+    return NextResponse.json({ error: humanError(e) }, { status: 500 });
+  }
+}

--- a/app/api/mcp/[transport]/route.ts
+++ b/app/api/mcp/[transport]/route.ts
@@ -1,0 +1,177 @@
+import { createMcpHandler, withMcpAuth } from "mcp-handler";
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+import { z } from "zod";
+import { authenticateApiKey } from "@/lib/api-auth";
+import { createServiceClient } from "@/lib/supabase/service";
+import { getProjects } from "@/lib/data";
+import {
+  getRunReport,
+  latestCompletedRun,
+  listRuns,
+  projectSummary,
+  triggerRunForProject,
+} from "@/lib/api-service";
+import { humanError } from "@/lib/llm";
+
+// MCP server for Lettertrace (Streamable HTTP, stateless — no Redis needed
+// since SSE is disabled). Connect with:
+//   claude mcp add --transport http lettertrace https://<host>/api/mcp/mcp \
+//     -H "Authorization: Bearer lt_live_..."
+// Tools are read/trigger only: Lettertrace reports how a brand shows up in AI
+// answers; it deliberately offers no recommendations.
+
+export const maxDuration = 300;
+export const dynamic = "force-dynamic";
+
+/** The authenticated user's id, stashed in AuthInfo.extra by verifyToken. */
+function userIdOf(extra: { authInfo?: AuthInfo }): string {
+  const userId = extra.authInfo?.extra?.userId;
+  if (typeof userId !== "string") throw new Error("Unauthorized");
+  return userId;
+}
+
+function json(data: unknown) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }],
+  };
+}
+
+function toolError(message: string) {
+  return {
+    content: [{ type: "text" as const, text: message }],
+    isError: true,
+  };
+}
+
+const handler = createMcpHandler(
+  (server) => {
+    server.tool(
+      "list_projects",
+      "List the organizations (projects) this Lettertrace account monitors, including brand name, domain, and when each last ran.",
+      {},
+      async (_args, extra) => {
+        const supabase = createServiceClient();
+        const projects = await getProjects(supabase, userIdOf(extra));
+        return json({ projects: projects.map(projectSummary) });
+      },
+    );
+
+    server.tool(
+      "list_runs",
+      "List recent monitoring runs for a project (status, model, prompt counts, timestamps). Use a run id with get_share_of_voice_report for the metrics.",
+      {
+        project_id: z.string().uuid().describe("Project id from list_projects"),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(100)
+          .optional()
+          .describe("Max runs to return (default 20)"),
+      },
+      async ({ project_id, limit }, extra) => {
+        const supabase = createServiceClient();
+        const runs = await listRuns(
+          supabase,
+          userIdOf(extra),
+          project_id,
+          limit ?? 20,
+        );
+        if (!runs) return toolError("Project not found.");
+        return json({ runs });
+      },
+    );
+
+    server.tool(
+      "get_share_of_voice_report",
+      "Share-of-voice report for a monitoring run: how often the brand and each competitor are mentioned in AI assistant answers, with share of voice, prominence, sentiment, and recommendation rate. Pass run_id, or just project_id for the latest completed run.",
+      {
+        run_id: z
+          .string()
+          .uuid()
+          .optional()
+          .describe("Run id from list_runs"),
+        project_id: z
+          .string()
+          .uuid()
+          .optional()
+          .describe("If run_id is omitted: use this project's latest completed run"),
+      },
+      async ({ run_id, project_id }, extra) => {
+        const supabase = createServiceClient();
+        const userId = userIdOf(extra);
+
+        let targetRunId = run_id ?? null;
+        if (!targetRunId && project_id) {
+          const latest = await latestCompletedRun(supabase, userId, project_id);
+          if (!latest) {
+            return toolError(
+              "No completed runs for that project yet. Trigger one with trigger_run.",
+            );
+          }
+          targetRunId = latest.id;
+        }
+        if (!targetRunId) {
+          return toolError("Pass run_id or project_id.");
+        }
+
+        const report = await getRunReport(supabase, userId, targetRunId);
+        if (!report) return toolError("Run not found.");
+        return json(report);
+      },
+    );
+
+    server.tool(
+      "trigger_run",
+      "Execute a monitoring run now for a project: queries the configured AI assistant with every active prompt and stores mention data. Requires the account's own provider key (free-trial runs are dashboard-only). Can take a few minutes.",
+      {
+        project_id: z.string().uuid().describe("Project id from list_projects"),
+      },
+      async ({ project_id }, extra) => {
+        const supabase = createServiceClient();
+        try {
+          const outcome = await triggerRunForProject(
+            supabase,
+            userIdOf(extra),
+            project_id,
+          );
+          if (!outcome.ok) return toolError(outcome.message);
+          return json(outcome.result);
+        } catch (e) {
+          return toolError(humanError(e));
+        }
+      },
+    );
+  },
+  {
+    serverInfo: { name: "lettertrace", version: "1.0.0" },
+    capabilities: {
+      tools: {},
+    },
+  },
+  {
+    basePath: "/api/mcp",
+    maxDuration,
+    disableSse: true,
+  },
+);
+
+// Bearer auth with Lettertrace API keys. verifyToken stashes the owner's user
+// id in AuthInfo.extra, which tool callbacks read via extra.authInfo.
+const verifyToken = async (
+  _req: Request,
+  token?: string,
+): Promise<AuthInfo | undefined> => {
+  const auth = await authenticateApiKey(token);
+  if (!auth) return undefined;
+  return {
+    token: token!,
+    clientId: auth.userId,
+    scopes: [],
+    extra: { userId: auth.userId, keyId: auth.keyId },
+  };
+};
+
+const authHandler = withMcpAuth(handler, verifyToken, { required: true });
+
+export { authHandler as GET, authHandler as POST, authHandler as DELETE };

--- a/app/api/mcp/mcp-route.test.ts
+++ b/app/api/mcp/mcp-route.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { authenticateApiKey } from "@/lib/api-auth";
+import { POST as mcpPost } from "@/app/api/mcp/[transport]/route";
+
+vi.mock("@/lib/api-auth", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/api-auth")>()),
+  authenticateApiKey: vi.fn(),
+}));
+vi.mock("@/lib/supabase/service", () => ({ createServiceClient: vi.fn() }));
+// lib/data uses React cache(), which doesn't exist in the vitest environment.
+vi.mock("@/lib/data", () => ({ getProjects: vi.fn() }));
+
+function rpc(body: unknown, token?: string) {
+  return new Request("http://localhost/api/mcp/mcp", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+      ...(token ? { authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+const INITIALIZE = {
+  jsonrpc: "2.0",
+  id: 1,
+  method: "initialize",
+  params: {
+    protocolVersion: "2025-03-26",
+    capabilities: {},
+    clientInfo: { name: "vitest", version: "0.0.0" },
+  },
+};
+
+beforeEach(() => {
+  vi.mocked(authenticateApiKey).mockReset();
+});
+
+describe("MCP endpoint auth", () => {
+  it("401s without a bearer token", async () => {
+    const res = await mcpPost(rpc(INITIALIZE));
+    expect(res.status).toBe(401);
+    expect(authenticateApiKey).toHaveBeenCalledWith(undefined);
+  });
+
+  it("401s with an invalid key", async () => {
+    vi.mocked(authenticateApiKey).mockResolvedValue(null);
+    const res = await mcpPost(rpc(INITIALIZE, "lt_live_bogus"));
+    expect(res.status).toBe(401);
+  });
+
+  it("completes the initialize handshake with a valid key", async () => {
+    vi.mocked(authenticateApiKey).mockResolvedValue({
+      supabase: {} as never,
+      userId: "user-1",
+      keyId: "key-1",
+    });
+    const res = await mcpPost(rpc(INITIALIZE, "lt_live_valid"));
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain('"lettertrace"'); // serverInfo.name
+    expect(text).toContain('"tools"'); // capabilities advertise tools
+  });
+});

--- a/app/api/v1/projects/[id]/runs/route.ts
+++ b/app/api/v1/projects/[id]/runs/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from "next/server";
+import { authenticateApiKey, bearerToken } from "@/lib/api-auth";
+import { listRuns, triggerRunForProject } from "@/lib/api-service";
+import { humanError } from "@/lib/llm";
+
+export const maxDuration = 300;
+export const dynamic = "force-dynamic";
+
+// GET /api/v1/projects/:id/runs — recent runs for a project (?limit=20).
+export async function GET(
+  request: Request,
+  { params }: { params: { id: string } },
+) {
+  const auth = await authenticateApiKey(
+    bearerToken(request.headers.get("authorization")),
+  );
+  if (!auth) {
+    return NextResponse.json(
+      { error: "Invalid or missing API key" },
+      { status: 401 },
+    );
+  }
+
+  const limit = Number(new URL(request.url).searchParams.get("limit")) || 20;
+  const runs = await listRuns(auth.supabase, auth.userId, params.id, limit);
+  if (!runs) {
+    return NextResponse.json({ error: "Project not found" }, { status: 404 });
+  }
+  return NextResponse.json({ runs });
+}
+
+// POST /api/v1/projects/:id/runs — execute a monitoring run now (BYOK-only).
+export async function POST(
+  request: Request,
+  { params }: { params: { id: string } },
+) {
+  const auth = await authenticateApiKey(
+    bearerToken(request.headers.get("authorization")),
+  );
+  if (!auth) {
+    return NextResponse.json(
+      { error: "Invalid or missing API key" },
+      { status: 401 },
+    );
+  }
+
+  try {
+    const outcome = await triggerRunForProject(
+      auth.supabase,
+      auth.userId,
+      params.id,
+    );
+    if (!outcome.ok) {
+      return NextResponse.json(
+        { error: outcome.message },
+        { status: outcome.code === "not_found" ? 404 : 402 },
+      );
+    }
+    return NextResponse.json(outcome.result);
+  } catch (e) {
+    return NextResponse.json({ error: humanError(e) }, { status: 500 });
+  }
+}

--- a/app/api/v1/projects/route.ts
+++ b/app/api/v1/projects/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { authenticateApiKey, bearerToken } from "@/lib/api-auth";
+import { getProjects } from "@/lib/data";
+import { projectSummary } from "@/lib/api-service";
+
+export const dynamic = "force-dynamic";
+
+// GET /api/v1/projects — list the caller's organizations.
+// Auth: Authorization: Bearer <lettertrace api key>
+export async function GET(request: Request) {
+  const auth = await authenticateApiKey(
+    bearerToken(request.headers.get("authorization")),
+  );
+  if (!auth) {
+    return NextResponse.json(
+      { error: "Invalid or missing API key" },
+      { status: 401 },
+    );
+  }
+
+  const projects = await getProjects(auth.supabase, auth.userId);
+  return NextResponse.json({ projects: projects.map(projectSummary) });
+}

--- a/app/api/v1/runs/[id]/route.ts
+++ b/app/api/v1/runs/[id]/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import { authenticateApiKey, bearerToken } from "@/lib/api-auth";
+import { getRunReport } from "@/lib/api-service";
+
+export const dynamic = "force-dynamic";
+
+// GET /api/v1/runs/:id — share-of-voice report for one run.
+export async function GET(
+  request: Request,
+  { params }: { params: { id: string } },
+) {
+  const auth = await authenticateApiKey(
+    bearerToken(request.headers.get("authorization")),
+  );
+  if (!auth) {
+    return NextResponse.json(
+      { error: "Invalid or missing API key" },
+      { status: 401 },
+    );
+  }
+
+  const report = await getRunReport(auth.supabase, auth.userId, params.id);
+  if (!report) {
+    return NextResponse.json({ error: "Run not found" }, { status: 404 });
+  }
+  return NextResponse.json(report);
+}

--- a/app/api/v1/v1-routes.test.ts
+++ b/app/api/v1/v1-routes.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { authenticateApiKey } from "@/lib/api-auth";
+import { getProjects } from "@/lib/data";
+import {
+  getRunReport,
+  listRuns,
+  triggerRunForProject,
+} from "@/lib/api-service";
+import { GET as getProjectsRoute } from "@/app/api/v1/projects/route";
+import {
+  GET as getRunsRoute,
+  POST as postRunRoute,
+} from "@/app/api/v1/projects/[id]/runs/route";
+import { GET as getReportRoute } from "@/app/api/v1/runs/[id]/route";
+
+vi.mock("@/lib/api-auth", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/api-auth")>()),
+  authenticateApiKey: vi.fn(),
+}));
+vi.mock("@/lib/data", () => ({ getProjects: vi.fn() }));
+vi.mock("@/lib/api-service", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/api-service")>()),
+  listRuns: vi.fn(),
+  getRunReport: vi.fn(),
+  triggerRunForProject: vi.fn(),
+}));
+
+const AUTH_CTX = { supabase: {} as never, userId: "user-1", keyId: "key-1" };
+
+function req(path: string, init?: RequestInit) {
+  return new Request(`http://localhost${path}`, {
+    headers: { authorization: "Bearer lt_live_test" },
+    ...init,
+  });
+}
+
+beforeEach(() => {
+  vi.mocked(authenticateApiKey).mockReset().mockResolvedValue(AUTH_CTX);
+  vi.mocked(getProjects).mockReset();
+  vi.mocked(listRuns).mockReset();
+  vi.mocked(getRunReport).mockReset();
+  vi.mocked(triggerRunForProject).mockReset();
+});
+
+describe("GET /api/v1/projects", () => {
+  it("401s without a valid key", async () => {
+    vi.mocked(authenticateApiKey).mockResolvedValue(null);
+    const res = await getProjectsRoute(new Request("http://localhost/api/v1/projects"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns the caller's projects, trimmed", async () => {
+    vi.mocked(getProjects).mockResolvedValue([
+      { id: "p1", user_id: "user-1", name: "Credal", brand_name: "Credal" } as never,
+    ]);
+    const res = await getProjectsRoute(req("/api/v1/projects"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.projects).toHaveLength(1);
+    expect(body.projects[0]).not.toHaveProperty("user_id");
+    expect(getProjects).toHaveBeenCalledWith(AUTH_CTX.supabase, "user-1");
+  });
+});
+
+describe("GET /api/v1/projects/:id/runs", () => {
+  it("404s for a project that isn't the caller's", async () => {
+    vi.mocked(listRuns).mockResolvedValue(null);
+    const res = await getRunsRoute(req("/api/v1/projects/p1/runs"), {
+      params: { id: "p1" },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("passes the ?limit param through", async () => {
+    vi.mocked(listRuns).mockResolvedValue([]);
+    const res = await getRunsRoute(req("/api/v1/projects/p1/runs?limit=5"), {
+      params: { id: "p1" },
+    });
+    expect(res.status).toBe(200);
+    expect(listRuns).toHaveBeenCalledWith(AUTH_CTX.supabase, "user-1", "p1", 5);
+  });
+});
+
+describe("POST /api/v1/projects/:id/runs", () => {
+  it("402s when the account has no key of its own", async () => {
+    vi.mocked(triggerRunForProject).mockResolvedValue({
+      ok: false,
+      code: "no_key",
+      message: "needs a key",
+    });
+    const res = await postRunRoute(
+      req("/api/v1/projects/p1/runs", { method: "POST" }),
+      { params: { id: "p1" } },
+    );
+    expect(res.status).toBe(402);
+  });
+
+  it("returns the run result on success", async () => {
+    vi.mocked(triggerRunForProject).mockResolvedValue({
+      ok: true,
+      result: { runId: "r1", status: "completed", totalResponses: 3, tokensUsed: 10 },
+    });
+    const res = await postRunRoute(
+      req("/api/v1/projects/p1/runs", { method: "POST" }),
+      { params: { id: "p1" } },
+    );
+    expect(res.status).toBe(200);
+    expect((await res.json()).runId).toBe("r1");
+  });
+});
+
+describe("GET /api/v1/runs/:id", () => {
+  it("404s for an unknown or unowned run", async () => {
+    vi.mocked(getRunReport).mockResolvedValue(null);
+    const res = await getReportRoute(req("/api/v1/runs/r1"), { params: { id: "r1" } });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns the report", async () => {
+    vi.mocked(getRunReport).mockResolvedValue({
+      run: { id: "r1" } as never,
+      totalResponses: 2,
+      summary: {
+        brandMentionRate: 0.5,
+        brandShareOfVoice: 0.25,
+        brandSentimentScore: 1,
+        brandAvgProminence: 0.9,
+      },
+      entities: [],
+    });
+    const res = await getReportRoute(req("/api/v1/runs/r1"), { params: { id: "r1" } });
+    expect(res.status).toBe(200);
+    expect((await res.json()).summary.brandShareOfVoice).toBe(0.25);
+  });
+});

--- a/app/dashboard/settings/api-keys-manager.tsx
+++ b/app/dashboard/settings/api-keys-manager.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Check, Copy, Plus, Trash2 } from "lucide-react";
+import { Button, Input, Spinner } from "@/components/ui";
+import { formatDate } from "@/lib/utils";
+import type { ApiKeyPublic } from "@/lib/types";
+
+// Lettertrace API keys for programmatic access (REST v1 + MCP). The plaintext
+// is shown exactly once, right after creation.
+
+export default function ApiKeysManager({ keys }: { keys: ApiKeyPublic[] }) {
+  const router = useRouter();
+
+  const [name, setName] = useState("");
+  const [creating, setCreating] = useState(false);
+  const [removingId, setRemovingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [freshKey, setFreshKey] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  async function handleCreate(e: React.FormEvent) {
+    e.preventDefault();
+    if (creating) return;
+    setError(null);
+    setCreating(true);
+    try {
+      const res = await fetch("/api/api-keys", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data?.error || "Something went wrong. Please try again.");
+        return;
+      }
+      setFreshKey(data.apiKey);
+      setCopied(false);
+      setName("");
+      router.refresh();
+    } catch {
+      setError("Network error. Please try again.");
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function handleRemove(id: string) {
+    if (removingId) return;
+    setError(null);
+    setRemovingId(id);
+    try {
+      const res = await fetch(`/api/api-keys/${id}`, { method: "DELETE" });
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        setError(data?.error || "Could not remove that key.");
+        return;
+      }
+      router.refresh();
+    } catch {
+      setError("Network error. Please try again.");
+    } finally {
+      setRemovingId(null);
+    }
+  }
+
+  async function handleCopy() {
+    if (!freshKey) return;
+    try {
+      await navigator.clipboard.writeText(freshKey);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* clipboard unavailable; the key is still visible to select */
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* One-time reveal of a freshly created key */}
+      {freshKey && (
+        <div className="rounded-xl border border-emerald-700/20 bg-mint/30 p-4">
+          <p className="text-sm font-medium text-ink">
+            Copy your new key now — it won&apos;t be shown again.
+          </p>
+          <div className="mt-2 flex items-center gap-2">
+            <code className="min-w-0 flex-1 truncate rounded-lg bg-paper px-3 py-2 font-mono text-sm text-ink">
+              {freshKey}
+            </code>
+            <Button type="button" size="sm" variant="secondary" onClick={handleCopy}>
+              {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+              {copied ? "Copied" : "Copy"}
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* Existing keys */}
+      {keys.length > 0 && (
+        <ul className="divide-y divide-ink/10 rounded-xl border border-ink/10 bg-paper">
+          {keys.map((k) => (
+            <li key={k.id} className="flex items-center gap-3 px-4 py-3">
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-medium text-ink">{k.name}</p>
+                <p className="font-mono text-xs text-ink-faint">
+                  {k.key_hint}
+                  <span className="ml-2 font-sans">
+                    Created {formatDate(k.created_at)}
+                    {k.last_used_at
+                      ? ` · Last used ${formatDate(k.last_used_at)}`
+                      : " · Never used"}
+                  </span>
+                </p>
+              </div>
+              <Button
+                type="button"
+                variant="danger"
+                size="sm"
+                onClick={() => handleRemove(k.id)}
+                disabled={removingId === k.id}
+              >
+                {removingId === k.id ? <Spinner /> : <Trash2 className="h-3.5 w-3.5" />}
+                Revoke
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {/* Create form */}
+      <form onSubmit={handleCreate} className="flex flex-wrap items-center gap-2">
+        <Input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Key name, e.g. “Claude Code”"
+          aria-label="API key name"
+          className="max-w-xs"
+        />
+        <Button type="submit" size="sm" disabled={creating}>
+          {creating ? <Spinner /> : <Plus className="h-3.5 w-3.5" />}
+          Create key
+        </Button>
+      </form>
+
+      {error && <p className="text-sm text-terracotta-dark">{error}</p>}
+    </div>
+  );
+}

--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -1,9 +1,11 @@
-import { KeyRound, Building2 } from "lucide-react";
+import { KeyRound, Building2, Plug } from "lucide-react";
 import { createClient } from "@/lib/supabase/server";
 import { getProject, getProviderKeysPublic } from "@/lib/data";
 import { Card, CardBody, SectionHeading } from "@/components/ui";
 import KeysManager from "./keys-manager";
+import ApiKeysManager from "./api-keys-manager";
 import ProjectForm from "./project-form";
+import type { ApiKeyPublic } from "@/lib/types";
 
 export const dynamic = "force-dynamic";
 
@@ -14,10 +16,16 @@ export default async function SettingsPage() {
   } = await supabase.auth.getUser();
   if (!user) return null;
 
-  const [project, keys] = await Promise.all([
+  const [project, keys, apiKeysRes] = await Promise.all([
     getProject(supabase, user.id),
     getProviderKeysPublic(supabase, user.id),
+    supabase
+      .from("api_keys")
+      .select("id, name, key_hint, last_used_at, created_at")
+      .eq("user_id", user.id)
+      .order("created_at", { ascending: true }),
   ]);
+  const apiKeys = (apiKeysRes.data as ApiKeyPublic[] | null) ?? [];
 
   return (
     <div className="space-y-8">
@@ -61,6 +69,27 @@ export default async function SettingsPage() {
             </div>
           </div>
           <ProjectForm project={project} />
+        </CardBody>
+      </Card>
+
+      <Card>
+        <CardBody className="space-y-5">
+          <div className="flex items-start gap-3">
+            <span className="mt-0.5 rounded-xl bg-teal/15 p-2 text-teal-900">
+              <Plug className="h-5 w-5" />
+            </span>
+            <div>
+              <h3 className="text-lg font-semibold text-ink">API &amp; MCP access</h3>
+              <p className="mt-1 text-sm text-ink-faint">
+                Create a key to read your share-of-voice data from scripts
+                (REST, <code className="font-mono text-xs">/api/v1</code>) or
+                connect Lettertrace to Claude and other MCP clients at{" "}
+                <code className="font-mono text-xs">/api/mcp/mcp</code>, sent as{" "}
+                <code className="font-mono text-xs">Authorization: Bearer</code>.
+              </p>
+            </div>
+          </div>
+          <ApiKeysManager keys={apiKeys} />
         </CardBody>
       </Card>
     </div>

--- a/lib/api-auth.test.ts
+++ b/lib/api-auth.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { generateApiKey, hashApiKey, keyHint } from "@/lib/crypto";
+import { authenticateApiKey, bearerToken } from "@/lib/api-auth";
+import { createServiceClient } from "@/lib/supabase/service";
+
+vi.mock("@/lib/supabase/service", () => ({ createServiceClient: vi.fn() }));
+
+// A minimal stand-in for the supabase client covering the exact chains
+// lib/api-auth uses: select().eq().maybeSingle() and update().eq() (awaited).
+function fakeServiceClient(row: { id: string; user_id: string } | null) {
+  const eqCalls: unknown[][] = [];
+  const updates: unknown[] = [];
+  const client = {
+    eqCalls,
+    updates,
+    from(_table: string) {
+      const q = {
+        select: () => q,
+        update: (patch: unknown) => {
+          updates.push(patch);
+          return q;
+        },
+        eq: (...args: unknown[]) => {
+          eqCalls.push(args);
+          return q;
+        },
+        maybeSingle: async () => ({ data: row, error: null }),
+        then: (resolve: (v: unknown) => unknown) =>
+          Promise.resolve({ data: null, error: null }).then(resolve),
+      };
+      return q;
+    },
+  };
+  return client;
+}
+
+describe("lettertrace api keys", () => {
+  it("generates prefixed, unique keys", () => {
+    const a = generateApiKey();
+    const b = generateApiKey();
+    expect(a).toMatch(/^lt_live_[A-Za-z0-9_-]{32}$/);
+    expect(a).not.toBe(b);
+  });
+
+  it("hashes deterministically and ignores surrounding whitespace", () => {
+    const key = generateApiKey();
+    expect(hashApiKey(key)).toBe(hashApiKey(`  ${key}\n`));
+    expect(hashApiKey(key)).toMatch(/^[0-9a-f]{64}$/);
+    expect(hashApiKey(key)).not.toBe(hashApiKey(generateApiKey()));
+  });
+
+  it("produces a recognizable hint without leaking the key", () => {
+    const key = generateApiKey();
+    const hint = keyHint(key);
+    expect(hint.startsWith("lt_live")).toBe(true);
+    expect(hint.length).toBeLessThan(15);
+  });
+});
+
+describe("authenticateApiKey", () => {
+  beforeEach(() => {
+    vi.mocked(createServiceClient).mockReset();
+  });
+
+  it("returns null without a token and never opens a client", async () => {
+    expect(await authenticateApiKey(null)).toBeNull();
+    expect(await authenticateApiKey(undefined)).toBeNull();
+    expect(await authenticateApiKey("")).toBeNull();
+    expect(createServiceClient).not.toHaveBeenCalled();
+  });
+
+  it("returns null for an unknown key", async () => {
+    const client = fakeServiceClient(null);
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+    expect(await authenticateApiKey(generateApiKey())).toBeNull();
+  });
+
+  it("resolves a valid key to its owner, looking up by hash only", async () => {
+    const client = fakeServiceClient({ id: "key-1", user_id: "user-1" });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const token = generateApiKey();
+    const ctx = await authenticateApiKey(token);
+
+    expect(ctx).toMatchObject({ userId: "user-1", keyId: "key-1" });
+    // The plaintext must never be used as a filter — only its hash.
+    expect(client.eqCalls).toContainEqual(["key_hash", hashApiKey(token)]);
+    for (const call of client.eqCalls) expect(call).not.toContain(token);
+    // Usage is stamped for the settings page.
+    expect(client.updates).toHaveLength(1);
+    expect(client.updates[0]).toHaveProperty("last_used_at");
+  });
+});
+
+describe("bearerToken", () => {
+  it("extracts the token case-insensitively", () => {
+    expect(bearerToken("Bearer abc123")).toBe("abc123");
+    expect(bearerToken("bearer abc123")).toBe("abc123");
+  });
+
+  it("rejects missing or malformed headers", () => {
+    expect(bearerToken(null)).toBeNull();
+    expect(bearerToken("")).toBeNull();
+    expect(bearerToken("Basic abc123")).toBeNull();
+    expect(bearerToken("Bearer")).toBeNull();
+  });
+});

--- a/lib/api-auth.ts
+++ b/lib/api-auth.ts
@@ -1,0 +1,46 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createServiceClient } from "@/lib/supabase/service";
+import { hashApiKey } from "@/lib/crypto";
+
+// Bearer-token auth for the programmatic surface (/api/v1 and /api/mcp).
+// Requests carry a Lettertrace API key instead of a Supabase session, so the
+// returned client is the service-role client: RLS is bypassed and every query
+// made with it MUST be scoped by userId explicitly.
+
+export interface ApiAuthContext {
+  supabase: SupabaseClient;
+  userId: string;
+  keyId: string;
+}
+
+/** Extract the token from an `Authorization: Bearer <token>` header. */
+export function bearerToken(header: string | null): string | null {
+  if (!header) return null;
+  const match = header.match(/^Bearer\s+(.+)$/i);
+  return match ? match[1].trim() : null;
+}
+
+/**
+ * Resolve an API key to its owner. Returns null for a missing or unknown key.
+ * Touches last_used_at so the settings page can show stale keys.
+ */
+export async function authenticateApiKey(
+  token: string | null | undefined,
+): Promise<ApiAuthContext | null> {
+  if (!token) return null;
+  const supabase = createServiceClient();
+
+  const { data } = await supabase
+    .from("api_keys")
+    .select("id, user_id")
+    .eq("key_hash", hashApiKey(token))
+    .maybeSingle();
+  if (!data) return null;
+
+  await supabase
+    .from("api_keys")
+    .update({ last_used_at: new Date().toISOString() })
+    .eq("id", data.id);
+
+  return { supabase, userId: data.user_id as string, keyId: data.id as string };
+}

--- a/lib/api-service.test.ts
+++ b/lib/api-service.test.ts
@@ -1,0 +1,294 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Mention, Project, Run } from "@/lib/types";
+import {
+  getOwnedProject,
+  getRunReport,
+  latestCompletedRun,
+  listRuns,
+  projectSummary,
+  triggerRunForProject,
+} from "@/lib/api-service";
+import { resolveRunKey } from "@/lib/trial";
+import { executeRun } from "@/lib/engine";
+
+vi.mock("@/lib/trial", () => ({ resolveRunKey: vi.fn() }));
+vi.mock("@/lib/engine", () => ({ executeRun: vi.fn() }));
+
+// ------------------------------------------------------------------
+// A tiny fake of the supabase query builder: per-table handlers receive the
+// recorded query (filters + modifiers) and return the {data, error, count}
+// payload. Covers every chain lib/api-service uses.
+// ------------------------------------------------------------------
+
+interface RecordedQuery {
+  table: string;
+  filters: [string, ...unknown[]][];
+  modifiers: [string, ...unknown[]][];
+}
+
+type Handler = (q: RecordedQuery) => {
+  data?: unknown;
+  error?: unknown;
+  count?: number;
+};
+
+function fakeDb(handlers: Record<string, Handler>) {
+  const queries: RecordedQuery[] = [];
+  const db = {
+    queries,
+    from(table: string) {
+      const q: RecordedQuery = { table, filters: [], modifiers: [] };
+      queries.push(q);
+      const result = () => ({ data: null, error: null, count: undefined, ...handlers[table]?.(q) });
+      const proxy = {
+        select: () => proxy,
+        eq: (...args: unknown[]) => {
+          q.filters.push(["eq", ...args]);
+          return proxy;
+        },
+        order: (...args: unknown[]) => {
+          q.modifiers.push(["order", ...args]);
+          return proxy;
+        },
+        limit: (...args: unknown[]) => {
+          q.modifiers.push(["limit", ...args]);
+          return proxy;
+        },
+        maybeSingle: async () => result(),
+        then: (resolve: (v: unknown) => unknown, reject?: (e: unknown) => unknown) =>
+          Promise.resolve(result()).then(resolve, reject),
+      };
+      return proxy;
+    },
+  };
+  return db as typeof db & { from: (t: string) => never };
+}
+
+const PROJECT: Project = {
+  id: "proj-1",
+  user_id: "user-1",
+  name: "Credal",
+  brand_name: "Credal",
+  brand_aliases: [],
+  brand_domain: "credal.ai",
+  description: null,
+  default_provider: "anthropic",
+  default_model: "claude-sonnet-4-6",
+  schedule: "off",
+  use_web_search: true,
+  last_run_at: null,
+  created_at: "2026-07-01T00:00:00Z",
+  updated_at: "2026-07-01T00:00:00Z",
+};
+
+function makeRun(overrides: Partial<Run>): Run {
+  return {
+    id: "run-1",
+    project_id: "proj-1",
+    status: "completed",
+    provider: "anthropic",
+    model: "claude-sonnet-4-6",
+    prompt_count: 2,
+    completed_count: 2,
+    error: null,
+    started_at: null,
+    finished_at: null,
+    created_at: "2026-07-02T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeMention(overrides: Partial<Mention>): Mention {
+  return {
+    id: Math.random().toString(36).slice(2),
+    response_id: "resp-1",
+    run_id: "run-1",
+    project_id: "proj-1",
+    topic_id: null,
+    entity_type: "brand",
+    competitor_id: null,
+    entity_name: "Credal",
+    mentioned: true,
+    mention_count: 1,
+    first_position: 0.1,
+    sentiment: "positive",
+    recommended: false,
+    created_at: "2026-07-02T00:00:00Z",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.mocked(resolveRunKey).mockReset();
+  vi.mocked(executeRun).mockReset();
+});
+
+describe("projectSummary", () => {
+  it("exposes only the public fields (no user_id)", () => {
+    const summary = projectSummary(PROJECT);
+    expect(summary).not.toHaveProperty("user_id");
+    expect(summary).toMatchObject({
+      id: "proj-1",
+      brand_name: "Credal",
+      default_provider: "anthropic",
+    });
+  });
+});
+
+describe("getOwnedProject", () => {
+  it("scopes the query by both project id and user id", async () => {
+    const db = fakeDb({ projects: () => ({ data: PROJECT }) });
+    const project = await getOwnedProject(db as never, "user-1", "proj-1");
+    expect(project).toEqual(PROJECT);
+    expect(db.queries[0].filters).toEqual([
+      ["eq", "id", "proj-1"],
+      ["eq", "user_id", "user-1"],
+    ]);
+  });
+
+  it("returns null when the project is not the user's", async () => {
+    const db = fakeDb({ projects: () => ({ data: null }) });
+    expect(await getOwnedProject(db as never, "user-2", "proj-1")).toBeNull();
+  });
+});
+
+describe("listRuns", () => {
+  it("returns null when the project lookup fails ownership", async () => {
+    const db = fakeDb({ projects: () => ({ data: null }) });
+    expect(await listRuns(db as never, "user-2", "proj-1")).toBeNull();
+  });
+
+  it("lists runs newest-first and clamps the limit to 1..100", async () => {
+    const runs = [makeRun({ id: "run-2" }), makeRun({ id: "run-1" })];
+    const db = fakeDb({
+      projects: () => ({ data: PROJECT }),
+      runs: () => ({ data: runs }),
+    });
+    expect(await listRuns(db as never, "user-1", "proj-1", 500)).toEqual(runs);
+
+    const runQuery = db.queries.find((q) => q.table === "runs")!;
+    expect(runQuery.modifiers).toContainEqual(["limit", 100]);
+    expect(runQuery.modifiers).toContainEqual(["order", "created_at", { ascending: false }]);
+
+    const db2 = fakeDb({
+      projects: () => ({ data: PROJECT }),
+      runs: () => ({ data: [] }),
+    });
+    await listRuns(db2 as never, "user-1", "proj-1", -3);
+    expect(db2.queries.find((q) => q.table === "runs")!.modifiers).toContainEqual(["limit", 1]);
+  });
+});
+
+describe("latestCompletedRun", () => {
+  it("skips pending/failed runs", async () => {
+    const db = fakeDb({
+      projects: () => ({ data: PROJECT }),
+      runs: () => ({
+        data: [
+          makeRun({ id: "run-3", status: "running" }),
+          makeRun({ id: "run-2", status: "failed" }),
+          makeRun({ id: "run-1", status: "completed" }),
+        ],
+      }),
+    });
+    const latest = await latestCompletedRun(db as never, "user-1", "proj-1");
+    expect(latest?.id).toBe("run-1");
+  });
+});
+
+describe("getRunReport", () => {
+  it("returns null for a run the user doesn't own", async () => {
+    const db = fakeDb({
+      runs: () => ({ data: makeRun({}) }),
+      projects: () => ({ data: null }), // ownership check fails
+    });
+    expect(await getRunReport(db as never, "user-2", "run-1")).toBeNull();
+  });
+
+  it("computes summary and entity stats from mentions", async () => {
+    // 2 responses; brand in one (positive), competitor in both.
+    const mentions = [
+      makeMention({ response_id: "resp-1" }),
+      makeMention({
+        response_id: "resp-1",
+        entity_type: "competitor",
+        competitor_id: "comp-1",
+        entity_name: "Rival",
+        sentiment: "negative",
+      }),
+      makeMention({
+        response_id: "resp-2",
+        entity_type: "competitor",
+        competitor_id: "comp-1",
+        entity_name: "Rival",
+        sentiment: "neutral",
+        mention_count: 2,
+      }),
+    ];
+    const db = fakeDb({
+      runs: () => ({ data: makeRun({}) }),
+      projects: () => ({ data: PROJECT }),
+      responses: () => ({ count: 2 }),
+      mentions: () => ({ data: mentions }),
+    });
+
+    const report = await getRunReport(db as never, "user-1", "run-1");
+    expect(report).not.toBeNull();
+    expect(report!.totalResponses).toBe(2);
+    expect(report!.summary.brandMentionRate).toBe(0.5);
+    // Brand: 1 of 4 total mention counts; competitor: 3 of 4.
+    expect(report!.summary.brandShareOfVoice).toBe(0.25);
+    expect(report!.entities[0].type).toBe("brand"); // brand sorts first
+    expect(report!.entities[1]).toMatchObject({ name: "Rival", shareOfVoice: 0.75 });
+  });
+});
+
+describe("triggerRunForProject", () => {
+  it("404s for a project the user doesn't own", async () => {
+    const db = fakeDb({ projects: () => ({ data: null }) });
+    const outcome = await triggerRunForProject(db as never, "user-2", "proj-1");
+    expect(outcome).toMatchObject({ ok: false, code: "not_found" });
+    expect(executeRun).not.toHaveBeenCalled();
+  });
+
+  it.each(["trial", "none", "exhausted"] as const)(
+    "refuses to run on key source %s (BYOK-only)",
+    async (source) => {
+      const db = fakeDb({ projects: () => ({ data: PROJECT }) });
+      vi.mocked(resolveRunKey).mockResolvedValue({
+        source,
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+      });
+      const outcome = await triggerRunForProject(db as never, "user-1", "proj-1");
+      expect(outcome).toMatchObject({ ok: false, code: "no_key" });
+      expect(executeRun).not.toHaveBeenCalled();
+    },
+  );
+
+  it("executes with the user's own key", async () => {
+    const db = fakeDb({ projects: () => ({ data: PROJECT }) });
+    vi.mocked(resolveRunKey).mockResolvedValue({
+      source: "own",
+      apiKey: "sk-ant-user-key",
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+    });
+    vi.mocked(executeRun).mockResolvedValue({
+      runId: "run-9",
+      status: "completed",
+      totalResponses: 4,
+      tokensUsed: 1234,
+    });
+
+    const outcome = await triggerRunForProject(db as never, "user-1", "proj-1");
+    expect(outcome).toMatchObject({ ok: true, result: { runId: "run-9" } });
+    expect(executeRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        project: PROJECT,
+        provider: "anthropic",
+        apiKey: "sk-ant-user-key",
+      }),
+    );
+  });
+});

--- a/lib/api-service.ts
+++ b/lib/api-service.ts
@@ -1,0 +1,164 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Mention, Project, Run } from "@/lib/types";
+import {
+  computeEntityStats,
+  computeRunSummary,
+  type EntityStat,
+  type RunSummary,
+} from "@/lib/metrics";
+import { executeRun, type RunResult } from "@/lib/engine";
+import { resolveRunKey } from "@/lib/trial";
+import { PROVIDERS } from "@/lib/models";
+
+// Operations behind the programmatic surface, shared by the REST v1 routes and
+// the MCP tools so the two can't drift apart. Callers authenticate with a
+// Lettertrace API key, so `supabase` is the service-role client: RLS is
+// bypassed and every query here scopes by userId explicitly.
+
+/** A project row trimmed to what the API exposes. */
+export function projectSummary(p: Project) {
+  return {
+    id: p.id,
+    name: p.name,
+    brand_name: p.brand_name,
+    brand_domain: p.brand_domain,
+    default_provider: p.default_provider,
+    default_model: p.default_model,
+    schedule: p.schedule,
+    use_web_search: p.use_web_search,
+    last_run_at: p.last_run_at,
+    created_at: p.created_at,
+  };
+}
+
+/** Fetch a project only if it belongs to the user. */
+export async function getOwnedProject(
+  supabase: SupabaseClient,
+  userId: string,
+  projectId: string,
+): Promise<Project | null> {
+  const { data } = await supabase
+    .from("projects")
+    .select("*")
+    .eq("id", projectId)
+    .eq("user_id", userId)
+    .maybeSingle();
+  return (data as Project | null) ?? null;
+}
+
+/** Recent runs for a project. Null when the project isn't the user's. */
+export async function listRuns(
+  supabase: SupabaseClient,
+  userId: string,
+  projectId: string,
+  limit = 20,
+): Promise<Run[] | null> {
+  const project = await getOwnedProject(supabase, userId, projectId);
+  if (!project) return null;
+  const { data } = await supabase
+    .from("runs")
+    .select("*")
+    .eq("project_id", projectId)
+    .order("created_at", { ascending: false })
+    .limit(Math.min(Math.max(limit, 1), 100));
+  return (data as Run[] | null) ?? [];
+}
+
+export interface RunReport {
+  run: Run;
+  totalResponses: number;
+  summary: RunSummary;
+  entities: EntityStat[];
+}
+
+/** The most recent completed run for a project, if any. */
+export async function latestCompletedRun(
+  supabase: SupabaseClient,
+  userId: string,
+  projectId: string,
+): Promise<Run | null> {
+  const runs = await listRuns(supabase, userId, projectId, 50);
+  return runs?.find((r) => r.status === "completed") ?? null;
+}
+
+/**
+ * Share-of-voice report for one run: brand summary plus per-entity stats,
+ * computed with the same lib/metrics functions the dashboard uses.
+ * Null when the run doesn't exist or isn't the user's.
+ */
+export async function getRunReport(
+  supabase: SupabaseClient,
+  userId: string,
+  runId: string,
+): Promise<RunReport | null> {
+  const { data: runRow } = await supabase
+    .from("runs")
+    .select("*")
+    .eq("id", runId)
+    .maybeSingle();
+  const run = runRow as Run | null;
+  if (!run) return null;
+
+  const project = await getOwnedProject(supabase, userId, run.project_id);
+  if (!project) return null;
+
+  const [{ count }, { data: mentionRows }] = await Promise.all([
+    supabase
+      .from("responses")
+      .select("id", { count: "exact", head: true })
+      .eq("run_id", runId),
+    supabase.from("mentions").select("*").eq("run_id", runId),
+  ]);
+
+  const mentions = (mentionRows ?? []) as Mention[];
+  const totalResponses = count ?? 0;
+
+  return {
+    run,
+    totalResponses,
+    summary: computeRunSummary(mentions, totalResponses),
+    entities: computeEntityStats(mentions, totalResponses),
+  };
+}
+
+export type TriggerOutcome =
+  | { ok: true; result: RunResult }
+  | { ok: false; code: "not_found" | "no_key"; message: string };
+
+/**
+ * Execute a monitoring run for one of the user's projects.
+ *
+ * Programmatic runs are BYOK-only: the free-trial gate lives in
+ * auth.uid()-scoped RPCs that a service-role request can't consume, and
+ * keeping the trial off the API surface also keeps it from being farmed
+ * by scripts. Dashboard runs are unaffected.
+ */
+export async function triggerRunForProject(
+  supabase: SupabaseClient,
+  userId: string,
+  projectId: string,
+): Promise<TriggerOutcome> {
+  const project = await getOwnedProject(supabase, userId, projectId);
+  if (!project) {
+    return { ok: false, code: "not_found", message: "Project not found." };
+  }
+
+  const key = await resolveRunKey(supabase, userId, project);
+  if (key.source !== "own") {
+    const providerLabel = PROVIDERS[project.default_provider].label;
+    return {
+      ok: false,
+      code: "no_key",
+      message: `API-triggered runs require your own ${providerLabel} key. Add one in Settings (free-trial runs are dashboard-only).`,
+    };
+  }
+
+  const result = await executeRun({
+    supabase,
+    project,
+    provider: key.provider,
+    model: key.model,
+    apiKey: key.apiKey!,
+  });
+  return { ok: true, result };
+}

--- a/lib/crypto.ts
+++ b/lib/crypto.ts
@@ -53,6 +53,22 @@ export function decryptSecret(payload: string): string {
   return plaintext.toString("utf8");
 }
 
+// ------------------------------------------------------------------
+// Lettertrace API keys (programmatic REST/MCP access). Unlike provider keys we
+// never need the plaintext back, so these are hashed, not encrypted: the
+// plaintext is shown once at creation and only the SHA-256 digest is stored.
+// ------------------------------------------------------------------
+
+const API_KEY_PREFIX = "lt_live_";
+
+export function generateApiKey(): string {
+  return `${API_KEY_PREFIX}${crypto.randomBytes(24).toString("base64url")}`;
+}
+
+export function hashApiKey(plaintext: string): string {
+  return crypto.createHash("sha256").update(plaintext.trim()).digest("hex");
+}
+
 // A non-reversible hint so users can recognize which key is stored, e.g. "sk-ant-…4a9c".
 export function keyHint(plaintext: string): string {
   const trimmed = plaintext.trim();

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -9,6 +9,11 @@ export async function updateSession(request: NextRequest) {
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
+      global: {
+        // Keep auth lookups out of Next's data cache (see lib/supabase/service.ts).
+        fetch: (input: RequestInfo | URL, init?: RequestInit) =>
+          fetch(input, { ...init, cache: "no-store" }),
+      },
       cookies: {
         getAll() {
           return request.cookies.getAll();

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,7 +1,8 @@
 import { cache } from "react";
 import { createServerClient, type CookieOptions } from "@supabase/ssr";
-import { createClient as createSupabaseClient } from "@supabase/supabase-js";
 import { cookies } from "next/headers";
+
+export { createServiceClient } from "./service";
 
 // Server Supabase client bound to the request cookies (respects RLS as the
 // signed-in user). Use inside Server Components, Route Handlers, Server Actions.
@@ -32,23 +33,6 @@ export const createClient = cache(function createClient() {
     },
   );
 });
-
-// Service-role client that bypasses RLS. Only for trusted server contexts such
-// as the cron endpoint, which must enumerate every user's due projects.
-// Requires SUPABASE_SERVICE_ROLE_KEY.
-export function createServiceClient() {
-  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-  if (!serviceKey) {
-    throw new Error(
-      "SUPABASE_SERVICE_ROLE_KEY is not set. It is required for scheduled runs.",
-    );
-  }
-  return createSupabaseClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    serviceKey,
-    { auth: { persistSession: false, autoRefreshToken: false } },
-  );
-}
 
 // Convenience: the signed-in user (or null). Deduped per request.
 export const getUser = cache(async function getUser() {

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -15,6 +15,14 @@ export const createClient = cache(function createClient() {
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
+      global: {
+        // Next.js patches global fetch and can serve repeated GETs from its
+        // data cache (observed with the service client — see lib/supabase/
+        // service.ts). Supabase queries must always hit Postgres; per-request
+        // dedupe is handled by React cache() in the data helpers instead.
+        fetch: (input: RequestInfo | URL, init?: RequestInit) =>
+          fetch(input, { ...init, cache: "no-store" }),
+      },
       cookies: {
         getAll() {
           return cookieStore.getAll();

--- a/lib/supabase/service.ts
+++ b/lib/supabase/service.ts
@@ -1,0 +1,29 @@
+import { createClient as createSupabaseClient } from "@supabase/supabase-js";
+
+// Service-role client that bypasses RLS. Only for trusted server contexts:
+// the cron endpoint (enumerates every user's due projects) and the
+// API-key-authenticated surface (/api/v1, /api/mcp), where every query must
+// scope by userId explicitly. Lives outside lib/supabase/server.ts so modules
+// that never touch request cookies (and their tests) don't drag in
+// next/headers. Requires SUPABASE_SERVICE_ROLE_KEY.
+export function createServiceClient() {
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!serviceKey) {
+    throw new Error(
+      "SUPABASE_SERVICE_ROLE_KEY is not set. It is required for scheduled runs and API-key access.",
+    );
+  }
+  return createSupabaseClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    serviceKey,
+    {
+      auth: { persistSession: false, autoRefreshToken: false },
+      global: {
+        // Next.js patches global fetch and may serve repeated GETs (same URL)
+        // from its data cache — which turned api_keys lookups and report reads
+        // into stale snapshots. Data queries must always hit Postgres.
+        fetch: (input, init) => fetch(input, { ...init, cache: "no-store" }),
+      },
+    },
+  );
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -29,6 +29,16 @@ export interface ProviderKey {
   created_at: string;
 }
 
+// Lettertrace API key for programmatic access (REST v1 + MCP). Only the hash
+// is stored; this is the safe shape returned to the browser.
+export interface ApiKeyPublic {
+  id: string;
+  name: string;
+  key_hint: string;
+  last_used_at: string | null;
+  created_at: string;
+}
+
 // Safe shape returned to the browser (no ciphertext).
 export interface ProviderKeyPublic {
   id: string;

--- a/middleware.ts
+++ b/middleware.ts
@@ -7,7 +7,8 @@ export async function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
-    // Run on everything except static assets and image files.
-    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+    // Run on everything except static assets, image files, and the
+    // token-authenticated programmatic surface (API keys, not cookies).
+    "/((?!_next/static|_next/image|favicon.ico|api/v1|api/mcp|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
   ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,14 +10,17 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.30.1",
+        "@modelcontextprotocol/sdk": "^1.26.0",
         "@supabase/ssr": "^0.5.2",
         "@supabase/supabase-js": "^2.45.4",
         "lucide-react": "^0.451.0",
+        "mcp-handler": "^1.1.0",
         "next": "14.2.15",
         "openai": "^4.67.3",
         "react": "18.3.1",
         "react-dom": "18.3.1",
-        "recharts": "^2.12.7"
+        "recharts": "^2.12.7",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@types/node": "^20.16.11",
@@ -575,6 +578,18 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.15",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.15.tgz",
+      "integrity": "sha512-Za2ai6TLdKjUvnur+eenO6nuYYipVAEhyCAdaV8IRvmU9kK8crOZUSYvIXn72E4f8fJqyAbpcJuTsYYmZp9Deg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -698,6 +713,68 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
+      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
@@ -935,6 +1012,65 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
+      "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -2282,6 +2418,44 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
@@ -2333,6 +2507,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -2704,6 +2917,43 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.16",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
@@ -2773,6 +3023,15 @@
         "node": ">=10.16.0"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -2819,7 +3078,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -2969,6 +3227,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3018,6 +3285,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/cookie": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
@@ -3027,11 +3316,36 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3247,7 +3561,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3329,6 +3642,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -3387,6 +3709,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.394",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.394.tgz",
@@ -3400,6 +3728,15 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.24.2",
@@ -3651,6 +3988,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -4105,6 +4448,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -4120,6 +4472,27 @@
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
@@ -4130,11 +4503,97 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
+      "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-equals": {
@@ -4190,6 +4649,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -4224,6 +4699,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -4333,6 +4829,15 @@
         "node": ">= 12.20"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
@@ -4345,6 +4850,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/fs.realpath": {
@@ -4420,6 +4934,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/get-intrinsic": {
@@ -4702,6 +5225,35 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.32",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
+      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/humanize-ms": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
@@ -4718,6 +5270,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ignore": {
@@ -4773,7 +5341,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/internal-slot": {
@@ -4798,6 +5365,24 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-array-buffer": {
@@ -5106,6 +5691,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -5262,7 +5853,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/iterator.prototype": {
@@ -5312,6 +5902,15 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.4.tgz",
+      "integrity": "sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5354,6 +5953,12 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -5538,6 +6143,80 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mcp-handler": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mcp-handler/-/mcp-handler-1.1.0.tgz",
+      "integrity": "sha512-MVCES7g18gcoZy+R/3v5nadkUMzMAWdos8jRl6DyljOKvd2/ZKDmwlCjL6zp4vo+7FeCXOYL1uWinHWlkKAAUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^11.1.0",
+        "redis": "^4.6.0"
+      },
+      "bin": {
+        "create-mcp-route": "dist/cli/index.js",
+        "mcp-adapter": "dist/cli/index.js",
+        "mcp-handler": "dist/cli/index.js"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "1.26.0",
+        "next": ">=13.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": false
+        },
+        "next": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mcp-handler/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/mcp-handler/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -5674,6 +6353,15 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/next": {
       "version": "14.2.15",
@@ -5866,7 +6554,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5975,11 +6662,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -6111,6 +6809,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6135,7 +6842,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6163,6 +6869,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/pathe": {
@@ -6219,6 +6935,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -6437,6 +7162,19 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -6445,6 +7183,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -6467,6 +7221,34 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/react": {
       "version": "18.3.1",
@@ -6592,6 +7374,23 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
     },
+    "node_modules/redis": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.1.tgz",
+      "integrity": "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==",
+      "license": "MIT",
+      "workspaces": [
+        "./packages/*"
+      ],
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.6.1",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.7",
+        "@redis/search": "1.2.0",
+        "@redis/time-series": "1.1.0"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -6634,6 +7433,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -6775,6 +7583,22 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -6854,6 +7678,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -6874,6 +7704,76 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/send/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/set-function-length": {
@@ -6925,11 +7825,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -6942,7 +7847,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6952,7 +7856,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
       "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -6972,7 +7875,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -6989,7 +7891,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -7008,7 +7909,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -7066,6 +7966,15 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "3.10.0",
@@ -7603,6 +8512,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -7672,6 +8590,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -7791,6 +8765,15 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/unrs-resolver": {
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
@@ -7876,6 +8859,15 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/victory-vendor": {
       "version": "36.9.2",
@@ -8077,7 +9069,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -8310,7 +9301,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
     },
     "node_modules/yocto-queue": {
@@ -8324,6 +9320,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -17,14 +17,17 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.30.1",
+    "@modelcontextprotocol/sdk": "^1.26.0",
     "@supabase/ssr": "^0.5.2",
     "@supabase/supabase-js": "^2.45.4",
+    "lucide-react": "^0.451.0",
+    "mcp-handler": "^1.1.0",
     "next": "14.2.15",
     "openai": "^4.67.3",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "recharts": "^2.12.7",
-    "lucide-react": "^0.451.0"
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/node": "^20.16.11",

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -348,3 +348,27 @@ create policy "sources_owner" on public.sources
 
 -- NOTE: the service-role key (used by /api/cron/run) bypasses RLS entirely,
 -- which is what lets the scheduler read due projects across all users.
+
+-- ---------- api_keys (programmatic access: REST v1 + MCP) ------------
+-- Lettertrace API keys let users query their own data (and trigger runs)
+-- from scripts and MCP clients. Only a SHA-256 hash is stored; the plaintext
+-- is shown once at creation. Lookups by hash happen through the service-role
+-- client (/api/v1 and /api/mcp requests carry no Supabase session).
+create table if not exists public.api_keys (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users (id) on delete cascade,
+  name text not null,
+  key_hash text not null unique,
+  key_hint text not null,
+  last_used_at timestamptz,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists api_keys_user_idx on public.api_keys (user_id);
+
+alter table public.api_keys enable row level security;
+
+drop policy if exists "api_keys_owner" on public.api_keys;
+create policy "api_keys_owner" on public.api_keys
+  for all using (user_id = auth.uid())
+  with check (user_id = auth.uid());

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,6 @@ export default defineConfig({
   resolve: { alias: { "@": root } },
   test: {
     environment: "node",
-    include: ["lib/**/*.test.ts"],
+    include: ["lib/**/*.test.ts", "app/**/*.test.ts"],
   },
 });


### PR DESCRIPTION
## What this adds

Users can now access their Lettertrace data programmatically — from scripts via a REST API, or conversationally from Claude / any MCP client — authenticated with API keys they create in Settings.

### 1. Lettertrace API keys
- New `api_keys` table (`supabase/schema.sql`): stores **SHA-256 hashes only** — the plaintext (`lt_live_…`) is shown once at creation, never again. Unlike provider keys there's nothing to decrypt later, so hashing > encryption here.
- New **"API & MCP access"** card in Settings: create (max 10), copy-once, revoke; shows key hint + last-used time.
- RLS `api_keys_owner` policy; programmatic lookups go through the service-role client keyed by hash.

### 2. REST v1 (`Authorization: Bearer lt_live_…`)
| Endpoint | Purpose |
|---|---|
| `GET /api/v1/projects` | List the caller's organizations |
| `GET /api/v1/projects/:id/runs` | Recent runs (`?limit=`) |
| `POST /api/v1/projects/:id/runs` | Trigger a monitoring run now |
| `GET /api/v1/runs/:id` | Share-of-voice report (same `lib/metrics` math as the dashboard) |

### 3. MCP server — `/api/mcp/mcp`
Streamable HTTP via `mcp-handler` (stateless, no Redis), same bearer auth:

```
claude mcp add --transport http lettertrace https://<host>/api/mcp/mcp \
  -H "Authorization: Bearer lt_live_..."
```

Tools: `list_projects`, `list_runs`, `get_share_of_voice_report` (accepts a run id, or a project id → latest completed run), `trigger_run`. Diagnostics only — tools return metrics, never recommendations.

Both surfaces share one service layer (`lib/api-service.ts`) so they can't drift. Every service-role query is explicitly scoped by the key owner's user id (tests assert cross-user access returns null).

## Design decisions

- **API-triggered runs are BYOK-only.** The free-trial gate lives in `auth.uid()`-scoped RPCs that a service-role request can't consume — and keeping the trial off the API also prevents free-run farming via scripts. Dashboard trials unchanged.
- `createServiceClient` moved to `lib/supabase/service.ts` (re-exported from the old path) so token-auth modules don't depend on `next/headers`.
- Middleware now skips `/api/v1` and `/api/mcp` (token auth, no session cookies).

## 🐛 Bug found & fixed during live E2E

Next.js patches global `fetch` and can serve repeated GETs from its data cache — which supabase-js rides on. In testing, an `api_keys` lookup was served stale (authenticated as a key's *previous* owner after the row changed) and report reads froze at their first snapshot. **Fix:** every server-side Supabase client now forces `cache: "no-store"` — the service client (`lib/supabase/service.ts`), the cookie client, and the middleware client. The RSC clients were probably protected by their dynamic render context, but Supabase queries should never be cacheable at all. The browser client is untouched (no patched fetch in the browser). This would have shipped stale API responses in production.

## Verification

- **Live E2E against production Supabase** (temp key, since revoked): 401s for missing/bad keys on REST + MCP, real project/run/report payloads verified against direct DB queries, 404 for unowned resources, full MCP handshake + `tools/call` returning real data.
- Schema verified live: RLS blocks anon reads *and* writes (42501), unique hash constraint enforced (23505).
- **44 tests passing** (27 new: auth hashing/scoping, service-layer ownership + report math + BYOK-only refusals, route status codes, MCP initialize through the real transport). Typecheck, lint, and production build all clean.

## Deploy notes

- Re-run `supabase/schema.sql` (done on the live instance ✅ — safe to re-run).
- Requires `SUPABASE_SERVICE_ROLE_KEY` (same variable the cron endpoint already needs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
