### PR TITLE
Support multiple brand domains per project (Phantomsites)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ curl https://your-app.com/api/v1/projects \
   -H "Authorization: Bearer lt_live_..."
 curl -X POST https://your-app.com/api/v1/projects \
   -H "Authorization: Bearer lt_live_..." -H "Content-Type: application/json" \
-  -d '{"name": "Acme", "brand_name": "Acme", "brand_domain": "acme.io"}'
+  -d '{"name": "Acme", "brand_name": "Acme", "brand_domains": ["acme.io"]}'
 
 # A project's prompts / bulk-add prompts (topics are get-or-created by name)
 curl https://your-app.com/api/v1/projects/<project-id>/prompts \

--- a/app/api/competitors/suggest/route.ts
+++ b/app/api/competitors/suggest/route.ts
@@ -56,7 +56,7 @@ export async function POST() {
       model: key.model,
       apiKey: key.apiKey!,
       brandName: project.brand_name,
-      brandDomain: project.brand_domain,
+      brandDomain: project.brand_domains[0] ?? null,
       description: project.description,
       topics,
       existing,

--- a/app/api/onboarding/complete/route.ts
+++ b/app/api/onboarding/complete/route.ts
@@ -52,10 +52,8 @@ export async function POST(request: Request) {
   }
   const name =
     typeof body.name === "string" && body.name.trim() ? body.name.trim() : brand_name;
-  const brand_domain =
-    typeof body.brand_domain === "string" && body.brand_domain.trim()
-      ? body.brand_domain.trim()
-      : null;
+  // First entry = primary domain; the rest are phantom sites for the brand.
+  const brand_domains = toStringArray(body.brand_domains);
   const description =
     typeof body.description === "string" && body.description.trim()
       ? body.description.trim()
@@ -84,7 +82,7 @@ export async function POST(request: Request) {
       name,
       brand_name,
       brand_aliases,
-      brand_domain,
+      brand_domains,
       description,
       default_provider: provider,
       default_model: model,

--- a/app/api/project/route.ts
+++ b/app/api/project/route.ts
@@ -26,6 +26,18 @@ function toNullableString(value: unknown): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
+// Brand domains, first = primary. Accepts an array or a comma-separated
+// string; deduped case-insensitively, order preserved.
+function toDomains(value: unknown): string[] {
+  const seen = new Set<string>();
+  return toAliases(value).filter((d) => {
+    const key = d.toLowerCase();
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
 export async function POST(request: Request) {
   const supabase = createClient();
   const {
@@ -80,7 +92,7 @@ export async function POST(request: Request) {
     name,
     brand_name,
     brand_aliases: toAliases(b.brand_aliases),
-    brand_domain: toNullableString(b.brand_domain),
+    brand_domains: toDomains(b.brand_domains),
     description: toNullableString(b.description),
     schedule,
     ...(typeof b.use_web_search === "boolean" ? { use_web_search: b.use_web_search } : {}),

--- a/app/api/v1/projects/route.ts
+++ b/app/api/v1/projects/route.ts
@@ -24,7 +24,7 @@ export async function GET(request: Request) {
 }
 
 // POST /api/v1/projects — create an organization for the caller.
-// Body: { name, brand_name, brand_aliases?, brand_domain?, description?,
+// Body: { name, brand_name, brand_aliases?, brand_domains?, description?,
 //         default_provider?, default_model?, use_web_search? }
 export async function POST(request: Request) {
   const auth = await authenticateApiKey(

--- a/app/dashboard/onboarding.tsx
+++ b/app/dashboard/onboarding.tsx
@@ -139,7 +139,7 @@ export function Onboarding() {
         body: JSON.stringify({
           brand_name: brandName.trim(),
           name: brandName.trim(),
-          brand_domain: domain.trim() || null,
+          brand_domains: domain.trim() ? [domain.trim()] : [],
           description: description.trim() || null,
           topics: cleaned,
         }),

--- a/app/dashboard/settings/project-form.tsx
+++ b/app/dashboard/settings/project-form.tsx
@@ -20,7 +20,9 @@ export default function ProjectForm({ project }: { project: Project | null }) {
   const [brandAliases, setBrandAliases] = useState(
     (project?.brand_aliases ?? []).join(", "),
   );
-  const [brandDomain, setBrandDomain] = useState(project?.brand_domain ?? "");
+  const [brandDomains, setBrandDomains] = useState(
+    (project?.brand_domains ?? []).join(", "),
+  );
   const [description, setDescription] = useState(project?.description ?? "");
   const [schedule, setSchedule] = useState<Schedule>(project?.schedule ?? "off");
   const [useWebSearch, setUseWebSearch] = useState(project?.use_web_search ?? true);
@@ -47,7 +49,7 @@ export default function ProjectForm({ project }: { project: Project | null }) {
           name,
           brand_name: brandName,
           brand_aliases: aliases,
-          brand_domain: brandDomain,
+          brand_domains: brandDomains,
           description,
           schedule,
           use_web_search: useWebSearch,
@@ -116,16 +118,20 @@ export default function ProjectForm({ project }: { project: Project | null }) {
 
       <div className="grid gap-4 sm:grid-cols-2">
         <div>
-          <Label htmlFor="p-domain">Brand domain</Label>
+          <Label htmlFor="p-domains">Brand domains</Label>
           <Input
-            id="p-domain"
-            value={brandDomain}
+            id="p-domains"
+            value={brandDomains}
             onChange={(e) => {
-              setBrandDomain(e.target.value);
+              setBrandDomains(e.target.value);
               setSaved(false);
             }}
-            placeholder="acme.com"
+            placeholder="acme.com, acme-guides.com"
           />
+          <p className="mt-1.5 text-xs text-ink-faint">
+            Comma-separated, main domain first. Sources cited from any of these
+            count as yours — include phantom sites for this brand.
+          </p>
         </div>
         <div>
           <Label htmlFor="p-schedule">Monitoring schedule</Label>

--- a/lib/api-service.test.ts
+++ b/lib/api-service.test.ts
@@ -88,7 +88,7 @@ const PROJECT: Project = {
   name: "Credal",
   brand_name: "Credal",
   brand_aliases: [],
-  brand_domain: "credal.ai",
+  brand_domains: ["credal.ai"],
   description: null,
   default_provider: "anthropic",
   default_model: "claude-sonnet-4-6",
@@ -401,7 +401,7 @@ describe("createProject", () => {
       name: "Acme",
       brand_name: "Acme",
       brand_aliases: [],
-      brand_domain: null,
+      brand_domains: [],
       description: null,
       default_provider: "anthropic",
       default_model: "claude-opus-4-8", // defaultModelFor("anthropic")
@@ -416,14 +416,15 @@ describe("createProject", () => {
       name: "Acme",
       brand_name: "Acme",
       brand_aliases: ["Acme Inc", " acme.io "],
-      brand_domain: "acme.io",
+      brand_domains: ["acme.io", " acme-guides.io ", "ACME.io"],
       default_provider: "openai",
       default_model: "gpt-4o-mini",
       use_web_search: false,
     });
     expect(insertedValues(db, "projects")).toMatchObject({
       brand_aliases: ["Acme Inc", "acme.io"],
-      brand_domain: "acme.io",
+      // Trimmed and deduped case-insensitively, primary first.
+      brand_domains: ["acme.io", "acme-guides.io"],
       default_provider: "openai",
       default_model: "gpt-4o-mini",
       use_web_search: false,

--- a/lib/api-service.ts
+++ b/lib/api-service.ts
@@ -29,7 +29,7 @@ export function projectSummary(p: Project) {
     id: p.id,
     name: p.name,
     brand_name: p.brand_name,
-    brand_domain: p.brand_domain,
+    brand_domains: p.brand_domains,
     default_provider: p.default_provider,
     default_model: p.default_model,
     schedule: p.schedule,
@@ -70,6 +70,18 @@ function toNullableString(value: unknown): string | null {
   if (typeof value !== "string") return null;
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : null;
+}
+
+// Brand domains, first = primary. Accepts an array or a comma-separated
+// string; deduped case-insensitively, order preserved.
+function toDomains(value: unknown): string[] {
+  const seen = new Set<string>();
+  return toAliases(value).filter((d) => {
+    const key = d.toLowerCase();
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
 }
 
 export type CreateProjectOutcome =
@@ -125,7 +137,7 @@ export async function createProject(
       name,
       brand_name,
       brand_aliases: toAliases(input.brand_aliases),
-      brand_domain: toNullableString(input.brand_domain),
+      brand_domains: toDomains(input.brand_domains),
       description: toNullableString(input.description),
       default_provider: provider,
       default_model: model,

--- a/lib/engine.test.ts
+++ b/lib/engine.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { hostOf, isOwnedDomain } from "@/lib/engine";
 
 describe("hostOf", () => {
-  it("normalizes a messy brand_domain to a registrable host", () => {
+  it("normalizes a messy domain entry to a registrable host", () => {
     expect(hostOf("https://www.notion.so/pricing")).toBe("notion.so");
     expect(hostOf("Notion.so")).toBe("notion.so");
     expect(hostOf("http://acme.co.uk/path?x=1")).toBe("acme.co.uk");

--- a/lib/engine.ts
+++ b/lib/engine.ts
@@ -6,7 +6,7 @@ import { detectMention, brandTerms } from "@/lib/mentions";
 // Run at most this many queries at once to stay under provider rate limits.
 const CONCURRENCY = 4;
 
-// The brand's registrable web host, e.g. "notion.so" from a messy brand_domain.
+// The brand's registrable web host, e.g. "notion.so" from a messy domain entry.
 export function hostOf(domain: string | null): string {
   if (!domain) return "";
   return domain
@@ -102,9 +102,11 @@ export async function executeRun(params: {
     return { runId, status: "completed", totalResponses: 0, tokensUsed: 0 };
   }
 
-  const bTerms = brandTerms(project.brand_name, project.brand_aliases, project.brand_domain);
-  // The brand's own web host, for flagging cited sources as "yours".
-  const ownedHost = hostOf(project.brand_domain);
+  // Mention terms derive from the PRIMARY domain only: phantom-site names
+  // aren't the brand name, so they shouldn't count as brand mentions.
+  const bTerms = brandTerms(project.brand_name, project.brand_aliases, project.brand_domains[0] ?? null);
+  // Every domain (main + phantoms) counts when flagging cited sources as "yours".
+  const ownedHosts = project.brand_domains.map(hostOf).filter(Boolean);
   let processed = 0; // prompts attempted (success or failure)
   let succeeded = 0; // answers actually stored
   let tokensUsed = 0; // total provider tokens consumed (for trial metering)
@@ -149,7 +151,7 @@ export async function executeRun(params: {
           domain: s.domain,
           title: s.title,
           snippet: s.snippet,
-          is_owned: isOwnedDomain(s.domain, ownedHost),
+          is_owned: ownedHosts.some((h) => isOwnedDomain(s.domain, h)),
         }));
         await supabase.from("sources").insert(sourceRows);
       }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -54,7 +54,8 @@ export interface Project {
   name: string;
   brand_name: string;
   brand_aliases: string[];
-  brand_domain: string | null;
+  /** All domains for the brand; index 0 is the primary (main TLD), the rest are phantom sites. */
+  brand_domains: string[];
   description: string | null;
   default_provider: Provider;
   default_model: string;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -104,7 +104,7 @@ create table if not exists public.projects (
   name text not null,
   brand_name text not null,
   brand_aliases text[] not null default '{}',
-  brand_domain text,
+  brand_domains text[] not null default '{}',
   description text,
   default_provider text not null default 'anthropic' check (default_provider in ('anthropic', 'openai')),
   default_model text not null default 'claude-sonnet-4-6',
@@ -118,6 +118,29 @@ create table if not exists public.projects (
 -- sources they cite. Default on. Safe to re-run.
 alter table public.projects
   add column if not exists use_web_search boolean not null default true;
+
+-- Phantomsites: a brand can have several domains — the main site plus phantom
+-- sites that build rapport for the same brand. The first entry is the primary
+-- (main TLD); every entry counts for source ownership. Migrates the old single
+-- brand_domain into the array, then retires it. Safe to re-run.
+alter table public.projects
+  add column if not exists brand_domains text[] not null default '{}';
+do $$
+begin
+  if exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'projects'
+      and column_name = 'brand_domain'
+  ) then
+    update public.projects
+      set brand_domains = array[btrim(brand_domain)]
+      where brand_domain is not null
+        and btrim(brand_domain) <> ''
+        and brand_domains = '{}';
+    alter table public.projects drop column brand_domain;
+  end if;
+end $$;
 
 -- Multi-org: which of the user's projects (organizations) the dashboard is
 -- currently showing. Falls back to the earliest project when unset. Safe to


### PR DESCRIPTION
## What

Projects now model a brand's full web presence instead of a single domain. Each project carries three identity pieces: the **project name**, the **brand name** (what we're actually looking for in answers), and **`brand_domains`** — a list where the first entry is the main TLD and the rest are phantom sites that build rapport for the same brand.

## Why

With Phantomsites, one brand deliberately operates several domains. Citations from any of them are "ours", so ownership tracking has to cover the whole set, not just the main site.

## Changes

- **Schema**: `projects.brand_domain text` → `brand_domains text[] not null default '{}'`. Re-runnable migration backfills the old column into the array and drops it; fresh installs get the new shape directly. Re-run `supabase/schema.sql` after deploying.
- **Engine**: a cited source is `is_owned` when its domain matches (or is a subdomain of) *any* configured domain. Mention terms and competitor suggestions still derive from the primary domain only — phantom-site names aren't the brand name and shouldn't inflate mention counts.
- **API**: `POST /api/v1/projects` and the project summary (REST v1 + MCP) now use `brand_domains: string[]` (accepts an array or comma-separated string, deduped case-insensitively, order preserved). **Breaking** for anyone sending `brand_domain` — acceptable pre-launch.
- **UI**: settings form takes a comma-separated domain list (main domain first); onboarding still collects one website, stored as the primary.
- **Tests**: fixtures updated; `createProject` tests cover trim/dedupe of the domain list. 74 tests green, typecheck clean.

## Notes for reviewers

- Convention to preserve going forward: **index 0 = primary domain**. `brandTerms` and `suggestCompetitors` rely on it.
- `sources.domain` still records which domain was cited, so main-vs-phantom attribution stays possible in the dashboard later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
