### PR TITLE
Never redirect a deployed sign-in to localhost

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
-import { safePath } from "@/lib/utils";
+import { resolveRedirectBase, safePath } from "@/lib/utils";
 
 // Longest provider error we'll echo back onto the sign-in screen. The text is
 // attacker-influenceable via the query string (it renders as escaped text, so
@@ -16,10 +16,10 @@ export async function GET(request: Request) {
   const code = searchParams.get("code");
   const next = safePath(searchParams.get("next"));
 
-  // Behind a proxy (Vercel) the `origin` parsed off the request can be the
-  // internal deployment host rather than the public domain, which would strand
-  // the user on the wrong URL. Prefer the configured site URL when we have one.
-  const base = process.env.NEXT_PUBLIC_SITE_URL ?? origin;
+  // Prefer the configured site URL — behind a proxy the origin parsed off the
+  // request can be the internal deployment host — but never follow it to
+  // loopback from a deployed request. See resolveRedirectBase.
+  const base = resolveRedirectBase(process.env.NEXT_PUBLIC_SITE_URL, origin);
 
   const failed = (reason: string) => {
     const url = new URL("/login", base);

--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { resolveRedirectBase, safePath } from "@/lib/utils";
+
+describe("resolveRedirectBase", () => {
+  const PROD = "https://lettertrace.com";
+  const LOCAL = "http://localhost:3000";
+
+  // The outage this exists to prevent: NEXT_PUBLIC_SITE_URL left at localhost
+  // in production sent every signed-in user to their own machine, where the
+  // cookies just set on the real domain don't exist. Silent, and it looks
+  // exactly like "sign-in doesn't work".
+  it("ignores a loopback site URL when the request came from a real domain", () => {
+    expect(resolveRedirectBase(LOCAL, PROD)).toBe(PROD);
+    expect(resolveRedirectBase("http://127.0.0.1:3000", PROD)).toBe(PROD);
+    expect(resolveRedirectBase("http://localhost", PROD)).toBe(PROD);
+  });
+
+  it("still honours a loopback site URL for a genuinely local request", () => {
+    expect(resolveRedirectBase(LOCAL, LOCAL)).toBe(LOCAL);
+    expect(resolveRedirectBase(LOCAL, "http://127.0.0.1:3000")).toBe(LOCAL);
+  });
+
+  it("prefers the configured URL over the request origin behind a proxy", () => {
+    // The case the configured value exists for: Vercel's internal host.
+    expect(resolveRedirectBase(PROD, "https://lettertrace-abc123.vercel.app")).toBe(PROD);
+  });
+
+  it("falls back to the origin when nothing is configured", () => {
+    expect(resolveRedirectBase(undefined, PROD)).toBe(PROD);
+    expect(resolveRedirectBase(null, PROD)).toBe(PROD);
+    expect(resolveRedirectBase("", PROD)).toBe(PROD);
+    expect(resolveRedirectBase("   ", PROD)).toBe(PROD);
+  });
+
+  it("falls back to the origin rather than breaking on a malformed value", () => {
+    expect(resolveRedirectBase("lettertrace.com", PROD)).toBe(PROD); // no scheme
+    expect(resolveRedirectBase("not a url", PROD)).toBe(PROD);
+  });
+
+  it("tolerates surrounding whitespace in the env var", () => {
+    expect(resolveRedirectBase(`  ${PROD}  `, "https://internal.vercel.app")).toBe(PROD);
+  });
+
+  it("treats ::1 as loopback too", () => {
+    expect(resolveRedirectBase("http://[::1]:3000", PROD)).toBe(PROD);
+  });
+
+  it("does not mistake a hostname that merely contains 'localhost'", () => {
+    const lookalike = "https://localhost.evil.com";
+    expect(resolveRedirectBase(lookalike, PROD)).toBe(lookalike);
+  });
+});
+
+describe("safePath", () => {
+  it("allows same-origin paths", () => {
+    expect(safePath("/dashboard/runs")).toBe("/dashboard/runs");
+  });
+
+  it("rejects protocol-relative and backslash open-redirect tricks", () => {
+    expect(safePath("//evil.com")).toBe("/dashboard");
+    expect(safePath("/\\evil.com")).toBe("/dashboard");
+    expect(safePath("https://evil.com")).toBe("/dashboard");
+  });
+
+  it("falls back for non-strings", () => {
+    expect(safePath(null)).toBe("/dashboard");
+    expect(safePath(undefined)).toBe("/dashboard");
+    expect(safePath("", "/somewhere")).toBe("/somewhere");
+  });
+});

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -24,6 +24,47 @@ export function timeAgo(iso: string | null): string {
   return new Date(iso).toLocaleDateString();
 }
 
+function isLoopback(url: string): boolean {
+  try {
+    const host = new URL(url).hostname.toLowerCase();
+    return host === "localhost" || host === "127.0.0.1" || host === "::1" || host === "[::1]";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The absolute base to build post-auth redirects on.
+ *
+ * Prefers the configured site URL, because behind a proxy the origin parsed off
+ * the request can be the internal deployment host rather than the public
+ * domain. Two cases fall back to the request origin instead:
+ *
+ *   - the configured value is unset or unparseable
+ *   - it points at loopback while the request didn't
+ *
+ * That second case is a real outage we shipped: NEXT_PUBLIC_SITE_URL was left
+ * at http://localhost:3000 in production, so every OAuth sign-in exchanged its
+ * code correctly, set cookies on the real domain, and then redirected the user
+ * to their own machine — where those cookies don't exist. It presents as
+ * "signing in silently dumps me back on the login page" with no error anywhere,
+ * and a deploy should simply not be able to do it.
+ */
+export function resolveRedirectBase(
+  configured: string | null | undefined,
+  origin: string,
+): string {
+  const value = typeof configured === "string" ? configured.trim() : "";
+  if (!value) return origin;
+  try {
+    new URL(value);
+  } catch {
+    return origin; // malformed env var shouldn't break sign-in
+  }
+  if (isLoopback(value) && !isLoopback(origin)) return origin;
+  return value;
+}
+
 // Guard against open redirects: only allow a same-origin path target.
 // Rejects protocol-relative ("//evil.com") and backslash ("/\\evil.com") tricks.
 export function safePath(


### PR DESCRIPTION
`NEXT_PUBLIC_SITE_URL` was left at `http://localhost:3000` in the production environment, so **every OAuth sign-in on lettertrace.com redirected the user to their own machine.**

Reproduced against production before the fix:

```
GET https://lettertrace.com/auth/callback?error=probe
  307 -> http://localhost:3000/login?error=probe
```

## Why it was invisible

Every layer looks healthy in isolation, which is what made it expensive to find:

1. Google → Supabase → `https://lettertrace.com/auth/callback?code=…` ✅
2. The route exchanges the code and sets session cookies **on lettertrace.com** ✅
3. It then redirects to `http://localhost:3000/dashboard` ❌
4. The browser lands on a different origin, which has none of those cookies
5. Middleware sees no session and bounces to `/login`

The session is created correctly every single time. The user is just moved off the domain holding it. Nothing errors, nothing logs, and it presents as "signing in with Google doesn't work". Password sign-in keeps working throughout, because it never touches the callback — which actively misleads you into suspecting OAuth config.

## The fix

The callback preferred the configured site URL for a real reason: behind a proxy the `origin` parsed off the request can be Vercel's internal deployment host rather than the public domain. But preferring it *unconditionally* let one wrong environment variable break sign-in for everybody.

`resolveRedirectBase` keeps that preference and adds two escapes:

- fall back to the request origin when the configured value is missing or unparseable
- fall back when it points at loopback and the request didn't

A deployment should not be able to send users to localhost no matter what the environment says.

Extracted as a pure function so each case is unit-testable. 11 new tests, including a check that `https://localhost.evil.com` is *not* treated as loopback. Also backfills tests for `safePath`, which had none.

## Still required on the deploy side

This makes the failure impossible, but production should still be configured correctly:

```
Vercel → Environment Variables → Production
NEXT_PUBLIC_SITE_URL = https://lettertrace.com
```

**A redeploy is required** — `NEXT_PUBLIC_*` values are inlined at build time, so editing the variable alone changes nothing.

## Verification

Typecheck, 90 tests (11 new), and a production build pass.

> The `<img>` ESLint warning in `components/dashboard/nav.tsx` is pre-existing and unrelated. It only became visible because clearing `.next` dropped the ESLint cache that had been hiding it.

Independent of #12 and #13 — touches only `app/auth/callback/route.ts` and `lib/utils.ts`, and can merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
