### PR TITLE
v1 API: project + prompt write surface, raw run responses, provider override

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,11 +137,27 @@ Create an API key in **Settings → API & MCP access** (shown once, stored hashe
 **REST v1:**
 
 ```bash
-# List your organizations
+# List your organizations / create one
 curl https://your-app.com/api/v1/projects \
   -H "Authorization: Bearer lt_live_..."
+curl -X POST https://your-app.com/api/v1/projects \
+  -H "Authorization: Bearer lt_live_..." -H "Content-Type: application/json" \
+  -d '{"name": "Acme", "brand_name": "Acme", "brand_domain": "acme.io"}'
+
+# A project's prompts / bulk-add prompts (topics are get-or-created by name)
+curl https://your-app.com/api/v1/projects/<project-id>/prompts \
+  -H "Authorization: Bearer lt_live_..."
+curl -X POST https://your-app.com/api/v1/projects/<project-id>/prompts \
+  -H "Authorization: Bearer lt_live_..." -H "Content-Type: application/json" \
+  -d '{"prompts": [{"text": "best crm for startups", "topic": "CRM"}]}'
+
+# Toggle a prompt on or off
+curl -X PATCH https://your-app.com/api/v1/prompts/<prompt-id> \
+  -H "Authorization: Bearer lt_live_..." -H "Content-Type: application/json" \
+  -d '{"is_active": false}'
 
 # Recent runs for a project / trigger a run now
+# (optional body {"provider", "model"} overrides the project default for that run)
 curl https://your-app.com/api/v1/projects/<project-id>/runs \
   -H "Authorization: Bearer lt_live_..."
 curl -X POST https://your-app.com/api/v1/projects/<project-id>/runs \
@@ -149,6 +165,10 @@ curl -X POST https://your-app.com/api/v1/projects/<project-id>/runs \
 
 # Share-of-voice report for a run
 curl https://your-app.com/api/v1/runs/<run-id> \
+  -H "Authorization: Bearer lt_live_..."
+
+# Raw artifacts for a run: each response's full text + cited sources + mentions
+curl https://your-app.com/api/v1/runs/<run-id>/responses \
   -H "Authorization: Bearer lt_live_..."
 ```
 
@@ -159,11 +179,12 @@ claude mcp add --transport http lettertrace https://your-app.com/api/mcp/mcp \
   -H "Authorization: Bearer lt_live_..."
 ```
 
-Tools: `list_projects`, `list_runs`, `get_share_of_voice_report`, `trigger_run`.
+Tools: `list_projects`, `list_runs`, `get_share_of_voice_report`, `trigger_run`. (The write endpoints above are REST-only for now.)
 
 Notes:
 
 - API-triggered runs are **BYOK-only** — the account must have its own provider key; free-trial runs stay dashboard-only.
+- Projects created via the API start with `schedule: "off"` — trigger runs explicitly (or flip the schedule in the dashboard).
 - API keys grant access to all of the account's organizations. Revoke them anytime from Settings.
 - Requires `SUPABASE_SERVICE_ROLE_KEY` (the same variable scheduled runs use), since API-key requests carry no browser session.
 - Upgrading an existing deployment? Re-run `supabase/schema.sql` — it adds the `api_keys` table (safe to re-run).

--- a/app/api/v1/projects/[id]/prompts/route.ts
+++ b/app/api/v1/projects/[id]/prompts/route.ts
@@ -1,14 +1,15 @@
 import { NextResponse } from "next/server";
 import { authenticateApiKey, bearerToken } from "@/lib/api-auth";
-import { getProjects } from "@/lib/data";
-import { createProject, projectSummary } from "@/lib/api-service";
+import { createPrompts, listProjectPrompts } from "@/lib/api-service";
 import { humanError } from "@/lib/llm";
 
 export const dynamic = "force-dynamic";
 
-// GET /api/v1/projects — list the caller's organizations.
-// Auth: Authorization: Bearer <lettertrace api key>
-export async function GET(request: Request) {
+// GET /api/v1/projects/:id/prompts — the project's prompts with topic names.
+export async function GET(
+  request: Request,
+  { params }: { params: { id: string } },
+) {
   const auth = await authenticateApiKey(
     bearerToken(request.headers.get("authorization")),
   );
@@ -19,14 +20,19 @@ export async function GET(request: Request) {
     );
   }
 
-  const projects = await getProjects(auth.supabase, auth.userId);
-  return NextResponse.json({ projects: projects.map(projectSummary) });
+  const prompts = await listProjectPrompts(auth.supabase, auth.userId, params.id);
+  if (!prompts) {
+    return NextResponse.json({ error: "Project not found" }, { status: 404 });
+  }
+  return NextResponse.json({ prompts });
 }
 
-// POST /api/v1/projects — create an organization for the caller.
-// Body: { name, brand_name, brand_aliases?, brand_domain?, description?,
-//         default_provider?, default_model?, use_web_search? }
-export async function POST(request: Request) {
+// POST /api/v1/projects/:id/prompts — bulk-add prompts, get-or-creating each
+// topic by name. Body: { prompts: [{ text, topic }] }
+export async function POST(
+  request: Request,
+  { params }: { params: { id: string } },
+) {
   const auth = await authenticateApiKey(
     bearerToken(request.headers.get("authorization")),
   );
@@ -43,18 +49,23 @@ export async function POST(request: Request) {
   } catch {
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
+  const { prompts } = (body ?? {}) as { prompts?: unknown };
 
   try {
-    const outcome = await createProject(
+    const outcome = await createPrompts(
       auth.supabase,
       auth.userId,
-      (body ?? {}) as Record<string, unknown>,
+      params.id,
+      prompts,
     );
     if (!outcome.ok) {
-      return NextResponse.json({ error: outcome.message }, { status: 400 });
+      return NextResponse.json(
+        { error: outcome.message },
+        { status: outcome.code === "not_found" ? 404 : 400 },
+      );
     }
     return NextResponse.json(
-      { project: projectSummary(outcome.project) },
+      { created: outcome.created, skipped: outcome.skipped },
       { status: 201 },
     );
   } catch (e) {

--- a/app/api/v1/projects/[id]/runs/route.ts
+++ b/app/api/v1/projects/[id]/runs/route.ts
@@ -1,7 +1,9 @@
 import { NextResponse } from "next/server";
 import { authenticateApiKey, bearerToken } from "@/lib/api-auth";
 import { listRuns, triggerRunForProject } from "@/lib/api-service";
+import { isProvider, PROVIDERS } from "@/lib/models";
 import { humanError } from "@/lib/llm";
+import type { Provider } from "@/lib/types";
 
 export const maxDuration = 300;
 export const dynamic = "force-dynamic";
@@ -30,6 +32,8 @@ export async function GET(
 }
 
 // POST /api/v1/projects/:id/runs — execute a monitoring run now (BYOK-only).
+// Optional body { provider?, model? } overrides the project default for this
+// run; no body keeps the default.
 export async function POST(
   request: Request,
   { params }: { params: { id: string } },
@@ -44,11 +48,38 @@ export async function POST(
     );
   }
 
+  // An absent (or empty) body is the common case and must keep working.
+  const options: { provider?: Provider; model?: string } = {};
+  let raw: unknown = null;
+  try {
+    raw = await request.json();
+  } catch {
+    // No JSON body: run with the project's default provider/model.
+  }
+  if (raw && typeof raw === "object") {
+    const b = raw as Record<string, unknown>;
+    if (typeof b.provider === "string" && b.provider.length > 0) {
+      if (!isProvider(b.provider)) {
+        return NextResponse.json(
+          {
+            error: `Unknown provider "${b.provider}". Use one of: ${Object.keys(PROVIDERS).join(", ")}.`,
+          },
+          { status: 400 },
+        );
+      }
+      options.provider = b.provider;
+    }
+    if (typeof b.model === "string" && b.model.trim().length > 0) {
+      options.model = b.model.trim();
+    }
+  }
+
   try {
     const outcome = await triggerRunForProject(
       auth.supabase,
       auth.userId,
       params.id,
+      options,
     );
     if (!outcome.ok) {
       return NextResponse.json(

--- a/app/api/v1/prompts/[id]/route.ts
+++ b/app/api/v1/prompts/[id]/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import { authenticateApiKey, bearerToken } from "@/lib/api-auth";
+import { setPromptActive } from "@/lib/api-service";
+import { humanError } from "@/lib/llm";
+
+export const dynamic = "force-dynamic";
+
+// PATCH /api/v1/prompts/:id — toggle a prompt. Body: { is_active: boolean }
+export async function PATCH(
+  request: Request,
+  { params }: { params: { id: string } },
+) {
+  const auth = await authenticateApiKey(
+    bearerToken(request.headers.get("authorization")),
+  );
+  if (!auth) {
+    return NextResponse.json(
+      { error: "Invalid or missing API key" },
+      { status: 401 },
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  const { is_active } = (body ?? {}) as { is_active?: unknown };
+  if (typeof is_active !== "boolean") {
+    return NextResponse.json(
+      { error: "is_active must be a boolean." },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const prompt = await setPromptActive(
+      auth.supabase,
+      auth.userId,
+      params.id,
+      is_active,
+    );
+    if (!prompt) {
+      return NextResponse.json({ error: "Prompt not found" }, { status: 404 });
+    }
+    return NextResponse.json({ prompt });
+  } catch (e) {
+    return NextResponse.json({ error: humanError(e) }, { status: 500 });
+  }
+}

--- a/app/api/v1/runs/[id]/responses/route.ts
+++ b/app/api/v1/runs/[id]/responses/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import { authenticateApiKey, bearerToken } from "@/lib/api-auth";
+import { getRunResponses } from "@/lib/api-service";
+
+export const dynamic = "force-dynamic";
+
+// GET /api/v1/runs/:id/responses — the run's raw artifacts: each response's
+// full text plus the cited sources and detected mentions.
+export async function GET(
+  request: Request,
+  { params }: { params: { id: string } },
+) {
+  const auth = await authenticateApiKey(
+    bearerToken(request.headers.get("authorization")),
+  );
+  if (!auth) {
+    return NextResponse.json(
+      { error: "Invalid or missing API key" },
+      { status: 401 },
+    );
+  }
+
+  const result = await getRunResponses(auth.supabase, auth.userId, params.id);
+  if (!result) {
+    return NextResponse.json({ error: "Run not found" }, { status: 404 });
+  }
+  return NextResponse.json(result);
+}

--- a/app/api/v1/v1-routes.test.ts
+++ b/app/api/v1/v1-routes.test.ts
@@ -2,16 +2,30 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { authenticateApiKey } from "@/lib/api-auth";
 import { getProjects } from "@/lib/data";
 import {
+  createProject,
+  createPrompts,
   getRunReport,
+  getRunResponses,
+  listProjectPrompts,
   listRuns,
+  setPromptActive,
   triggerRunForProject,
 } from "@/lib/api-service";
-import { GET as getProjectsRoute } from "@/app/api/v1/projects/route";
+import {
+  GET as getProjectsRoute,
+  POST as postProjectRoute,
+} from "@/app/api/v1/projects/route";
 import {
   GET as getRunsRoute,
   POST as postRunRoute,
 } from "@/app/api/v1/projects/[id]/runs/route";
+import {
+  GET as getPromptsRoute,
+  POST as postPromptsRoute,
+} from "@/app/api/v1/projects/[id]/prompts/route";
+import { PATCH as patchPromptRoute } from "@/app/api/v1/prompts/[id]/route";
 import { GET as getReportRoute } from "@/app/api/v1/runs/[id]/route";
+import { GET as getResponsesRoute } from "@/app/api/v1/runs/[id]/responses/route";
 
 vi.mock("@/lib/api-auth", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/api-auth")>()),
@@ -20,8 +34,13 @@ vi.mock("@/lib/api-auth", async (importOriginal) => ({
 vi.mock("@/lib/data", () => ({ getProjects: vi.fn() }));
 vi.mock("@/lib/api-service", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/api-service")>()),
+  createProject: vi.fn(),
+  createPrompts: vi.fn(),
+  listProjectPrompts: vi.fn(),
   listRuns: vi.fn(),
   getRunReport: vi.fn(),
+  getRunResponses: vi.fn(),
+  setPromptActive: vi.fn(),
   triggerRunForProject: vi.fn(),
 }));
 
@@ -37,8 +56,13 @@ function req(path: string, init?: RequestInit) {
 beforeEach(() => {
   vi.mocked(authenticateApiKey).mockReset().mockResolvedValue(AUTH_CTX);
   vi.mocked(getProjects).mockReset();
+  vi.mocked(createProject).mockReset();
+  vi.mocked(createPrompts).mockReset();
+  vi.mocked(listProjectPrompts).mockReset();
   vi.mocked(listRuns).mockReset();
   vi.mocked(getRunReport).mockReset();
+  vi.mocked(getRunResponses).mockReset();
+  vi.mocked(setPromptActive).mockReset();
   vi.mocked(triggerRunForProject).mockReset();
 });
 
@@ -59,6 +83,191 @@ describe("GET /api/v1/projects", () => {
     expect(body.projects).toHaveLength(1);
     expect(body.projects[0]).not.toHaveProperty("user_id");
     expect(getProjects).toHaveBeenCalledWith(AUTH_CTX.supabase, "user-1");
+  });
+});
+
+describe("POST /api/v1/projects", () => {
+  it("400s without a JSON body", async () => {
+    const res = await postProjectRoute(req("/api/v1/projects", { method: "POST" }));
+    expect(res.status).toBe(400);
+    expect(createProject).not.toHaveBeenCalled();
+  });
+
+  it("400s when the op rejects the input", async () => {
+    vi.mocked(createProject).mockResolvedValue({
+      ok: false,
+      code: "invalid",
+      message: "A brand name is required.",
+    });
+    const res = await postProjectRoute(
+      req("/api/v1/projects", { method: "POST", body: JSON.stringify({ name: "Acme" }) }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("A brand name is required.");
+  });
+
+  it("201s with the trimmed project summary", async () => {
+    vi.mocked(createProject).mockResolvedValue({
+      ok: true,
+      project: { id: "p1", user_id: "user-1", name: "Acme", brand_name: "Acme" } as never,
+    });
+    const res = await postProjectRoute(
+      req("/api/v1/projects", {
+        method: "POST",
+        body: JSON.stringify({ name: "Acme", brand_name: "Acme" }),
+      }),
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.project).toMatchObject({ id: "p1", name: "Acme" });
+    expect(body.project).not.toHaveProperty("user_id");
+    expect(createProject).toHaveBeenCalledWith(AUTH_CTX.supabase, "user-1", {
+      name: "Acme",
+      brand_name: "Acme",
+    });
+  });
+});
+
+describe("GET /api/v1/projects/:id/prompts", () => {
+  it("404s for a project that isn't the caller's", async () => {
+    vi.mocked(listProjectPrompts).mockResolvedValue(null);
+    const res = await getPromptsRoute(req("/api/v1/projects/p1/prompts"), {
+      params: { id: "p1" },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns the prompts with topic names", async () => {
+    vi.mocked(listProjectPrompts).mockResolvedValue([
+      {
+        id: "prompt-1",
+        text: "best crm",
+        topic: "CRM",
+        source: "manual",
+        is_active: true,
+        created_at: "2026-07-02T00:00:00Z",
+      },
+    ]);
+    const res = await getPromptsRoute(req("/api/v1/projects/p1/prompts"), {
+      params: { id: "p1" },
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()).prompts[0].topic).toBe("CRM");
+  });
+});
+
+describe("POST /api/v1/projects/:id/prompts", () => {
+  it("maps not_found/invalid to 404/400", async () => {
+    vi.mocked(createPrompts).mockResolvedValue({
+      ok: false,
+      code: "not_found",
+      message: "Project not found.",
+    });
+    let res = await postPromptsRoute(
+      req("/api/v1/projects/p1/prompts", {
+        method: "POST",
+        body: JSON.stringify({ prompts: [{ text: "x", topic: "T" }] }),
+      }),
+      { params: { id: "p1" } },
+    );
+    expect(res.status).toBe(404);
+
+    vi.mocked(createPrompts).mockResolvedValue({
+      ok: false,
+      code: "invalid",
+      message: "bad entry",
+    });
+    res = await postPromptsRoute(
+      req("/api/v1/projects/p1/prompts", {
+        method: "POST",
+        body: JSON.stringify({ prompts: [{ text: "" }] }),
+      }),
+      { params: { id: "p1" } },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("201s with the created prompts and skip count", async () => {
+    vi.mocked(createPrompts).mockResolvedValue({
+      ok: true,
+      created: [
+        {
+          id: "prompt-1",
+          text: "best crm",
+          topic: "CRM",
+          source: "manual",
+          is_active: true,
+          created_at: "2026-07-02T00:00:00Z",
+        },
+      ],
+      skipped: 1,
+    });
+    const res = await postPromptsRoute(
+      req("/api/v1/projects/p1/prompts", {
+        method: "POST",
+        body: JSON.stringify({ prompts: [{ text: "best crm", topic: "CRM" }] }),
+      }),
+      { params: { id: "p1" } },
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.created).toHaveLength(1);
+    expect(body.skipped).toBe(1);
+    expect(createPrompts).toHaveBeenCalledWith(AUTH_CTX.supabase, "user-1", "p1", [
+      { text: "best crm", topic: "CRM" },
+    ]);
+  });
+});
+
+describe("PATCH /api/v1/prompts/:id", () => {
+  it("400s when is_active isn't a boolean", async () => {
+    const res = await patchPromptRoute(
+      req("/api/v1/prompts/prompt-1", {
+        method: "PATCH",
+        body: JSON.stringify({ is_active: "yes" }),
+      }),
+      { params: { id: "prompt-1" } },
+    );
+    expect(res.status).toBe(400);
+    expect(setPromptActive).not.toHaveBeenCalled();
+  });
+
+  it("404s for a prompt that isn't the caller's", async () => {
+    vi.mocked(setPromptActive).mockResolvedValue(null);
+    const res = await patchPromptRoute(
+      req("/api/v1/prompts/prompt-1", {
+        method: "PATCH",
+        body: JSON.stringify({ is_active: false }),
+      }),
+      { params: { id: "prompt-1" } },
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns the updated prompt", async () => {
+    vi.mocked(setPromptActive).mockResolvedValue({
+      id: "prompt-1",
+      text: "best crm",
+      topic: "CRM",
+      source: "manual",
+      is_active: false,
+      created_at: "2026-07-02T00:00:00Z",
+    });
+    const res = await patchPromptRoute(
+      req("/api/v1/prompts/prompt-1", {
+        method: "PATCH",
+        body: JSON.stringify({ is_active: false }),
+      }),
+      { params: { id: "prompt-1" } },
+    );
+    expect(res.status).toBe(200);
+    expect((await res.json()).prompt.is_active).toBe(false);
+    expect(setPromptActive).toHaveBeenCalledWith(
+      AUTH_CTX.supabase,
+      "user-1",
+      "prompt-1",
+      false,
+    );
   });
 });
 
@@ -106,6 +315,44 @@ describe("POST /api/v1/projects/:id/runs", () => {
     );
     expect(res.status).toBe(200);
     expect((await res.json()).runId).toBe("r1");
+    // No body -> no overrides: the project default stays in charge.
+    expect(triggerRunForProject).toHaveBeenCalledWith(
+      AUTH_CTX.supabase,
+      "user-1",
+      "p1",
+      {},
+    );
+  });
+
+  it("400s on an unknown provider override", async () => {
+    const res = await postRunRoute(
+      req("/api/v1/projects/p1/runs", {
+        method: "POST",
+        body: JSON.stringify({ provider: "gemini" }),
+      }),
+      { params: { id: "p1" } },
+    );
+    expect(res.status).toBe(400);
+    expect(triggerRunForProject).not.toHaveBeenCalled();
+  });
+
+  it("passes a provider/model override through", async () => {
+    vi.mocked(triggerRunForProject).mockResolvedValue({
+      ok: true,
+      result: { runId: "r2", status: "completed", totalResponses: 3, tokensUsed: 10 },
+    });
+    const res = await postRunRoute(
+      req("/api/v1/projects/p1/runs", {
+        method: "POST",
+        body: JSON.stringify({ provider: "openai", model: "gpt-4o-mini" }),
+      }),
+      { params: { id: "p1" } },
+    );
+    expect(res.status).toBe(200);
+    expect(triggerRunForProject).toHaveBeenCalledWith(AUTH_CTX.supabase, "user-1", "p1", {
+      provider: "openai",
+      model: "gpt-4o-mini",
+    });
   });
 });
 
@@ -131,5 +378,48 @@ describe("GET /api/v1/runs/:id", () => {
     const res = await getReportRoute(req("/api/v1/runs/r1"), { params: { id: "r1" } });
     expect(res.status).toBe(200);
     expect((await res.json()).summary.brandShareOfVoice).toBe(0.25);
+  });
+});
+
+describe("GET /api/v1/runs/:id/responses", () => {
+  it("404s for an unknown or unowned run", async () => {
+    vi.mocked(getRunResponses).mockResolvedValue(null);
+    const res = await getResponsesRoute(req("/api/v1/runs/r1/responses"), {
+      params: { id: "r1" },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns the raw artifacts", async () => {
+    vi.mocked(getRunResponses).mockResolvedValue({
+      run: { id: "r1" } as never,
+      responses: [
+        {
+          id: "resp-1",
+          prompt_id: "prompt-1",
+          prompt_text: "best crm",
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+          response_text: "Credal is…",
+          sources: [
+            {
+              url: "https://credal.ai/blog",
+              domain: "credal.ai",
+              title: null,
+              snippet: null,
+              is_owned: true,
+            },
+          ],
+          mentions: [],
+        },
+      ],
+    });
+    const res = await getResponsesRoute(req("/api/v1/runs/r1/responses"), {
+      params: { id: "r1" },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.responses[0].sources[0].url).toBe("https://credal.ai/blog");
+    expect(getRunResponses).toHaveBeenCalledWith(AUTH_CTX.supabase, "user-1", "r1");
   });
 });

--- a/lib/api-service.test.ts
+++ b/lib/api-service.test.ts
@@ -1,17 +1,26 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Mention, Project, Run } from "@/lib/types";
 import {
+  createProject,
+  createPrompts,
   getOwnedProject,
   getRunReport,
+  getRunResponses,
   latestCompletedRun,
+  listProjectPrompts,
   listRuns,
   projectSummary,
+  setPromptActive,
   triggerRunForProject,
 } from "@/lib/api-service";
-import { resolveRunKey } from "@/lib/trial";
+import { pickDefaultProvider, resolveKey, resolveRunKey } from "@/lib/trial";
 import { executeRun } from "@/lib/engine";
 
-vi.mock("@/lib/trial", () => ({ resolveRunKey: vi.fn() }));
+vi.mock("@/lib/trial", () => ({
+  pickDefaultProvider: vi.fn(),
+  resolveKey: vi.fn(),
+  resolveRunKey: vi.fn(),
+}));
 vi.mock("@/lib/engine", () => ({ executeRun: vi.fn() }));
 
 // ------------------------------------------------------------------
@@ -42,6 +51,14 @@ function fakeDb(handlers: Record<string, Handler>) {
       const result = () => ({ data: null, error: null, count: undefined, ...handlers[table]?.(q) });
       const proxy = {
         select: () => proxy,
+        insert: (values: unknown) => {
+          q.modifiers.push(["insert", values]);
+          return proxy;
+        },
+        update: (values: unknown) => {
+          q.modifiers.push(["update", values]);
+          return proxy;
+        },
         eq: (...args: unknown[]) => {
           q.filters.push(["eq", ...args]);
           return proxy;
@@ -54,6 +71,7 @@ function fakeDb(handlers: Record<string, Handler>) {
           q.modifiers.push(["limit", ...args]);
           return proxy;
         },
+        single: async () => result(),
         maybeSingle: async () => result(),
         then: (resolve: (v: unknown) => unknown, reject?: (e: unknown) => unknown) =>
           Promise.resolve(result()).then(resolve, reject),
@@ -119,9 +137,19 @@ function makeMention(overrides: Partial<Mention>): Mention {
 }
 
 beforeEach(() => {
+  vi.mocked(pickDefaultProvider).mockReset().mockReturnValue("anthropic");
+  vi.mocked(resolveKey).mockReset();
   vi.mocked(resolveRunKey).mockReset();
   vi.mocked(executeRun).mockReset();
 });
+
+/** The values handed to .insert() on the first matching recorded query. */
+function insertedValues(db: { queries: RecordedQuery[] }, table: string): unknown {
+  const q = db.queries.find(
+    (query) => query.table === table && query.modifiers.some((m) => m[0] === "insert"),
+  );
+  return q?.modifiers.find((m) => m[0] === "insert")?.[1];
+}
 
 describe("projectSummary", () => {
   it("exposes only the public fields (no user_id)", () => {
@@ -290,5 +318,354 @@ describe("triggerRunForProject", () => {
         apiKey: "sk-ant-user-key",
       }),
     );
+  });
+
+  it("resolves a caller-sent provider/model with resolveKey, not the project default", async () => {
+    const db = fakeDb({ projects: () => ({ data: PROJECT }) });
+    vi.mocked(resolveKey).mockResolvedValue({
+      source: "own",
+      apiKey: "sk-user-openai-key",
+      provider: "openai",
+      model: "gpt-4o-mini",
+    });
+    vi.mocked(executeRun).mockResolvedValue({
+      runId: "run-10",
+      status: "completed",
+      totalResponses: 4,
+      tokensUsed: 1234,
+    });
+
+    const outcome = await triggerRunForProject(db as never, "user-1", "proj-1", {
+      provider: "openai",
+      model: "gpt-4o-mini",
+    });
+    expect(outcome).toMatchObject({ ok: true, result: { runId: "run-10" } });
+    expect(resolveRunKey).not.toHaveBeenCalled();
+    expect(resolveKey).toHaveBeenCalledWith(db, "user-1", "openai", "gpt-4o-mini");
+    expect(executeRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai",
+        model: "gpt-4o-mini",
+        apiKey: "sk-user-openai-key",
+      }),
+    );
+  });
+
+  it("names the requested provider when an override has no own key", async () => {
+    const db = fakeDb({ projects: () => ({ data: PROJECT }) });
+    vi.mocked(resolveKey).mockResolvedValue({
+      source: "none",
+      provider: "openai",
+      model: "gpt-4o",
+    });
+    const outcome = await triggerRunForProject(db as never, "user-1", "proj-1", {
+      provider: "openai",
+    });
+    expect(outcome).toMatchObject({ ok: false, code: "no_key" });
+    expect((outcome as { message: string }).message).toContain("OpenAI");
+    expect(executeRun).not.toHaveBeenCalled();
+  });
+});
+
+describe("createProject", () => {
+  it("requires a name and a brand name", async () => {
+    const db = fakeDb({});
+    expect(
+      await createProject(db as never, "user-1", { brand_name: "Acme" }),
+    ).toMatchObject({ ok: false, code: "invalid" });
+    expect(
+      await createProject(db as never, "user-1", { name: "Acme", brand_name: "  " }),
+    ).toMatchObject({ ok: false, code: "invalid" });
+    expect(db.queries).toHaveLength(0);
+  });
+
+  it("rejects an unknown default_provider", async () => {
+    const db = fakeDb({});
+    const outcome = await createProject(db as never, "user-1", {
+      name: "Acme",
+      brand_name: "Acme",
+      default_provider: "gemini",
+    });
+    expect(outcome).toMatchObject({ ok: false, code: "invalid" });
+    expect(db.queries).toHaveLength(0);
+  });
+
+  it("inserts with the dashboard defaults, tied to the caller", async () => {
+    const db = fakeDb({ projects: () => ({ data: PROJECT }) });
+    const outcome = await createProject(db as never, "user-1", {
+      name: "Acme",
+      brand_name: "Acme",
+    });
+    expect(outcome).toMatchObject({ ok: true, project: { id: "proj-1" } });
+    expect(insertedValues(db, "projects")).toMatchObject({
+      name: "Acme",
+      brand_name: "Acme",
+      brand_aliases: [],
+      brand_domain: null,
+      description: null,
+      default_provider: "anthropic",
+      default_model: "claude-opus-4-8", // defaultModelFor("anthropic")
+      schedule: "off", // API callers orchestrate their own cadence
+      user_id: "user-1",
+    });
+  });
+
+  it("honors an explicit provider, model, aliases and web-search flag", async () => {
+    const db = fakeDb({ projects: () => ({ data: PROJECT }) });
+    await createProject(db as never, "user-1", {
+      name: "Acme",
+      brand_name: "Acme",
+      brand_aliases: ["Acme Inc", " acme.io "],
+      brand_domain: "acme.io",
+      default_provider: "openai",
+      default_model: "gpt-4o-mini",
+      use_web_search: false,
+    });
+    expect(insertedValues(db, "projects")).toMatchObject({
+      brand_aliases: ["Acme Inc", "acme.io"],
+      brand_domain: "acme.io",
+      default_provider: "openai",
+      default_model: "gpt-4o-mini",
+      use_web_search: false,
+    });
+  });
+});
+
+describe("listProjectPrompts", () => {
+  it("returns null when the project isn't the user's", async () => {
+    const db = fakeDb({ projects: () => ({ data: null }) });
+    expect(await listProjectPrompts(db as never, "user-2", "proj-1")).toBeNull();
+  });
+
+  it("flattens the embedded topic name", async () => {
+    const db = fakeDb({
+      projects: () => ({ data: PROJECT }),
+      prompts: () => ({
+        data: [
+          {
+            id: "prompt-1",
+            text: "best crm for startups",
+            source: "manual",
+            is_active: true,
+            created_at: "2026-07-02T00:00:00Z",
+            topics: { name: "CRM" },
+          },
+        ],
+      }),
+    });
+    const prompts = await listProjectPrompts(db as never, "user-1", "proj-1");
+    expect(prompts).toEqual([
+      {
+        id: "prompt-1",
+        text: "best crm for startups",
+        topic: "CRM",
+        source: "manual",
+        is_active: true,
+        created_at: "2026-07-02T00:00:00Z",
+      },
+    ]);
+  });
+});
+
+describe("createPrompts", () => {
+  it("404s for a project the user doesn't own", async () => {
+    const db = fakeDb({ projects: () => ({ data: null }) });
+    const outcome = await createPrompts(db as never, "user-2", "proj-1", [
+      { text: "hi", topic: "CRM" },
+    ]);
+    expect(outcome).toMatchObject({ ok: false, code: "not_found" });
+  });
+
+  it("rejects entries with empty text or topic, naming the indexes", async () => {
+    const db = fakeDb({ projects: () => ({ data: PROJECT }) });
+    const outcome = await createPrompts(db as never, "user-1", "proj-1", [
+      { text: "ok", topic: "CRM" },
+      { text: "  ", topic: "CRM" },
+      { text: "ok too" },
+    ]);
+    expect(outcome).toMatchObject({ ok: false, code: "invalid" });
+    expect((outcome as { message: string }).message).toContain("1, 2");
+  });
+
+  it("get-or-creates topics by name and skips duplicate texts", async () => {
+    let promptInsertRows: Record<string, unknown>[] = [];
+    const db = fakeDb({
+      projects: () => ({ data: PROJECT }),
+      topics: (q) => {
+        const insert = q.modifiers.find((m) => m[0] === "insert");
+        if (!insert) return { data: [{ id: "topic-crm", name: "CRM" }] };
+        return {
+          data: (insert[1] as { name: string }[]).map((row, i) => ({
+            id: `topic-new-${i}`,
+            name: row.name,
+          })),
+        };
+      },
+      prompts: (q) => {
+        const insert = q.modifiers.find((m) => m[0] === "insert");
+        if (!insert) return { data: [{ text: "Existing prompt" }] };
+        promptInsertRows = insert[1] as Record<string, unknown>[];
+        return {
+          data: promptInsertRows.map((row, i) => ({
+            ...row,
+            id: `prompt-${i}`,
+            created_at: "2026-07-03T00:00:00Z",
+          })),
+        };
+      },
+    });
+
+    const outcome = await createPrompts(db as never, "user-1", "proj-1", [
+      { text: "existing PROMPT", topic: "CRM" }, // already in the project
+      { text: "best crm for startups", topic: "crm" }, // existing topic, other case
+      { text: "how much does acme cost", topic: "Pricing" }, // new topic
+      { text: "Best CRM for startups", topic: "CRM" }, // repeat within the batch
+    ]);
+
+    expect(outcome).toMatchObject({ ok: true, skipped: 2 });
+    const created = (outcome as { created: { text: string; topic: string | null }[] })
+      .created;
+    expect(created).toHaveLength(2);
+    expect(created[0]).toMatchObject({ text: "best crm for startups", topic: "CRM" });
+    expect(created[1]).toMatchObject({ text: "how much does acme cost", topic: "Pricing" });
+
+    // Only the genuinely new topic name is created.
+    expect(insertedValues(db, "topics")).toEqual([
+      { project_id: "proj-1", name: "Pricing" },
+    ]);
+    expect(promptInsertRows).toEqual([
+      expect.objectContaining({
+        project_id: "proj-1",
+        topic_id: "topic-crm",
+        source: "manual",
+        is_active: true,
+      }),
+      expect.objectContaining({ topic_id: "topic-new-0" }),
+    ]);
+  });
+});
+
+describe("setPromptActive", () => {
+  const PROMPT_ROW = {
+    id: "prompt-1",
+    project_id: "proj-1",
+    text: "best crm for startups",
+    source: "manual",
+    is_active: true,
+    created_at: "2026-07-02T00:00:00Z",
+    topics: { name: "CRM" },
+  };
+
+  it("returns null for an unknown prompt", async () => {
+    const db = fakeDb({ prompts: () => ({ data: null }) });
+    expect(await setPromptActive(db as never, "user-1", "prompt-1", false)).toBeNull();
+  });
+
+  it("returns null when the prompt's project isn't the user's", async () => {
+    const db = fakeDb({
+      prompts: () => ({ data: PROMPT_ROW }),
+      projects: () => ({ data: null }),
+    });
+    expect(await setPromptActive(db as never, "user-2", "prompt-1", false)).toBeNull();
+  });
+
+  it("updates scoped by prompt AND project id", async () => {
+    const db = fakeDb({
+      prompts: () => ({ data: PROMPT_ROW }),
+      projects: () => ({ data: PROJECT }),
+    });
+    const prompt = await setPromptActive(db as never, "user-1", "prompt-1", false);
+    expect(prompt).toMatchObject({ id: "prompt-1", topic: "CRM", is_active: false });
+
+    const updateQuery = db.queries.find((q) =>
+      q.modifiers.some((m) => m[0] === "update"),
+    )!;
+    expect(updateQuery.modifiers).toContainEqual(["update", { is_active: false }]);
+    expect(updateQuery.filters).toEqual([
+      ["eq", "id", "prompt-1"],
+      ["eq", "project_id", "proj-1"],
+    ]);
+  });
+});
+
+describe("getRunResponses", () => {
+  it("returns null for a run the user doesn't own", async () => {
+    const db = fakeDb({
+      runs: () => ({ data: makeRun({}) }),
+      projects: () => ({ data: null }),
+    });
+    expect(await getRunResponses(db as never, "user-2", "run-1")).toBeNull();
+  });
+
+  it("groups each response's text with its sources and mentions", async () => {
+    // prompt_id is null when the prompt was deleted after the run.
+    const responses = [
+      {
+        id: "resp-1",
+        prompt_id: "prompt-1",
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        response_text: "Credal is a strong option…",
+      },
+      {
+        id: "resp-2",
+        prompt_id: null,
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        response_text: "Several tools compete here…",
+      },
+    ];
+    const sources = [
+      {
+        id: "src-1",
+        response_id: "resp-1",
+        url: "https://credal.ai/blog/post",
+        domain: "credal.ai",
+        title: "Post",
+        snippet: "…",
+        is_owned: true,
+        created_at: "2026-07-02T00:00:00Z",
+      },
+    ];
+    const db = fakeDb({
+      runs: () => ({ data: makeRun({}) }),
+      projects: () => ({ data: PROJECT }),
+      responses: () => ({ data: responses }),
+      sources: () => ({ data: sources }),
+      mentions: () => ({ data: [makeMention({ response_id: "resp-1" })] }),
+      prompts: () => ({ data: [{ id: "prompt-1", text: "best crm for startups" }] }),
+    });
+
+    const result = await getRunResponses(db as never, "user-1", "run-1");
+    expect(result).not.toBeNull();
+    expect(result!.run.id).toBe("run-1");
+    expect(result!.responses).toHaveLength(2);
+
+    const [first, second] = result!.responses;
+    expect(first).toMatchObject({
+      id: "resp-1",
+      prompt_text: "best crm for startups",
+      response_text: "Credal is a strong option…",
+    });
+    expect(first.sources).toEqual([
+      {
+        url: "https://credal.ai/blog/post",
+        domain: "credal.ai",
+        title: "Post",
+        snippet: "…",
+        is_owned: true,
+      },
+    ]);
+    expect(first.mentions).toEqual([
+      {
+        entity_type: "brand",
+        entity_name: "Credal",
+        mention_count: 1,
+        first_position: 0.1,
+        sentiment: "positive",
+        recommended: false,
+      },
+    ]);
+    expect(second).toMatchObject({ prompt_text: null, sources: [], mentions: [] });
   });
 });

--- a/lib/api-service.ts
+++ b/lib/api-service.ts
@@ -1,5 +1,13 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
-import type { Mention, Project, Run } from "@/lib/types";
+import type {
+  Mention,
+  Project,
+  Prompt,
+  Provider,
+  Response,
+  Run,
+  Source,
+} from "@/lib/types";
 import {
   computeEntityStats,
   computeRunSummary,
@@ -7,8 +15,8 @@ import {
   type RunSummary,
 } from "@/lib/metrics";
 import { executeRun, type RunResult } from "@/lib/engine";
-import { resolveRunKey } from "@/lib/trial";
-import { PROVIDERS } from "@/lib/models";
+import { pickDefaultProvider, resolveKey, resolveRunKey } from "@/lib/trial";
+import { defaultModelFor, isProvider, PROVIDERS } from "@/lib/models";
 
 // Operations behind the programmatic surface, shared by the REST v1 routes and
 // the MCP tools so the two can't drift apart. Callers authenticate with a
@@ -44,6 +52,306 @@ export async function getOwnedProject(
     .eq("user_id", userId)
     .maybeSingle();
   return (data as Project | null) ?? null;
+}
+
+function toAliases(value: unknown): string[] {
+  const parts =
+    Array.isArray(value)
+      ? value
+      : typeof value === "string"
+        ? value.split(",")
+        : [];
+  return parts
+    .map((p) => (typeof p === "string" ? p.trim() : ""))
+    .filter((p) => p.length > 0);
+}
+
+function toNullableString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export type CreateProjectOutcome =
+  | { ok: true; project: Project }
+  | { ok: false; code: "invalid"; message: string };
+
+/**
+ * Create a project (organization) for the user. Mirrors the dashboard's
+ * insert (app/api/project/route.ts): provider/model are chosen automatically
+ * unless explicitly sent, aliases default empty. Schedule always starts "off":
+ * API callers orchestrate their own cadence and trigger runs explicitly.
+ */
+export async function createProject(
+  supabase: SupabaseClient,
+  userId: string,
+  input: Record<string, unknown>,
+): Promise<CreateProjectOutcome> {
+  const name = typeof input.name === "string" ? input.name.trim() : "";
+  const brand_name =
+    typeof input.brand_name === "string" ? input.brand_name.trim() : "";
+
+  if (!name) {
+    return { ok: false, code: "invalid", message: "A project name is required." };
+  }
+  if (!brand_name) {
+    return { ok: false, code: "invalid", message: "A brand name is required." };
+  }
+
+  if (
+    typeof input.default_provider === "string" &&
+    !isProvider(input.default_provider)
+  ) {
+    return {
+      ok: false,
+      code: "invalid",
+      message: `Unknown provider "${input.default_provider}". Use one of: ${Object.keys(PROVIDERS).join(", ")}.`,
+    };
+  }
+  const provider: Provider =
+    typeof input.default_provider === "string" && isProvider(input.default_provider)
+      ? input.default_provider
+      : pickDefaultProvider();
+  const model =
+    typeof input.default_model === "string" && input.default_model.trim().length > 0
+      ? input.default_model.trim()
+      : defaultModelFor(provider);
+
+  // `user_id` comes from the authenticated key, never the body: the insert is
+  // what ties the new project to the caller on the service-role client.
+  const { data, error } = await supabase
+    .from("projects")
+    .insert({
+      name,
+      brand_name,
+      brand_aliases: toAliases(input.brand_aliases),
+      brand_domain: toNullableString(input.brand_domain),
+      description: toNullableString(input.description),
+      default_provider: provider,
+      default_model: model,
+      schedule: "off",
+      ...(typeof input.use_web_search === "boolean"
+        ? { use_web_search: input.use_web_search }
+        : {}),
+      user_id: userId,
+    })
+    .select("*")
+    .single();
+
+  if (error || !data) throw error ?? new Error("Failed to create project.");
+  return { ok: true, project: data as Project };
+}
+
+/** A prompt row trimmed to what the API exposes, with its topic's name. */
+export interface PromptSummary {
+  id: string;
+  text: string;
+  topic: string | null;
+  source: Prompt["source"];
+  is_active: boolean;
+  created_at: string;
+}
+
+/** The name off a joined `topics(name)` embed (object or array per cardinality). */
+function embeddedTopicName(value: unknown): string | null {
+  const t = value as { name?: string } | { name?: string }[] | null;
+  const row = Array.isArray(t) ? t[0] : t;
+  return row?.name ?? null;
+}
+
+/** A project's prompts with their topic names. Null when not the user's. */
+export async function listProjectPrompts(
+  supabase: SupabaseClient,
+  userId: string,
+  projectId: string,
+): Promise<PromptSummary[] | null> {
+  const project = await getOwnedProject(supabase, userId, projectId);
+  if (!project) return null;
+  const { data } = await supabase
+    .from("prompts")
+    .select("id, text, source, is_active, created_at, topics(name)")
+    .eq("project_id", projectId)
+    .order("created_at", { ascending: true });
+  return ((data ?? []) as Record<string, unknown>[]).map((row) => ({
+    id: row.id as string,
+    text: row.text as string,
+    topic: embeddedTopicName(row.topics),
+    source: row.source as Prompt["source"],
+    is_active: row.is_active as boolean,
+    created_at: row.created_at as string,
+  }));
+}
+
+export type CreatePromptsOutcome =
+  | { ok: true; created: PromptSummary[]; skipped: number }
+  | { ok: false; code: "not_found" | "invalid"; message: string };
+
+/**
+ * Bulk-add prompts to a project. Each entry names its topic; topics are
+ * get-or-created per distinct name (case-insensitive against the project's
+ * existing topics) since prompts.topic_id is NOT NULL. Prompts whose text the
+ * project already has (case-insensitive, including repeats within the batch)
+ * are skipped, so callers can re-push their full set idempotently.
+ */
+export async function createPrompts(
+  supabase: SupabaseClient,
+  userId: string,
+  projectId: string,
+  entries: unknown,
+): Promise<CreatePromptsOutcome> {
+  const project = await getOwnedProject(supabase, userId, projectId);
+  if (!project) {
+    return { ok: false, code: "not_found", message: "Project not found." };
+  }
+
+  if (!Array.isArray(entries) || entries.length === 0) {
+    return {
+      ok: false,
+      code: "invalid",
+      message: "prompts must be a non-empty array of { text, topic }.",
+    };
+  }
+  const parsed: { text: string; topic: string }[] = [];
+  const bad: number[] = [];
+  entries.forEach((entry, i) => {
+    const e = (entry ?? {}) as Record<string, unknown>;
+    const text = typeof e.text === "string" ? e.text.trim() : "";
+    const topic = typeof e.topic === "string" ? e.topic.trim() : "";
+    if (!text || !topic) bad.push(i);
+    else parsed.push({ text, topic });
+  });
+  if (bad.length > 0) {
+    return {
+      ok: false,
+      code: "invalid",
+      message: `Every prompt needs a non-empty text and topic (bad ${bad.length === 1 ? "entry at index" : "entries at indexes"} ${bad.join(", ")}).`,
+    };
+  }
+
+  // The project is ownership-checked above; children scope by its id.
+  const [{ data: topicRows }, { data: promptRows }] = await Promise.all([
+    supabase.from("topics").select("id, name").eq("project_id", projectId),
+    supabase.from("prompts").select("text").eq("project_id", projectId),
+  ]);
+
+  const topicIdByKey = new Map<string, string>();
+  const topicNameById = new Map<string, string>();
+  for (const t of (topicRows ?? []) as { id: string; name: string }[]) {
+    topicIdByKey.set(t.name.trim().toLowerCase(), t.id);
+    topicNameById.set(t.id, t.name);
+  }
+
+  const seenTexts = new Set(
+    ((promptRows ?? []) as { text: string }[]).map((r) => r.text.trim().toLowerCase()),
+  );
+  const toInsert: { text: string; topic: string }[] = [];
+  let skipped = 0;
+  for (const e of parsed) {
+    const key = e.text.toLowerCase();
+    if (seenTexts.has(key)) {
+      skipped += 1;
+      continue;
+    }
+    seenTexts.add(key);
+    toInsert.push(e);
+  }
+  if (toInsert.length === 0) return { ok: true, created: [], skipped };
+
+  // Create the topic names this batch introduces (first spelling wins).
+  const newNames = toInsert
+    .filter((e, i, all) => {
+      const key = e.topic.toLowerCase();
+      return (
+        !topicIdByKey.has(key) &&
+        all.findIndex((o) => o.topic.toLowerCase() === key) === i
+      );
+    })
+    .map((e) => e.topic);
+  if (newNames.length > 0) {
+    const { data: createdTopics, error } = await supabase
+      .from("topics")
+      .insert(newNames.map((name) => ({ project_id: projectId, name })))
+      .select("id, name");
+    if (error || !createdTopics) throw error ?? new Error("Failed to create topics.");
+    for (const t of createdTopics as { id: string; name: string }[]) {
+      topicIdByKey.set(t.name.trim().toLowerCase(), t.id);
+      topicNameById.set(t.id, t.name);
+    }
+  }
+
+  const { data: createdRows, error: insertError } = await supabase
+    .from("prompts")
+    .insert(
+      toInsert.map((e) => ({
+        project_id: projectId,
+        topic_id: topicIdByKey.get(e.topic.toLowerCase())!,
+        text: e.text,
+        source: "manual",
+        is_active: true,
+      })),
+    )
+    .select("id, topic_id, text, source, is_active, created_at");
+  if (insertError || !createdRows) {
+    throw insertError ?? new Error("Failed to create prompts.");
+  }
+
+  return {
+    ok: true,
+    created: (createdRows as (PromptSummary & { topic_id: string })[]).map((r) => ({
+      id: r.id,
+      text: r.text,
+      topic: topicNameById.get(r.topic_id) ?? null,
+      source: r.source,
+      is_active: r.is_active,
+      created_at: r.created_at,
+    })),
+    skipped,
+  };
+}
+
+/**
+ * Toggle a prompt on or off. Ownership walks prompt -> project -> user, and
+ * the update itself re-scopes by project id: on the service-role client the
+ * explicit userId chain is the security boundary. Null when the prompt
+ * doesn't exist or isn't the user's.
+ */
+export async function setPromptActive(
+  supabase: SupabaseClient,
+  userId: string,
+  promptId: string,
+  isActive: boolean,
+): Promise<PromptSummary | null> {
+  const { data: promptRow } = await supabase
+    .from("prompts")
+    .select("id, project_id, text, source, is_active, created_at, topics(name)")
+    .eq("id", promptId)
+    .maybeSingle();
+  const prompt = promptRow as
+    | (Pick<
+        Prompt,
+        "id" | "project_id" | "text" | "source" | "is_active" | "created_at"
+      > & { topics: unknown })
+    | null;
+  if (!prompt) return null;
+
+  const project = await getOwnedProject(supabase, userId, prompt.project_id);
+  if (!project) return null;
+
+  const { error } = await supabase
+    .from("prompts")
+    .update({ is_active: isActive })
+    .eq("id", promptId)
+    .eq("project_id", project.id);
+  if (error) throw error;
+
+  return {
+    id: prompt.id,
+    text: prompt.text,
+    topic: embeddedTopicName(prompt.topics),
+    source: prompt.source,
+    is_active: isActive,
+    created_at: prompt.created_at,
+  };
 }
 
 /** Recent runs for a project. Null when the project isn't the user's. */
@@ -121,6 +429,114 @@ export async function getRunReport(
   };
 }
 
+/** One response's raw artifacts: the model's text plus what it cited and mentioned. */
+export interface ResponseArtifact {
+  id: string;
+  prompt_id: string | null;
+  prompt_text: string | null;
+  provider: Provider;
+  model: string;
+  response_text: string;
+  sources: Pick<Source, "url" | "domain" | "title" | "snippet" | "is_owned">[];
+  mentions: Pick<
+    Mention,
+    | "entity_type"
+    | "entity_name"
+    | "mention_count"
+    | "first_position"
+    | "sentiment"
+    | "recommended"
+  >[];
+}
+
+export interface RunResponses {
+  run: Run;
+  responses: ResponseArtifact[];
+}
+
+/**
+ * The raw artifacts of one run: every response's full text with the exact
+ * cited source URLs and detected mentions, for callers that do their own
+ * downstream analysis (the aggregate view stays in getRunReport). Ownership
+ * is checked the same way: run -> project -> user. Null when the run doesn't
+ * exist or isn't the user's.
+ */
+export async function getRunResponses(
+  supabase: SupabaseClient,
+  userId: string,
+  runId: string,
+): Promise<RunResponses | null> {
+  const { data: runRow } = await supabase
+    .from("runs")
+    .select("*")
+    .eq("id", runId)
+    .maybeSingle();
+  const run = runRow as Run | null;
+  if (!run) return null;
+
+  const project = await getOwnedProject(supabase, userId, run.project_id);
+  if (!project) return null;
+
+  const [
+    { data: responseRows },
+    { data: sourceRows },
+    { data: mentionRows },
+    { data: promptRows },
+  ] = await Promise.all([
+    supabase
+      .from("responses")
+      .select("*")
+      .eq("run_id", runId)
+      .order("created_at", { ascending: true }),
+    supabase.from("sources").select("*").eq("run_id", runId),
+    supabase.from("mentions").select("*").eq("run_id", runId),
+    supabase.from("prompts").select("id, text").eq("project_id", run.project_id),
+  ]);
+
+  const promptTextById = new Map(
+    ((promptRows ?? []) as Pick<Prompt, "id" | "text">[]).map((p) => [p.id, p.text]),
+  );
+  const sourcesByResponse = new Map<string, Source[]>();
+  for (const s of (sourceRows ?? []) as Source[]) {
+    const list = sourcesByResponse.get(s.response_id) ?? [];
+    list.push(s);
+    sourcesByResponse.set(s.response_id, list);
+  }
+  const mentionsByResponse = new Map<string, Mention[]>();
+  for (const m of (mentionRows ?? []) as Mention[]) {
+    const list = mentionsByResponse.get(m.response_id) ?? [];
+    list.push(m);
+    mentionsByResponse.set(m.response_id, list);
+  }
+
+  return {
+    run,
+    responses: ((responseRows ?? []) as Response[]).map((r) => ({
+      id: r.id,
+      prompt_id: r.prompt_id,
+      prompt_text: r.prompt_id ? promptTextById.get(r.prompt_id) ?? null : null,
+      provider: r.provider,
+      model: r.model,
+      response_text: r.response_text,
+      sources: (sourcesByResponse.get(r.id) ?? []).map((s) => ({
+        url: s.url,
+        domain: s.domain,
+        title: s.title,
+        snippet: s.snippet,
+        is_owned: s.is_owned,
+      })),
+      mentions: (mentionsByResponse.get(r.id) ?? []).map((m) => ({
+        entity_type: m.entity_type,
+        entity_name: m.entity_name,
+        mention_count: m.mention_count,
+        first_position: m.first_position,
+        sentiment: m.sentiment,
+        recommended: m.recommended,
+      })),
+    })),
+  };
+}
+
 export type TriggerOutcome =
   | { ok: true; result: RunResult }
   | { ok: false; code: "not_found" | "no_key"; message: string };
@@ -137,15 +553,28 @@ export async function triggerRunForProject(
   supabase: SupabaseClient,
   userId: string,
   projectId: string,
+  options?: { provider?: Provider; model?: string },
 ): Promise<TriggerOutcome> {
   const project = await getOwnedProject(supabase, userId, projectId);
   if (!project) {
     return { ok: false, code: "not_found", message: "Project not found." };
   }
 
-  const key = await resolveRunKey(supabase, userId, project);
+  // A caller-sent provider/model overrides the project default for this run
+  // only (the project row is untouched); key resolution still prefers the
+  // requested provider and falls back like the dashboard does.
+  const key =
+    options?.provider || options?.model
+      ? await resolveKey(
+          supabase,
+          userId,
+          options.provider ?? project.default_provider,
+          options.model,
+        )
+      : await resolveRunKey(supabase, userId, project);
   if (key.source !== "own") {
-    const providerLabel = PROVIDERS[project.default_provider].label;
+    const providerLabel =
+      PROVIDERS[options?.provider ?? project.default_provider].label;
     return {
       ok: false,
       code: "no_key",


### PR DESCRIPTION
## Motivation

Letterbrace is integrating Lettertrace as its GEO execution engine through the v1 REST API. The current surface (merged in #7) is read-plus-run-trigger with aggregate reports only. To drive Lettertrace fully programmatically, an integrator needs to:

- create one project per site it manages,
- push its own topic-derived prompts (instead of the AI-generated ones),
- trigger runs per provider,
- and pull the **raw** run artifacts — full response texts and the exact cited source URLs — because it does its own citation-to-page matching, mention-context extraction, and evidence building downstream.

This PR adds that write/read surface, following the existing patterns: ops live in `lib/api-service.ts` (shared seam), routes stay thin (`authenticateApiKey` → op → JSON with the same 401/404/402 conventions).

## Endpoints

**POST `/api/v1/projects`** — create an organization for the caller.
Body: `{ name, brand_name, brand_aliases?, brand_domain?, description?, default_provider?, default_model?, use_web_search? }`. Mirrors the dashboard's insert shape and defaults (auto-picked provider, `defaultModelFor` model, aliases `[]`, web search on). `schedule` always starts `"off"`: API callers orchestrate their own cadence and trigger runs explicitly. Returns `201 { project: <projectSummary> }`; `400` on missing name/brand or an unknown provider.

**GET `/api/v1/projects/:id/prompts`** — the project's prompts with their topic name: `{ prompts: [{ id, text, topic, source, is_active, created_at }] }`. `404` when the project isn't the caller's.

**POST `/api/v1/projects/:id/prompts`** — bulk add. Body: `{ prompts: [{ text, topic }] }` where `topic` is a topic *name*; topics are get-or-created per distinct name (case-insensitive against the project's existing topics — `prompts.topic_id` is NOT NULL so every prompt gets one). Entries with empty text/topic → `400` naming the offending indexes. Texts the project already has (case-insensitive, including repeats within the batch) are skipped so callers can re-push their full set idempotently. Returns `201 { created: [...], skipped: n }`; created prompts get `source: "manual"`.

**PATCH `/api/v1/prompts/:id`** — body `{ is_active: boolean }`. Ownership walks prompt → project → user; `404` otherwise. Returns `200 { prompt: {...} }`.

**GET `/api/v1/runs/:id/responses`** — the raw artifacts of one run: `{ run, responses: [{ id, prompt_id, prompt_text, provider, model, response_text, sources: [{ url, domain, title, snippet, is_owned }], mentions: [{ entity_type, entity_name, mention_count, first_position, sentiment, recommended }] }] }`. Ownership checked like `getRunReport` (run → project → user); child rows are kept lean (no per-row timestamps/ids beyond what's useful).

**POST `/api/v1/projects/:id/runs`** — now accepts an optional JSON body `{ provider?, model? }` to override the project default for that run only. Unknown provider → `400`. The key is resolved with `resolveKey(supabase, userId, provider, model)` (same fallback semantics as the dashboard) instead of `resolveRunKey`. An absent or empty body keeps today's behavior exactly, and the BYOK-only rule is unchanged.

## Security: userId scoping

These routes run on the **service-role client** (API-key auth carries no Supabase session), so RLS is bypassed and explicit `userId` scoping is the security boundary. Every new op scopes through the project chain: `getOwnedProject(supabase, userId, projectId)` gates each operation, child reads/writes filter by the ownership-checked project id, `createProject` ties `user_id` to the authenticated key (never the body), and `setPromptActive`'s update re-scopes by both prompt id and project id. The ownership tests assert the recorded query filters, same as the existing suite.

## Tests

- `lib/api-service.test.ts`: new op coverage on the existing fake query-builder (extended with `insert`/`update`/`single`) — insert shapes/defaults, topic get-or-create + dedupe, ownership failures, artifact grouping, provider-override key resolution.
- `app/api/v1/v1-routes.test.ts`: status-code mapping and op wiring for all new/changed routes, including "no body keeps defaults" and "unknown provider → 400 without touching the op".
- `npx vitest run`: 74/74 passing; `npx tsc --noEmit` clean.

## Follow-up

MCP parity for the new ops (create project / push prompts / raw responses as MCP tools) is intentionally left out to keep this PR tight; the ops all live in `lib/api-service.ts`, so the follow-up is registration-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)