### PR TITLE
Run sentiment classification on the cheap model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,13 @@ TRIAL_OPENAI_MODEL=gpt-4o-mini
 # bring-your-own-key model, shown when a user's free runs are used up.
 NEXT_PUBLIC_BYOK_VIDEO_URL=
 
+# Optional: which model classifies sentiment/recommendations after each answer.
+# Always defaults to the provider's cheap model (claude-haiku-4-5 /
+# gpt-4o-mini) regardless of the answer model — classification is a simple
+# structured judgment and doesn't benefit from a flagship model.
+ANALYSIS_ANTHROPIC_MODEL=
+ANALYSIS_OPENAI_MODEL=
+
 # ------------------------------------------------------------------
 # NOTE: This app is Bring-Your-Own-Key (BYOK). Users add their own
 # Anthropic / OpenAI API keys inside the app (Settings). You do NOT

--- a/lib/llm/index.ts
+++ b/lib/llm/index.ts
@@ -1,6 +1,7 @@
 import Anthropic from "@anthropic-ai/sdk";
 import OpenAI from "openai";
 import type { Provider, Sentiment } from "@/lib/types";
+import { analysisModelFor } from "@/lib/models";
 
 // ------------------------------------------------------------------
 // Provider adapters. Every call here uses the *user's own* API key (BYOK).
@@ -387,11 +388,15 @@ ${entityList}
 
 Return a JSON object: { "results": [ { "key": "<key>", "sentiment": "positive|neutral|negative", "recommended": true|false } ] } with one entry per entity.`;
 
+  // Classification always runs on the cheap model, regardless of which model
+  // answered the question — see analysisModelFor.
+  const analysisModel = analysisModelFor(opts.provider);
+
   try {
     const res =
       opts.provider === "anthropic"
-        ? await anthropicChat(opts.apiKey, opts.model, ANALYZE_SYSTEM, user, 700)
-        : await openaiChat(opts.apiKey, opts.model, ANALYZE_SYSTEM, user, 700, true);
+        ? await anthropicChat(opts.apiKey, analysisModel, ANALYZE_SYSTEM, user, 700)
+        : await openaiChat(opts.apiKey, analysisModel, ANALYZE_SYSTEM, user, 700, true);
 
     let parsed: unknown = extractJson(res.text);
     if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {

--- a/lib/models.test.ts
+++ b/lib/models.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { analysisModelFor, defaultModelFor, isProvider } from "@/lib/models";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("analysisModelFor", () => {
+  it("defaults to the cheap model for each provider", () => {
+    expect(analysisModelFor("anthropic")).toBe("claude-haiku-4-5");
+    expect(analysisModelFor("openai")).toBe("gpt-4o-mini");
+  });
+
+  it("never returns the flagship answer models", () => {
+    expect(analysisModelFor("anthropic")).not.toBe(defaultModelFor("anthropic"));
+    expect(analysisModelFor("openai")).not.toBe(defaultModelFor("openai"));
+  });
+
+  it("honors per-provider env overrides", () => {
+    vi.stubEnv("ANALYSIS_ANTHROPIC_MODEL", "claude-sonnet-4-6");
+    vi.stubEnv("ANALYSIS_OPENAI_MODEL", " gpt-4o ");
+    expect(analysisModelFor("anthropic")).toBe("claude-sonnet-4-6");
+    expect(analysisModelFor("openai")).toBe("gpt-4o"); // trimmed
+  });
+
+  it("ignores blank overrides", () => {
+    vi.stubEnv("ANALYSIS_ANTHROPIC_MODEL", "   ");
+    expect(analysisModelFor("anthropic")).toBe("claude-haiku-4-5");
+  });
+});
+
+describe("isProvider", () => {
+  it("accepts only known providers", () => {
+    expect(isProvider("anthropic")).toBe(true);
+    expect(isProvider("openai")).toBe(true);
+    expect(isProvider("gemini")).toBe(false);
+  });
+});

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -53,6 +53,18 @@ export function defaultModelFor(provider: Provider): string {
   return PROVIDERS[provider].models[0].id;
 }
 
+// Sentiment/recommendation enrichment is a simple structured-JSON judgment;
+// running it on the flagship answer model multiplies run cost for no quality
+// gain. Always classify on the provider's cheap model (overridable via env).
+export function analysisModelFor(provider: Provider): string {
+  const override =
+    provider === "anthropic"
+      ? process.env.ANALYSIS_ANTHROPIC_MODEL
+      : process.env.ANALYSIS_OPENAI_MODEL;
+  if (override && override.trim()) return override.trim();
+  return provider === "anthropic" ? "claude-haiku-4-5" : "gpt-4o-mini";
+}
+
 export function modelLabel(provider: Provider, modelId: string): string {
   const found = PROVIDERS[provider]?.models.find((m) => m.id === modelId);
   return found?.label ?? modelId;


### PR DESCRIPTION
## What

`analyzeResponse` — the per-entity sentiment + "recommended" judgment that runs after every monitored answer — was using the same flagship model that produced the answer. It's a simple structured-JSON classification; a flagship model adds cost, not quality.

It now **always classifies on the provider's cheap model**: `claude-haiku-4-5` (Anthropic) / `gpt-4o-mini` (OpenAI), regardless of the answer model. Overridable via `ANALYSIS_ANTHROPIC_MODEL` / `ANALYSIS_OPENAI_MODEL` (documented in `.env.example`).

## Why it matters

- One classification call runs per response with detected entities, on **every** monitoring run.
- Biggest saving is on **trial runs billed to Letterspade's shared keys** (the trial model override already capped the answer calls; classification was the leak).
- From the kickoff cost-control list — item: "sentiment enrichment still runs on the full model".

## Notes

- Answer quality is untouched: the monitored question is still answered by the user's selected model — that IS the product measurement. Only the post-hoc judgment moved.
- `generateVariations` and onboarding suggestions still use the selected model (creative tasks, low volume).
- Tests: `lib/models.test.ts` covers defaults, env overrides, and that analysis never resolves to a flagship model. Suite: 49 passing; typecheck/lint/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)