### PR TITLE
Client pilot harness, and the three bugs it surfaced

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# pilot harness transcripts
+/.pilot/

--- a/app/api/competitors/route.ts
+++ b/app/api/competitors/route.ts
@@ -64,6 +64,14 @@ export async function POST(request: Request) {
       .single();
 
     if (error) {
+      // 23505 = the competitors_project_name_uniq index. Adding the same
+      // competitor twice is a user-visible conflict, not a server fault.
+      if (error.code === "23505") {
+        return NextResponse.json(
+          { error: `"${name}" is already tracked as a competitor.` },
+          { status: 409 },
+        );
+      }
       return NextResponse.json({ error: error.message }, { status: 500 });
     }
 

--- a/app/api/competitors/suggest/route.ts
+++ b/app/api/competitors/suggest/route.ts
@@ -75,7 +75,14 @@ export async function POST() {
         (n) => n.trim().toLowerCase(),
       ),
     );
-    const fresh = suggestions.filter((s) => !taken.has(s.name.trim().toLowerCase()));
+    // Adding as we go also collapses repeats *within* this batch, so a model
+    // that names the same competitor twice can't get two rows past the UI.
+    const fresh = suggestions.filter((s) => {
+      const name = s.name.trim().toLowerCase();
+      if (taken.has(name)) return false;
+      taken.add(name);
+      return true;
+    });
 
     return NextResponse.json({ suggestions: fresh });
   } catch (e) {

--- a/lib/llm/analysis.test.ts
+++ b/lib/llm/analysis.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import { parseAnalysis, type AnalyzeEntity } from "@/lib/llm";
+
+const entities: AnalyzeEntity[] = [
+  { key: "brand", name: "Cloudflare" },
+  { key: "c1f2e3d4-0000-4000-8000-000000000001", name: "Fastly" },
+];
+
+describe("parseAnalysis", () => {
+  it("resolves rows keyed by the key we supplied (Claude's shape)", () => {
+    const results = parseAnalysis(entities, {
+      results: [
+        { key: "brand", sentiment: "positive", recommended: true },
+        { key: "c1f2e3d4-0000-4000-8000-000000000001", sentiment: "neutral", recommended: false },
+      ],
+    });
+    expect(results).toEqual([
+      { key: "brand", sentiment: "positive", recommended: true },
+      { key: "c1f2e3d4-0000-4000-8000-000000000001", sentiment: "neutral", recommended: false },
+    ]);
+  });
+
+  // The regression this function exists for: gpt-4o-mini echoes the entity NAME
+  // in the `key` field, which used to drop every row and flatten OpenAI projects
+  // to neutral / not-recommended.
+  it("resolves rows keyed by entity name (gpt-4o-mini's shape)", () => {
+    const results = parseAnalysis(entities, {
+      results: [
+        { key: "Cloudflare", sentiment: "positive", recommended: true },
+        { key: "Fastly", sentiment: "negative", recommended: false },
+      ],
+    });
+    expect(results).toEqual([
+      { key: "brand", sentiment: "positive", recommended: true },
+      { key: "c1f2e3d4-0000-4000-8000-000000000001", sentiment: "negative", recommended: false },
+    ]);
+  });
+
+  it("matches names case- and whitespace-insensitively, and reads a `name` field", () => {
+    expect(parseAnalysis(entities, [{ name: "  cloudflare ", sentiment: "positive" }])).toEqual([
+      { key: "brand", sentiment: "positive", recommended: false },
+    ]);
+  });
+
+  it("accepts a bare array as well as a { results: [...] } wrapper", () => {
+    expect(parseAnalysis(entities, [{ key: "brand", sentiment: "negative" }])).toEqual([
+      { key: "brand", sentiment: "negative", recommended: false },
+    ]);
+  });
+
+  it("drops rows that match no requested entity rather than guessing", () => {
+    expect(
+      parseAnalysis(entities, {
+        results: [
+          { key: "Akamai", sentiment: "positive", recommended: true },
+          { key: "brand", sentiment: "positive", recommended: true },
+        ],
+      }),
+    ).toEqual([{ key: "brand", sentiment: "positive", recommended: true }]);
+  });
+
+  it("keeps only the first row per entity when the model repeats one", () => {
+    const results = parseAnalysis(entities, {
+      results: [
+        { key: "brand", sentiment: "positive", recommended: true },
+        { key: "Cloudflare", sentiment: "negative", recommended: false },
+      ],
+    });
+    expect(results).toEqual([{ key: "brand", sentiment: "positive", recommended: true }]);
+  });
+
+  it("prefers a key match over a name match when the two collide", () => {
+    // "Fastly" is both the second entity's name and the first entity's key.
+    const collide: AnalyzeEntity[] = [
+      { key: "Fastly", name: "Acme" },
+      { key: "comp-1", name: "Fastly" },
+    ];
+    expect(parseAnalysis(collide, [{ key: "Fastly", sentiment: "positive" }])).toEqual([
+      { key: "Fastly", sentiment: "positive", recommended: false },
+    ]);
+  });
+
+  it("defaults an unrecognized sentiment to neutral and coerces recommended", () => {
+    expect(parseAnalysis(entities, [{ key: "brand", sentiment: "glowing", recommended: "yes" }])).toEqual([
+      { key: "brand", sentiment: "neutral", recommended: true },
+    ]);
+  });
+
+  it("returns nothing for malformed payloads instead of throwing", () => {
+    expect(parseAnalysis(entities, null)).toEqual([]);
+    expect(parseAnalysis(entities, "nope")).toEqual([]);
+    expect(parseAnalysis(entities, { results: "nope" })).toEqual([]);
+    expect(parseAnalysis(entities, [null, 42, "x"])).toEqual([]);
+  });
+});

--- a/lib/llm/index.ts
+++ b/lib/llm/index.ts
@@ -190,10 +190,23 @@ async function anthropicWebSearch(
 ): Promise<QueryResult> {
   const client = new Anthropic({ apiKey, ...CLIENT_OPTS });
   // web_search is a server-side tool not in older SDK typings; cast the params.
+  //
+  // Keep the 20250305 tool version. The newer web_search_20260209 runs dynamic
+  // filtering through code execution and returns results in a shape this parser
+  // doesn't read: measured against the same prompt it produced 0 inline
+  // citations (vs 11) for 2.6x the tokens, falling back to the "retrieved but
+  // not cited" path below. Upgrading needs the citation parsing reworked first.
   const params = {
     model,
     max_tokens: ANSWER_MAX_TOKENS,
     tools: [{ type: "web_search_20250305", name: "web_search", max_uses: WEB_SEARCH_MAX_USES }],
+    // Force the browse, matching the OpenAI path. Left to choose, the model
+    // answers well-known questions from memory and cites nothing — in a live
+    // pilot it searched on only 4 of 10 prompts where OpenAI searched on 10,
+    // which made the two providers' mention rates measure different things.
+    // use_web_search is opt-in per project, so when it's on the user has asked
+    // us to check the live web. Costs roughly 4x the tokens of a memory answer.
+    tool_choice: { type: "tool", name: "web_search" },
     messages: [{ role: "user", content: prompt }],
   };
   const msg = await client.messages.create(
@@ -583,11 +596,18 @@ export async function suggestCompetitors(
     }
     const arr = Array.isArray(parsed) ? parsed : [];
     const suggestions: CompetitorSuggestion[] = [];
+    // Models occasionally list the same company twice in one response. Two rows
+    // for one competitor become two entities in computeEntityStats, which
+    // inflates the share-of-voice denominator and understates the brand.
+    const seen = new Set<string>();
     for (const item of arr) {
       if (!item || typeof item !== "object") continue;
       const o = item as Record<string, unknown>;
       const name = typeof o.name === "string" ? o.name.trim() : "";
       if (!name) continue;
+      const dedupeKey = name.toLowerCase();
+      if (seen.has(dedupeKey)) continue;
+      seen.add(dedupeKey);
       suggestions.push({
         name,
         domain:

--- a/lib/llm/index.ts
+++ b/lib/llm/index.ts
@@ -358,6 +358,61 @@ const ANALYZE_SYSTEM = `You analyze how brands are portrayed inside an AI assist
 Only judge based on the provided answer text. Return ONLY JSON.`;
 
 /**
+ * Map a model's raw analysis rows back onto the entities we asked about.
+ *
+ * Models are unreliable about which identifier they echo: Claude returns the
+ * `key` we supplied, while gpt-4o-mini routinely returns the entity's *name*
+ * instead ("Cloudflare" rather than "brand"). Keying purely off `key` silently
+ * dropped every OpenAI row, so the caller fell back to neutral / not-recommended
+ * for the whole project. Resolve on key first, then name, and drop anything that
+ * matches neither rather than inventing a verdict.
+ *
+ * Exported for tests; `analyzeResponse` is the real entry point.
+ */
+export function parseAnalysis(entities: AnalyzeEntity[], raw: unknown): AnalyzedResult[] {
+  let parsed = raw;
+  if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+    parsed = (parsed as { results?: unknown }).results ?? [];
+  }
+  const rows = Array.isArray(parsed) ? parsed : [];
+
+  // Both lookups point at the canonical key. Keys win: an entity whose *name*
+  // collides with another entity's key must not steal its row.
+  const byName = new Map<string, string>();
+  const byKey = new Map<string, string>();
+  for (const e of entities) {
+    byKey.set(e.key.trim().toLowerCase(), e.key);
+    const name = e.name.trim().toLowerCase();
+    if (name && !byName.has(name)) byName.set(name, e.key);
+  }
+
+  const results: AnalyzedResult[] = [];
+  const seen = new Set<string>();
+  for (const item of rows) {
+    if (!item || typeof item !== "object") continue;
+    const o = item as Record<string, unknown>;
+
+    const candidates = [o.key, o.name, o.entity]
+      .filter((v): v is string => typeof v === "string")
+      .map((v) => v.trim().toLowerCase());
+    let key: string | undefined;
+    for (const c of candidates) {
+      key = byKey.get(c) ?? byName.get(c);
+      if (key) break;
+    }
+    // A row we can't attribute is worse than no row: it would be applied to the
+    // wrong entity. Drop it and let the caller default.
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+
+    const sentiment: Sentiment =
+      o.sentiment === "positive" || o.sentiment === "negative" ? o.sentiment : "neutral";
+    results.push({ key, sentiment, recommended: Boolean(o.recommended) });
+  }
+  return results;
+}
+
+/**
  * Given an assistant answer and the entities that were detected in it, classify
  * sentiment + whether each was recommended. Only pass entities already known to
  * be mentioned (saves tokens; an entity not in the text has no sentiment).
@@ -398,23 +453,7 @@ Return a JSON object: { "results": [ { "key": "<key>", "sentiment": "positive|ne
         ? await anthropicChat(opts.apiKey, analysisModel, ANALYZE_SYSTEM, user, 700)
         : await openaiChat(opts.apiKey, analysisModel, ANALYZE_SYSTEM, user, 700, true);
 
-    let parsed: unknown = extractJson(res.text);
-    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-      parsed = (parsed as { results?: unknown }).results ?? [];
-    }
-    const arr = Array.isArray(parsed) ? parsed : [];
-    const valid: AnalyzedResult[] = [];
-    for (const item of arr) {
-      if (!item || typeof item !== "object") continue;
-      const o = item as Record<string, unknown>;
-      const key = typeof o.key === "string" ? o.key : null;
-      const sentiment = o.sentiment;
-      if (!key) continue;
-      const s: Sentiment =
-        sentiment === "positive" || sentiment === "negative" ? sentiment : "neutral";
-      valid.push({ key, sentiment: s, recommended: Boolean(o.recommended) });
-    }
-    return { results: valid, tokens: res.tokens };
+    return { results: parseAnalysis(opts.entities, extractJson(res.text)), tokens: res.tokens };
   } catch {
     // Sentiment is best-effort enrichment; never fail a run over it.
     return {

--- a/scripts/pilot-client.ts
+++ b/scripts/pilot-client.ts
@@ -1,0 +1,448 @@
+/**
+ * Client pilot harness.
+ *
+ * Drives the real Lettertrace pipeline — scrape → suggest topics/prompts →
+ * suggest competitors → query the answer engine → detect mentions → classify
+ * sentiment — against a live brand, without writing anything to Supabase.
+ *
+ * It calls the same lib/ functions the product does, so what it reports is what
+ * a real run would store. The point is to see which prompt shapes actually
+ * surface a brand before committing a client to a monitoring config.
+ *
+ *   npx tsx scripts/pilot-client.ts cloudflare
+ *   npx tsx scripts/pilot-client.ts runlayer --providers anthropic
+ *   npx tsx scripts/pilot-client.ts all --max-prompts 6
+ *
+ * Reads TRIAL_ANTHROPIC_API_KEY / TRIAL_OPENAI_API_KEY from .env.local.
+ * Writes a JSON transcript next to the summary it prints.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { scrapeDomain } from "../lib/scrape";
+import {
+  runQuery,
+  analyzeResponse,
+  suggestFromSite,
+  suggestCompetitors,
+  humanError,
+  type CitedSource,
+  type CompetitorSuggestion,
+} from "../lib/llm";
+import { detectMention, brandTerms } from "../lib/mentions";
+import { hostOf, isOwnedDomain } from "../lib/engine";
+import type { Provider } from "../lib/types";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "..");
+
+// --- env ------------------------------------------------------------------
+
+function loadEnvLocal(): void {
+  const raw = readFileSync(resolve(repoRoot, ".env.local"), "utf8");
+  for (const line of raw.split("\n")) {
+    const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*)$/);
+    if (!m) continue;
+    const value = m[2].trim().replace(/^["']|["']$/g, "");
+    if (value && !process.env[m[1]]) process.env[m[1]] = value;
+  }
+}
+
+// --- client fixtures ------------------------------------------------------
+
+interface ClientConfig {
+  key: string;
+  brandName: string;
+  /** index 0 is the primary domain; the rest are phantom sites. */
+  brandDomains: string[];
+  brandAliases: string[];
+  /** Used only when the site can't be scraped (bot walls, JS-only pages). */
+  fallbackDescription: string;
+}
+
+const CLIENTS: ClientConfig[] = [
+  {
+    key: "cloudflare",
+    brandName: "Cloudflare",
+    brandDomains: ["cloudflare.com"],
+    brandAliases: [],
+    fallbackDescription:
+      "Cloudflare is a global network providing CDN, DDoS protection, DNS, zero-trust security, and edge compute (Workers) for websites and applications.",
+  },
+  {
+    key: "runlayer",
+    brandName: "Runlayer",
+    brandDomains: ["runlayer.com"],
+    brandAliases: [],
+    fallbackDescription:
+      "Runlayer is an MCP (Model Context Protocol) security platform providing an MCP gateway with real-time threat detection, fine-grained identity-based permissions, and observability for enterprise AI agent deployments.",
+  },
+];
+
+// --- args -----------------------------------------------------------------
+
+const argv = process.argv.slice(2);
+const positional = argv.filter((a) => !a.startsWith("--"));
+const flag = (name: string, fallback: string): string => {
+  const i = argv.indexOf(`--${name}`);
+  return i >= 0 && argv[i + 1] ? argv[i + 1] : fallback;
+};
+
+const which = positional[0] ?? "all";
+const maxPrompts = Number(flag("max-prompts", "10"));
+const providers = flag("providers", "anthropic,openai")
+  .split(",")
+  .map((p) => p.trim())
+  .filter((p): p is Provider => p === "anthropic" || p === "openai");
+const webSearch = flag("web-search", "on") !== "off";
+
+// Answer models: the flagship of each provider, i.e. what a real user asking
+// ChatGPT or Claude would hit. Sentiment classification runs on the cheap model
+// regardless (see analysisModelFor).
+const ANSWER_MODEL: Record<Provider, string> = {
+  anthropic: "claude-opus-4-8",
+  openai: "gpt-4o",
+};
+
+// Rough blended $/1M tokens, only for an order-of-magnitude spend estimate.
+const BLENDED_COST_PER_MTOK: Record<Provider, number> = {
+  anthropic: 10,
+  openai: 7,
+};
+
+// --- concurrency ----------------------------------------------------------
+
+const CONCURRENCY = 3;
+
+async function mapPool<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const out: R[] = new Array(items.length);
+  let cursor = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, async () => {
+      while (cursor < items.length) {
+        const i = cursor++;
+        out[i] = await fn(items[i], i);
+      }
+    }),
+  );
+  return out;
+}
+
+// --- result shapes --------------------------------------------------------
+
+interface PromptOutcome {
+  topic: string;
+  prompt: string;
+  provider: Provider;
+  model: string;
+  ok: boolean;
+  error?: string;
+  answerChars: number;
+  brandMentioned: boolean;
+  brandCount: number;
+  /** 0 = very start of the answer, 1 = very end. -1 when absent. */
+  brandPosition: number;
+  brandSentiment?: string;
+  brandRecommended?: boolean;
+  competitorsFound: string[];
+  sources: { domain: string; owned: boolean }[];
+  ownedSourceCited: boolean;
+  tokens: number;
+}
+
+interface ClientReport {
+  client: string;
+  brandName: string;
+  brandDomains: string[];
+  description: string;
+  scraped: boolean;
+  topics: { name: string; prompts: string[] }[];
+  competitors: CompetitorSuggestion[];
+  outcomes: PromptOutcome[];
+  tokensUsed: number;
+}
+
+// --- pipeline -------------------------------------------------------------
+
+function keyFor(provider: Provider): string {
+  const k =
+    provider === "anthropic"
+      ? process.env.TRIAL_ANTHROPIC_API_KEY
+      : process.env.TRIAL_OPENAI_API_KEY;
+  if (!k) throw new Error(`Missing TRIAL_${provider.toUpperCase()}_API_KEY in .env.local`);
+  return k;
+}
+
+async function buildConfig(
+  client: ClientConfig,
+  setupProvider: Provider,
+): Promise<Pick<ClientReport, "description" | "scraped" | "topics" | "competitors"> & { tokens: number }> {
+  const apiKey = keyFor(setupProvider);
+  const model = ANSWER_MODEL[setupProvider];
+  let tokens = 0;
+
+  // 1. Scrape the primary domain (same path onboarding uses).
+  const primary = client.brandDomains[0];
+  let siteText = "";
+  let scraped = false;
+  try {
+    const res = await scrapeDomain(primary);
+    const text = res.text ?? "";
+    if (res.ok && text.trim().length > 200) {
+      siteText = text;
+      scraped = true;
+    }
+  } catch {
+    /* fall through to the description fallback */
+  }
+  if (!scraped) siteText = client.fallbackDescription;
+  console.log(
+    `  scrape ${primary}: ${scraped ? `${siteText.length} chars` : "FAILED — using fallback description"}`,
+  );
+
+  // 2. Infer description + topics + prompts from the site.
+  const suggestion = await suggestFromSite({
+    provider: setupProvider,
+    model,
+    apiKey,
+    brandName: client.brandName,
+    siteText,
+  });
+  tokens += suggestion.tokens;
+  const description = suggestion.description || client.fallbackDescription;
+  console.log(`  description: ${description}`);
+  console.log(
+    `  topics: ${suggestion.topics.length} (${suggestion.topics.reduce((n, t) => n + t.prompts.length, 0)} prompts)`,
+  );
+
+  // 3. Suggest competitors.
+  const comp = await suggestCompetitors({
+    provider: setupProvider,
+    model,
+    apiKey,
+    brandName: client.brandName,
+    brandDomain: primary,
+    description,
+    topics: suggestion.topics.map((t) => t.name),
+    existing: [],
+    count: 8,
+  });
+  tokens += comp.tokens;
+  console.log(`  competitors: ${comp.suggestions.map((c) => c.name).join(", ") || "(none)"}`);
+
+  return { description, scraped, topics: suggestion.topics, competitors: comp.suggestions, tokens };
+}
+
+async function runPrompt(
+  client: ClientConfig,
+  competitors: CompetitorSuggestion[],
+  topic: string,
+  prompt: string,
+  provider: Provider,
+): Promise<PromptOutcome> {
+  const apiKey = keyFor(provider);
+  const model = ANSWER_MODEL[provider];
+  const bTerms = brandTerms(client.brandName, client.brandAliases, client.brandDomains[0]);
+  const ownedHosts = client.brandDomains.map(hostOf).filter(Boolean);
+
+  const base: PromptOutcome = {
+    topic,
+    prompt,
+    provider,
+    model,
+    ok: false,
+    answerChars: 0,
+    brandMentioned: false,
+    brandCount: 0,
+    brandPosition: -1,
+    competitorsFound: [],
+    sources: [],
+    ownedSourceCited: false,
+    tokens: 0,
+  };
+
+  let answer: string;
+  let sources: CitedSource[];
+  let tokens: number;
+  try {
+    const res = await runQuery({ provider, model, apiKey, prompt, webSearch });
+    answer = res.text;
+    sources = res.sources;
+    tokens = res.tokens;
+  } catch (err) {
+    return { ...base, error: humanError(err) };
+  }
+
+  const brandHit = detectMention(answer, bTerms);
+  const competitorsFound: string[] = [];
+  for (const c of competitors) {
+    if (detectMention(answer, [c.name, ...c.aliases]).mentioned) competitorsFound.push(c.name);
+  }
+
+  const sourceRows = sources.map((s) => ({
+    domain: s.domain,
+    owned: ownedHosts.some((h) => isOwnedDomain(s.domain, h)),
+  }));
+
+  let brandSentiment: string | undefined;
+  let brandRecommended: boolean | undefined;
+  if (brandHit.mentioned) {
+    const analysis = await analyzeResponse({
+      provider,
+      model,
+      apiKey,
+      question: prompt,
+      responseText: answer,
+      entities: [{ key: "brand", name: client.brandName }],
+    });
+    tokens += analysis.tokens;
+    const r = analysis.results.find((x) => x.key === "brand");
+    brandSentiment = r?.sentiment;
+    brandRecommended = r?.recommended;
+  }
+
+  return {
+    ...base,
+    ok: true,
+    answerChars: answer.length,
+    brandMentioned: brandHit.mentioned,
+    brandCount: brandHit.count,
+    brandPosition: brandHit.firstPosition,
+    brandSentiment,
+    brandRecommended,
+    competitorsFound,
+    sources: sourceRows,
+    ownedSourceCited: sourceRows.some((s) => s.owned),
+    tokens,
+  };
+}
+
+async function runClient(client: ClientConfig): Promise<ClientReport> {
+  console.log(`\n=== ${client.brandName} (${client.brandDomains[0]}) ===`);
+  const setupProvider = providers[0];
+  const config = await buildConfig(client, setupProvider);
+
+  // Flatten topics → prompts, round-robin across topics so a cap still gives
+  // topic variety rather than every prompt from the first topic.
+  const flat: { topic: string; prompt: string }[] = [];
+  const maxDepth = Math.max(0, ...config.topics.map((t) => t.prompts.length));
+  for (let i = 0; i < maxDepth; i++) {
+    for (const t of config.topics) {
+      if (t.prompts[i]) flat.push({ topic: t.name, prompt: t.prompts[i] });
+    }
+  }
+  const selected = flat.slice(0, maxPrompts);
+
+  const jobs: { topic: string; prompt: string; provider: Provider }[] = [];
+  for (const provider of providers) {
+    for (const s of selected) jobs.push({ ...s, provider });
+  }
+  console.log(`  running ${jobs.length} queries (${selected.length} prompts x ${providers.length} provider(s))…`);
+
+  let done = 0;
+  const outcomes = await mapPool(jobs, CONCURRENCY, async (job) => {
+    const out = await runPrompt(client, config.competitors, job.topic, job.prompt, job.provider);
+    done++;
+    const mark = !out.ok ? "ERR " : out.brandMentioned ? "HIT " : "miss";
+    console.log(`  [${String(done).padStart(2)}/${jobs.length}] ${mark} (${job.provider}) ${job.prompt.slice(0, 72)}`);
+    if (out.error) console.log(`         ${out.error}`);
+    return out;
+  });
+
+  return {
+    client: client.key,
+    brandName: client.brandName,
+    brandDomains: client.brandDomains,
+    description: config.description,
+    scraped: config.scraped,
+    topics: config.topics,
+    competitors: config.competitors,
+    outcomes,
+    tokensUsed: config.tokens + outcomes.reduce((n, o) => n + o.tokens, 0),
+  };
+}
+
+// --- reporting ------------------------------------------------------------
+
+function pct(n: number, d: number): string {
+  return d === 0 ? "n/a" : `${Math.round((n / d) * 100)}%`;
+}
+
+function summarize(report: ClientReport): void {
+  const ok = report.outcomes.filter((o) => o.ok);
+  const hits = ok.filter((o) => o.brandMentioned);
+  console.log(`\n--- ${report.brandName}: ${hits.length}/${ok.length} answers mentioned the brand (${pct(hits.length, ok.length)}) ---`);
+
+  for (const provider of providers) {
+    const sub = ok.filter((o) => o.provider === provider);
+    if (!sub.length) continue;
+    const h = sub.filter((o) => o.brandMentioned);
+    console.log(`  ${provider}: ${h.length}/${sub.length} (${pct(h.length, sub.length)})`);
+  }
+
+  // Share of voice: how often each competitor appeared vs the brand.
+  const tally = new Map<string, number>();
+  for (const o of ok) for (const c of o.competitorsFound) tally.set(c, (tally.get(c) ?? 0) + 1);
+  const ranked = [...tally.entries()].sort((a, b) => b[1] - a[1]);
+  console.log(`  brand appeared in ${hits.length}; top competitors:`);
+  for (const [name, n] of ranked.slice(0, 8)) {
+    console.log(`    ${String(n).padStart(3)}  ${name}`);
+  }
+
+  const withOwned = ok.filter((o) => o.ownedSourceCited);
+  console.log(`  answers citing an owned domain: ${withOwned.length}/${ok.length}`);
+
+  const errs = report.outcomes.filter((o) => !o.ok);
+  if (errs.length) console.log(`  errors: ${errs.length}`);
+}
+
+async function main(): Promise<void> {
+  loadEnvLocal();
+
+  const targets =
+    which === "all" ? CLIENTS : CLIENTS.filter((c) => c.key === which);
+  if (!targets.length) {
+    console.error(`Unknown client "${which}". Known: ${CLIENTS.map((c) => c.key).join(", ")}, all`);
+    process.exit(1);
+  }
+  console.log(
+    `providers=${providers.join(",")} webSearch=${webSearch} maxPrompts=${maxPrompts}`,
+  );
+
+  const reports: ClientReport[] = [];
+  for (const client of targets) {
+    reports.push(await runClient(client));
+  }
+
+  console.log("\n================ SUMMARY ================");
+  let totalTokens = 0;
+  for (const r of reports) {
+    summarize(r);
+    totalTokens += r.tokensUsed;
+  }
+  const est = reports.reduce((sum, r) => {
+    const perProvider = r.outcomes.reduce(
+      (n, o) => n + (o.tokens / 1_000_000) * BLENDED_COST_PER_MTOK[o.provider],
+      0,
+    );
+    return sum + perProvider;
+  }, 0);
+  console.log(`\ntokens: ${totalTokens.toLocaleString()}  (~$${est.toFixed(2)} at blended rates)`);
+
+  const outDir = process.env.PILOT_OUT_DIR ?? resolve(repoRoot, ".pilot");
+  mkdirSync(outDir, { recursive: true });
+  const outFile = resolve(outDir, `pilot-${which}-${Date.now()}.json`);
+  writeFileSync(outFile, JSON.stringify(reports, null, 2));
+  console.log(`transcript: ${outFile}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -238,6 +238,66 @@ create table if not exists public.sources (
   created_at timestamptz not null default now()
 );
 
+-- ---------- competitor de-duplication --------------------------------
+-- The competitor suggester could name the same company twice and nothing
+-- rejected the second copy. computeEntityStats keys on competitor_id and sums
+-- mention_count across every row, so a duplicate inflated the share-of-voice
+-- DENOMINATOR — quietly understating the brand's own share rather than the
+-- competitor's. Collapse anything already stored, then make it impossible.
+--
+-- Note mentions.competitor_id is ON DELETE SET NULL, so simply deleting the
+-- duplicate row would orphan its mentions to the entity_name fallback in
+-- entityKey() and leave the double-count in place. Re-point first, then delete.
+-- Safe to re-run: every statement is a no-op once the data is clean.
+
+-- 1. Re-point mentions from each duplicate onto the oldest copy of that name.
+with canonical as (
+  select project_id,
+         lower(name) as lname,
+         (array_agg(id order by created_at, id))[1] as keep_id
+  from public.competitors
+  group by project_id, lower(name)
+),
+dupes as (
+  select c.id as dup_id, k.keep_id
+  from public.competitors c
+  join canonical k on k.project_id = c.project_id and k.lname = lower(c.name)
+  where c.id <> k.keep_id
+)
+update public.mentions m
+set competitor_id = d.keep_id
+from dupes d
+where m.competitor_id = d.dup_id;
+
+-- 2. Drop the mention rows that re-pointing just made redundant (one entity
+--    counted twice in the same response), keeping the earliest of each pair.
+delete from public.mentions m
+using public.mentions keep
+where m.entity_type = 'competitor'
+  and m.competitor_id is not null
+  and m.competitor_id = keep.competitor_id
+  and m.response_id = keep.response_id
+  and m.id > keep.id;
+
+-- 3. Remove the duplicate competitor rows themselves.
+with canonical as (
+  select project_id,
+         lower(name) as lname,
+         (array_agg(id order by created_at, id))[1] as keep_id
+  from public.competitors
+  group by project_id, lower(name)
+)
+delete from public.competitors c
+using canonical k
+where k.project_id = c.project_id
+  and k.lname = lower(c.name)
+  and c.id <> k.keep_id;
+
+-- 4. One competitor name per project, case-insensitive. POST /api/competitors
+--    turns the resulting 23505 into a 409.
+create unique index if not exists competitors_project_name_uniq
+  on public.competitors (project_id, lower(name));
+
 -- ---------- indexes --------------------------------------------------
 create index if not exists idx_projects_user on public.projects (user_id);
 create index if not exists idx_competitors_project on public.competitors (project_id);


### PR DESCRIPTION
Adds a harness for dry-running a real client through the pipeline against live data, plus the three bugs that running it surfaced. Cloudflare and Runlayer were the first two clients through it.

## Why

We had no way to answer "will this client actually show up in AI answers, and which prompts get them there?" without committing them to a monitoring config and waiting for a scheduled run. `scripts/pilot-client.ts` drives the real pipeline — scrape → suggest topics/prompts → suggest competitors → query the answer engine → detect mentions → classify sentiment — without writing to Supabase. It calls the same `lib/` functions the product does, so what it reports is what a real run would store.

```
npx tsx scripts/pilot-client.ts all --max-prompts 10
npx tsx scripts/pilot-client.ts runlayer --providers anthropic
```

Add a client to the `CLIENTS` array to onboard the next one. Transcripts land in `.pilot/` (gitignored).

## Pilot results

| | Mention rate | Claude (opus-4-8) | ChatGPT (gpt-4o) | Median prominence |
|---|---|---|---|---|
| Cloudflare | **19/20 (95%)** | 10/10 | 9/10 | 0.12 — named in the first sentences |
| Runlayer | **1/20 (5%)** | 1/10 | 0/10 | 0.73 — buried near the end |

Runlayer's misses are real, not a search artifact: **web search ran on 19 of its 20 queries.** The models went and looked and still didn't name them.

The single hit is the most useful data point in the run:

> *"How do I set up a governed MCP gateway for Claude, Cursor, and ChatGPT?"* — mentioned twice, and it cited runlayer.com directly.

That was the only prompt naming the specific product category and the specific client tools. Every generic phrasing — "govern and secure AI agents", "control what AI agents can access", "roll out AI agents safely" — missed on both providers. The category is also thin: of 8 suggested competitors only Prompt Security (4) and Witness AI (3) ever appeared, so nobody owns this space in AI answers yet.

**Implication for prompt design:** specificity is what converts. Name the protocol, the tools, the integration. For an early-stage client, generic category questions measure nothing because everyone scores zero.

Whole run cost ~$3.80 for 40 queries against the trial keys.

## Fixes

### 1. Sentiment was silently dead on every OpenAI project

`analyzeResponse` keyed its results purely off the `key` field the model echoed back. Claude echoes the key we supplied; gpt-4o-mini returns the entity's **name** instead:

```json
{"results": [{"key": "Cloudflare", "sentiment": "positive", "recommended": true}]}
```

Every OpenAI row therefore failed to match, `executeRun`'s `analyzed[d.key]` lookup fell through to its `?? "neutral"` / `?? false` defaults, and every mention on an OpenAI project was stored as neutral and not-recommended — flattening `sentimentScore` and `recommendRate` to zero for those projects.

The pilot made the split unmissable: **10/10 Anthropic hits classified positive+recommended, 0/9 OpenAI hits classified at all.**

Rows now resolve on key first, then entity name, and a row matching neither is dropped rather than attributed to the wrong entity. Pulled out as `parseAnalysis` so the mapping is unit-testable without a network call, matching how the source helpers are tested (9 new tests).

### 2. Duplicate competitors understated brand share of voice

`suggestCompetitors` could name the same company twice (seen live: `Akamai, Fastly, Amazon CloudFront, Fastly, …`) and nothing rejected the second copy. `computeEntityStats` keys on `competitor_id` and sums `mention_count` across every row, so the duplicate landed in the share-of-voice **denominator** — understating the brand's own share rather than inflating the competitor's.

Deduped at three layers, because any one alone leaves a gap:

- `suggestCompetitors` drops repeats by lowercased name
- the suggest route's filter now adds to its `taken` set as it goes — it previously checked only *already-tracked* rows, so a repeat inside one batch sailed through
- a unique index on `(project_id, lower(name))`

`POST /api/competitors` turns the resulting 23505 into a 409 with a readable message instead of a raw 500.

**Schema note:** `mentions.competitor_id` is `ON DELETE SET NULL`, not cascade. Deleting the duplicate row first would orphan its mentions to the `entity_name` fallback in `entityKey()` and leave the double-count fully intact, just relabelled. The migration re-points mentions onto the surviving competitor, drops the rows that re-pointing makes redundant, *then* deletes. Every statement is a no-op once the data is clean.

### 3. Cross-provider mention rates weren't comparable

The OpenAI path forced its browse via `tool_choice`; the Anthropic path left it to the model. In the pilot Claude searched on 4 of 10 prompts where OpenAI searched on 10 — so a run compared "what Claude recalls" against "what ChatGPT found" on a single axis. Both are forced now.

**Cost impact, stated plainly:** ~15k tokens per Anthropic query versus ~4.6k when it answered from memory, so roughly **3× per query** on projects with `use_web_search` on. The toggle is opt-in, so when it's on the user has asked us to check the live web — but it's a real bill increase worth knowing before enabling it for a client.

### Bonus: do not upgrade the web search tool version

`web_search_20250305` stays pinned. Measured against the same prompt on `claude-opus-4-8`:

| Tool version | Searches | Retrieved | Citations | Tokens |
|---|---|---|---|---|
| `web_search_20250305` (current) | 2 | 17 | **11** | 21,855 |
| `web_search_20260209` (newer) | 5 | 41 | **0** | 57,565 |

The newer variant runs dynamic filtering through code execution and returns results in a shape our parser doesn't read, so it falls through to the "retrieved but not cited" path — 2.6× the tokens for none of the citation signal. Now commented in place so nobody upgrades it as routine maintenance.

## Verification

Typecheck, lint, and all 88 tests pass (9 new).

Verified against the live Supabase project via a throwaway auth user, deleted afterward with everything cascaded:

```
competitor uniqueness:
  PASS  first insert of 'Fastly' succeeds
  PASS  exact duplicate rejected — 23505
  PASS  case-variant duplicate rejected — 23505
  PASS  a different competitor still inserts

executeRun (openai / gpt-4o, web search on):
  PASS  run completed — 1 response(s)

stored mentions:
    brand      Cloudflare   sentiment=positive recommended=true count=3
    competitor Fastly       sentiment=positive recommended=true count=3
    competitor Akamai       sentiment=positive recommended=true count=4
  PASS  brand sentiment persisted as non-neutral (the OpenAI fix)
  PASS  web search ran and sources were stored — 6 source(s)
```

That middle block is a real `executeRun` on an OpenAI project writing to the real `mentions` table. Before the fix all three rows would have stored `neutral` / `false`.

Forced browse verified separately: 3/3 Anthropic queries returned sources (6, 4, 5) where Claude previously searched on 4 of 10.

## Smaller print

- **The migration has been applied and ran cleanly.** All four statements executed against the live schema, and the index half is confirmed working by the test output above. The dedupe statements had no duplicates to collapse, so their behaviour *with duplicate rows present* is the one thing unexercised — and the unique index makes that state unreachable going forward, so it was a one-time cleanup for data that didn't exist.
- **Step 3 keeps the oldest duplicate and discards the newer row's `aliases` and `domain`.** Fine for an accidental duplicate, lossy if someone hand-curated aliases on the copy that loses. Kept minimal rather than adding alias-merging logic that couldn't be tested.
- **The competitor dedupe has no unit test.** `suggestCompetitors` does a network call and, unlike `parseAnalysis`, would need refactoring to make its parse loop testable. It's a straightforward `Set` guard, covered by inspection.

## Follow-ups deliberately not done here

- **OpenAI web search isn't metered.** `web_search_preview` is priced as a per-call fee that never appears in `usage`, so `tokensUsed` is blind to it and `trial_tokens_used` doesn't count it. `TRIAL_RUN_LIMIT` still caps trial users by run count, so it's bounded — but worth addressing before widening the trial.
- **Sentiment isn't comparable across providers.** On identical text Claude rated a competitor `negative` and gpt-4o rated it `neutral`. Genuine model disagreement, not a bug, but it means the metric shouldn't be charted across providers without a caveat.
- **The setup model may matter as much as the answer model.** When gpt-4o generated the monitoring prompts instead of Claude, it produced how-to phrasings ("How can edge computing improve performance?") rather than recommendation phrasings ("What's the best CDN?"), and Cloudflare scored 0/3 instead of 9/10. That's n=3 — a hypothesis worth testing, not a finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
