### PR TITLE
Add privacy policy and terms of service pages

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -355,9 +355,30 @@ export default function LandingPage() {
               Open-source monitoring for how your brand shows up in AI assistant answers.
             </p>
           </div>
-          <FooterCol title="Product" links={["How it works", "Features", "Open source"]} />
-          <FooterCol title="Open source" links={["GitHub", "MIT License", "Self-host guide"]} />
-          <FooterCol title="Company" links={["The Letter Company", "Privacy", "Contact"]} />
+          <FooterCol
+            title="Product"
+            links={[
+              { label: "How it works", href: "#how" },
+              { label: "Features", href: "#features" },
+              { label: "Open source", href: "#open-source" },
+            ]}
+          />
+          <FooterCol
+            title="Open source"
+            links={[
+              { label: "GitHub", href: GITHUB_URL },
+              { label: "MIT License", href: `${GITHUB_URL}/blob/main/LICENSE` },
+              { label: "Self-host guide", href: `${GITHUB_URL}#getting-started` },
+            ]}
+          />
+          <FooterCol
+            title="Company"
+            links={[
+              { label: "Privacy Policy", href: "/privacy" },
+              { label: "Terms of Service", href: "/terms" },
+              { label: "Contact", href: "mailto:support@letterbrace.com" },
+            ]}
+          />
         </div>
         <div className="border-t border-ink/10">
           <div className="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-2 px-5 py-5 text-xs text-ink-faint">
@@ -415,15 +436,21 @@ function OSPoint({ icon: Icon, children }: { icon: typeof ShieldCheck; children:
   );
 }
 
-function FooterCol({ title, links }: { title: string; links: string[] }) {
+function FooterCol({
+  title,
+  links,
+}: {
+  title: string;
+  links: { label: string; href: string }[];
+}) {
   return (
     <div>
       <p className="text-sm font-semibold text-ink">{title}</p>
       <ul className="mt-3 space-y-2">
         {links.map((l) => (
-          <li key={l}>
-            <Link href={GITHUB_URL} className="text-sm text-ink-faint transition hover:text-ink">
-              {l}
+          <li key={l.label}>
+            <Link href={l.href} className="text-sm text-ink-faint transition hover:text-ink">
+              {l.label}
             </Link>
           </li>
         ))}

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,115 @@
+import type { Metadata } from "next";
+import { LegalPage, Section } from "@/components/legal";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy",
+  description:
+    "How Lettertrace collects, uses, and protects your data, including your bring-your-own-key provider credentials.",
+};
+
+const UPDATED = "July 27, 2026";
+
+export default function PrivacyPage() {
+  return (
+    <LegalPage
+      title="Privacy Policy"
+      updated={UPDATED}
+      intro="Lettertrace is operated by The Letter Company. This policy explains what we collect when you use the hosted service at lettertrace.com, why we collect it, and who else sees it. Lettertrace is also open source — if you self-host it, this policy does not apply to your deployment, because we never receive your data."
+    >
+      <Section n={1} title="Information we collect">
+        <p><strong>Account information.</strong> Your email address, and — if you sign in with Google or GitHub — the name and profile picture that provider returns. We never receive your Google or GitHub password.</p>
+        <p><strong>Monitoring configuration.</strong> The brands, domains, aliases, competitors, topics, and prompts you set up, plus your model and schedule preferences.</p>
+        <p><strong>Run results.</strong> For each monitoring run we store the full text of the answers the AI models returned, the web sources they cited, and the brand and competitor mentions detected in them, along with sentiment and position.</p>
+        <p><strong>Provider API keys.</strong> If you bring your own Anthropic or OpenAI key, we store it encrypted (see §5) so scheduled runs can use it. We also store a short hint such as <code>sk-…4a9c</code> so you can tell your keys apart.</p>
+        <p><strong>Lettertrace API keys.</strong> Stored only as SHA-256 hashes. The full key is shown once at creation and cannot be recovered by us or by you afterwards.</p>
+        <p><strong>Usage counters.</strong> If you use trial runs on our shared provider keys, we count the runs and tokens consumed so we can apply the free-run limit.</p>
+        <p>We do not use advertising trackers, and we do not build behavioural profiles of you.</p>
+      </Section>
+
+      <Section n={2} title="What we send to AI providers">
+        <p>This is the part most worth understanding, because it is the core of what Lettertrace does.</p>
+        <p>When a monitoring run executes, we send your prompts to Anthropic and/or OpenAI. If web search is enabled for a project, those providers also run search queries derived from your prompts. The answers come back to us and are stored against your account.</p>
+        <p><strong>Under bring-your-own-key, those requests are made with your API key, under your own account with that provider.</strong> How they handle, retain, and train on that traffic is governed by your agreement with them, not by this policy. Review Anthropic&apos;s and OpenAI&apos;s privacy terms directly.</p>
+        <p>If you instead use trial runs on our shared keys, those requests are made under The Letter Company&apos;s provider accounts and are subject to our agreements with those providers.</p>
+        <p>Prompts are questions about a market or category. Do not put personal data, customer information, or confidential material into a prompt — it will be transmitted to a third-party model provider.</p>
+      </Section>
+
+      <Section n={3} title="Website content we fetch">
+        <p>During onboarding you can give us a brand&apos;s domain, and we fetch that site&apos;s public homepage to suggest topics and prompts. We fetch only publicly reachable pages over HTTP(S), and we block requests to private and internal network addresses. We store the extracted text only long enough to generate suggestions.</p>
+      </Section>
+
+      <Section n={4} title="How we use your information">
+        <ul>
+          <li>To operate the service: run monitors, detect mentions, and show your results.</li>
+          <li>To authenticate you and keep your account secure.</li>
+          <li>To enforce free-trial limits, where you use our shared provider keys.</li>
+          <li>To respond to support requests you send us.</li>
+          <li>To diagnose faults and keep the service running.</li>
+        </ul>
+        <p>We do not sell your personal information, and we do not share it for advertising.</p>
+      </Section>
+
+      <Section n={5} title="Security">
+        <p><strong>Provider API keys are encrypted at rest using AES-256-GCM</strong> with a unique initialization vector per key. They are decrypted only in memory, at the moment a run executes.</p>
+        <p><strong>Lettertrace API keys are stored as SHA-256 hashes only</strong> — never in plaintext.</p>
+        <p><strong>Your data is isolated per account by Postgres Row Level Security</strong>, enforced by the database rather than only by application code. Elevated database access is limited to the scheduled-run job and the API-key-authenticated surface, where every query is scoped to the key&apos;s owner.</p>
+        <p>Traffic to and from lettertrace.com is encrypted in transit over TLS. No system is perfectly secure, and we cannot guarantee absolute security.</p>
+      </Section>
+
+      <Section n={6} title="Service providers">
+        <p>We rely on the following processors to run Lettertrace:</p>
+        <ul>
+          <li><strong>Supabase</strong> — database, authentication, and storage of everything described in §1.</li>
+          <li><strong>Vercel</strong> — application hosting and request logs.</li>
+          <li><strong>Anthropic</strong> and <strong>OpenAI</strong> — the AI models queried during runs, as described in §2.</li>
+          <li><strong>Google</strong> and <strong>GitHub</strong> — optional sign-in. They tell us your email, name, and profile picture; we tell them nothing about your usage.</li>
+        </ul>
+        <p>We may also disclose information where legally required, or to protect the rights and safety of our users or the service.</p>
+      </Section>
+
+      <Section n={7} title="Data retention">
+        <p>Your configuration and run history are retained for as long as your account is active, because the product&apos;s value is the trend over time — deleting old runs would erase the record of how your visibility changed.</p>
+        <p>When you delete a project, its topics, prompts, competitors, runs, responses, sources, and mentions are deleted with it. When your account is deleted, everything associated with it is deleted.</p>
+        <p>Deleting a provider API key removes the encrypted value immediately. Revoking a Lettertrace API key takes effect immediately.</p>
+      </Section>
+
+      <Section n={8} title="Your rights">
+        <p>You can, at any time:</p>
+        <ul>
+          <li>Access and correct your account and project information in the dashboard.</li>
+          <li>Delete individual projects, prompts, competitors, or provider keys.</li>
+          <li>Revoke Lettertrace API keys.</li>
+          <li>Request a copy of your data, or deletion of your account, by emailing us.</li>
+        </ul>
+        <p>Depending on where you live, you may have additional rights under the GDPR, the UK GDPR, or the CCPA — including access, correction, deletion, portability, and objecting to certain processing. We honour these requests regardless of where you are. We do not sell personal information as defined by the CCPA.</p>
+      </Section>
+
+      <Section n={9} title="Cookies">
+        <p>We use cookies only for authentication — keeping you signed in and refreshing your session. We do not use advertising or cross-site tracking cookies. Clearing them signs you out.</p>
+      </Section>
+
+      <Section n={10} title="Children">
+        <p>Lettertrace is a business tool and is not directed at children under 16. We do not knowingly collect information from them. If you believe a child has given us information, email us and we will delete it.</p>
+      </Section>
+
+      <Section n={11} title="International transfers">
+        <p>The Letter Company operates in the United States, and our service providers process data in the United States and other countries. Using Lettertrace means your information may be transferred to and processed in those countries.</p>
+      </Section>
+
+      <Section n={12} title="Self-hosting">
+        <p>Lettertrace is open source under the MIT licence. If you run your own instance, your data stays in your own infrastructure and we receive none of it. This policy covers only the hosted service we operate at lettertrace.com.</p>
+      </Section>
+
+      <Section n={13} title="Changes to this policy">
+        <p>We may update this policy as the service changes. We will update the date at the top, and for material changes we will make a reasonable effort to notify you. Continuing to use Lettertrace after an update means you accept the revised policy.</p>
+      </Section>
+
+      <Section n={14} title="Contact">
+        <p>
+          Questions about this policy, or requests about your data:{" "}
+          <a href="mailto:privacy@letterbrace.com">privacy@letterbrace.com</a>
+        </p>
+      </Section>
+    </LegalPage>
+  );
+}

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,0 +1,117 @@
+import type { Metadata } from "next";
+import { LegalPage, Section } from "@/components/legal";
+
+export const metadata: Metadata = {
+  title: "Terms of Service",
+  description:
+    "The terms governing use of the hosted Lettertrace service, operated by The Letter Company.",
+};
+
+const UPDATED = "July 27, 2026";
+
+export default function TermsPage() {
+  return (
+    <LegalPage
+      title="Terms of Service"
+      updated={UPDATED}
+      intro="These terms govern your use of the hosted Lettertrace service at lettertrace.com, operated by The Letter Company. Lettertrace's source code is separately available under the MIT licence; these terms apply to the service we run, not to the code."
+    >
+      <Section n={1} title="Agreement">
+        <p>By creating an account or using Lettertrace, you agree to these terms. If you are using it on behalf of a company, you confirm you have authority to bind that company, and &quot;you&quot; means that company. If you do not agree, do not use the service.</p>
+      </Section>
+
+      <Section n={2} title="What Lettertrace does">
+        <p>Lettertrace sends questions you configure to AI assistants such as Claude and ChatGPT, records their answers, and reports how often your brand and your competitors are named, in what tone, and how prominently. It is a measurement tool. It does not influence what those models say.</p>
+      </Section>
+
+      <Section n={3} title="Accounts">
+        <p>You are responsible for the accuracy of your account information, for keeping your credentials secure, and for everything that happens under your account. Tell us promptly if you believe your account or an API key has been compromised. One person or organisation per account; do not share credentials.</p>
+      </Section>
+
+      <Section n={4} title="Your provider keys and costs">
+        <p>Lettertrace is bring-your-own-key. When you add an Anthropic or OpenAI key, runs execute against your own account with that provider.</p>
+        <ul>
+          <li><strong>You pay those providers directly.</strong> We do not mark up, resell, or reimburse provider usage, and we are not responsible for charges you incur. Monitoring runs consume tokens every time they execute, including on a schedule.</li>
+          <li><strong>You must comply with your provider&apos;s terms.</strong> Using Lettertrace does not exempt you from them.</li>
+          <li><strong>You are responsible for your own spending controls.</strong> Set limits with your provider. Settings such as the number of prompts, the model, replicate count, and web search all change how much a run costs, and a scheduled run repeats that cost on its own.</li>
+        </ul>
+        <p>Where we offer trial runs on our shared provider keys, those are a limited courtesy, subject to a run cap, and may be changed or withdrawn at any time.</p>
+      </Section>
+
+      <Section n={5} title="Your content">
+        <p>You keep ownership of everything you put into Lettertrace — your brand configuration, topics, prompts, and competitor lists — and of the reports generated from your runs. You grant us a limited licence to store, process, and transmit that content as needed to operate the service for you.</p>
+        <p>You are responsible for having the right to monitor the brands and domains you configure.</p>
+      </Section>
+
+      <Section n={6} title="Accuracy of measurements">
+        <p>Please read this section carefully; it describes a real limitation of the product rather than boilerplate.</p>
+        <p><strong>AI models are not deterministic.</strong> The same prompt sent to the same model can return a different answer each time. A brand named in one run may be absent from the next with no underlying change in the world. Lettertrace reports mention rates with confidence intervals for exactly this reason, and those intervals should be read, not ignored.</p>
+        <p><strong>Results are estimates from a sample</strong>, not a complete census of what AI assistants say. A run measures the prompts you configured, at one moment, on the models you selected. Different prompts produce very different results.</p>
+        <p><strong>Detection and classification can be wrong.</strong> Brand matching is literal text matching and may miss unusual phrasings or match coincidental ones. Sentiment and recommendation labels are produced by a model and may be inaccurate.</p>
+        <p>Lettertrace is provided as an input to your judgement, not a substitute for it. Do not rely on it as the sole basis for a commercial, financial, or legal decision.</p>
+      </Section>
+
+      <Section n={7} title="Acceptable use">
+        <p>Do not:</p>
+        <ul>
+          <li>Use Lettertrace to break the law, or to infringe anyone&apos;s rights.</li>
+          <li>Attempt to access another user&apos;s account or data.</li>
+          <li>Probe, scan, overload, or otherwise interfere with the service or its infrastructure.</li>
+          <li>Use it to generate spam, harassment, or deliberately misleading material about a person or company.</li>
+          <li>Circumvent trial limits, rate limits, or other technical restrictions.</li>
+          <li>Configure prompts intended to extract personal data about individuals.</li>
+        </ul>
+      </Section>
+
+      <Section n={8} title="Programmatic access">
+        <p>Lettertrace offers a REST API and an MCP server, authenticated with Lettertrace API keys. Keep those keys secret; anyone holding one can read your data and trigger runs that spend your provider credits. Revoke a key immediately if it may have leaked. We may apply rate limits, and may suspend a key that is degrading the service for others.</p>
+      </Section>
+
+      <Section n={9} title="Third-party services">
+        <p>Lettertrace depends on Anthropic, OpenAI, Supabase, Vercel, and — if you use social sign-in — Google and GitHub. We do not control those services. Outages, changes, price increases, or policy changes on their side may affect or interrupt Lettertrace, and we are not liable for them.</p>
+      </Section>
+
+      <Section n={10} title="Open source and self-hosting">
+        <p>Lettertrace&apos;s source is released under the MIT licence, and you are free to run your own instance under that licence. These terms govern only the hosted service we operate. We provide no warranty or support for self-hosted deployments, and we are not responsible for how they behave.</p>
+      </Section>
+
+      <Section n={11} title="Availability and changes">
+        <p>We aim to keep Lettertrace available but offer no uptime guarantee. We may modify, suspend, or discontinue features at any time. Scheduled runs may be delayed or skipped during maintenance or provider outages.</p>
+      </Section>
+
+      <Section n={12} title="Fees">
+        <p>The hosted service is currently offered free of charge. If we introduce paid plans we will give notice before charging you, and you will be free to stop using the service instead. Charges from AI providers under your own keys are separate and always your responsibility (§4).</p>
+      </Section>
+
+      <Section n={13} title="Disclaimer of warranties">
+        <p>Lettertrace is provided &quot;as is&quot; and &quot;as available&quot;, without warranties of any kind, express or implied, including merchantability, fitness for a particular purpose, and non-infringement. We do not warrant that the service will be uninterrupted, error-free, or that its measurements will be accurate or complete.</p>
+      </Section>
+
+      <Section n={14} title="Limitation of liability">
+        <p>To the maximum extent permitted by law, The Letter Company is not liable for any indirect, incidental, special, consequential, or punitive damages, or for lost profits, lost revenue, lost data, or business interruption, arising from your use of Lettertrace.</p>
+        <p>This includes charges you incur with AI providers, and decisions made on the basis of measurements the service reports.</p>
+        <p>Our total liability for any claim relating to the service is limited to the greater of the amount you paid us for it in the twelve months before the claim, or one hundred US dollars.</p>
+        <p>Some jurisdictions do not allow certain limitations, in which case the above apply to the fullest extent permitted.</p>
+      </Section>
+
+      <Section n={15} title="Indemnification">
+        <p>You agree to indemnify The Letter Company against claims, losses, and reasonable legal costs arising from your use of the service, your content, or your breach of these terms.</p>
+      </Section>
+
+      <Section n={16} title="Termination">
+        <p>You may delete your account at any time. We may suspend or terminate access if you breach these terms, or if we reasonably believe your use puts the service or other users at risk. On termination your right to use the service ends immediately and your data is deleted in accordance with our <a href="/privacy">Privacy Policy</a>. Export anything you want to keep beforehand.</p>
+      </Section>
+
+      <Section n={17} title="Changes to these terms">
+        <p>We may update these terms as the service changes. We will update the date at the top, and for material changes we will make a reasonable effort to notify you. Continuing to use Lettertrace after an update means you accept the revised terms.</p>
+      </Section>
+
+      <Section n={18} title="Contact">
+        <p>
+          Questions about these terms:{" "}
+          <a href="mailto:support@letterbrace.com">support@letterbrace.com</a>
+        </p>
+      </Section>
+    </LegalPage>
+  );
+}

--- a/components/legal.tsx
+++ b/components/legal.tsx
@@ -1,0 +1,84 @@
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { Logo } from "@/components/logo";
+import { ThemeToggle } from "@/components/theme";
+
+// Shared chrome for the public legal pages (/privacy, /terms). Kept separate
+// from the marketing page's nav so these stay readable and link-stable — they
+// get cited from Google's OAuth consent screen and from client contracts.
+
+export function LegalPage({
+  title,
+  updated,
+  intro,
+  children,
+}: {
+  title: string;
+  updated: string;
+  intro: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="min-h-screen bg-paper">
+      <header className="border-b border-ink/10">
+        <div className="mx-auto flex max-w-3xl items-center justify-between px-5 py-5">
+          <Link href="/" className="inline-flex items-center gap-2">
+            <Logo />
+          </Link>
+          <div className="flex items-center gap-3">
+            <ThemeToggle />
+            <Link
+              href="/"
+              className="inline-flex items-center gap-1 text-sm text-ink-faint transition hover:text-ink"
+            >
+              <ArrowLeft className="h-4 w-4" aria-hidden /> Back
+            </Link>
+          </div>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-3xl px-5 py-14">
+        <h1 className="font-serif text-4xl font-semibold tracking-tight text-ink">{title}</h1>
+        <p className="mt-3 text-sm text-ink-faint">Last updated {updated}</p>
+        <p className="mt-6 text-base leading-relaxed text-ink-soft">{intro}</p>
+
+        <div className="mt-12 space-y-10">{children}</div>
+
+        <div className="mt-16 border-t border-ink/10 pt-8 text-sm text-ink-faint">
+          <p>
+            Lettertrace is operated by The Letter Company.{" "}
+            <Link href="/privacy" className="text-terracotta-dark hover:text-terracotta">
+              Privacy Policy
+            </Link>{" "}
+            ·{" "}
+            <Link href="/terms" className="text-terracotta-dark hover:text-terracotta">
+              Terms of Service
+            </Link>
+          </p>
+        </div>
+      </main>
+    </div>
+  );
+}
+
+export function Section({
+  n,
+  title,
+  children,
+}: {
+  n: number;
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section id={`s${n}`} className="scroll-mt-8">
+      <h2 className="font-serif text-2xl font-semibold text-ink">
+        <span className="mr-2 text-ink-faint/70">{n}.</span>
+        {title}
+      </h2>
+      <div className="mt-4 space-y-4 text-base leading-relaxed text-ink-soft [&_a]:text-terracotta-dark [&_a:hover]:text-terracotta [&_code]:rounded [&_code]:bg-ink/5 [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-sm [&_li]:leading-relaxed [&_strong]:font-semibold [&_strong]:text-ink [&_ul]:list-disc [&_ul]:space-y-2 [&_ul]:pl-6">
+        {children}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
Dedicated `/privacy` and `/terms` pages for the hosted service, operated by **The Letter Company**, matching the structure and contacts used on Letterstory (`privacy@letterbrace.com`, `support@letterbrace.com`).

> ⚠️ **These are drafts and have not been reviewed by a lawyer.** They are written to be accurate about what the product does, which is the part an outside template can't get right — but accuracy is not the same as legal sufficiency. See "Before relying on these" below.

## Written against what Lettertrace actually does

The clauses that matter here are the ones a generic policy wouldn't contain:

- **What we send to AI providers.** Under bring-your-own-key, run traffic goes to Anthropic/OpenAI *under the user's own provider account*, governed by their agreement with that provider rather than by our policy. Also warns not to put personal or confidential data into prompts, since prompts are transmitted to a third party.
- **Costs.** Provider charges are the user's, scheduled runs repeat that cost unattended, and prompt count, model, replicates, and web search all move it.
- **Accuracy** (Terms §6). Models are not deterministic — the same prompt can return a different answer each run, which we measured directly while building this. The terms say so plainly: reported rates are sample estimates carrying confidence intervals, detection is literal text matching that can miss or over-match, and sentiment is model-produced and can be wrong. Overclaiming what the product measures would have been the easiest way to get this wrong, and it's the clause most likely to matter if a client ever disputes a number.
- **Security specifics** that are true of this codebase: AES-256-GCM per-key encryption with unique IVs, SHA-256-hashed API keys, Postgres RLS isolation.
- **Open source vs hosted.** The MIT-licensed source and the service we run are separate; self-hosted deployments send us nothing and aren't covered.

Privacy also covers the site-scraping step during onboarding, cookies (auth only, no tracking), retention and cascade deletion, GDPR/UK GDPR/CCPA rights, and international transfers.

## Also fixes the footer

Every footer link pointed at `GITHUB_URL` regardless of its label — including the one that said "Privacy". `FooterCol` now takes `{label, href}` pairs, and Company links to the two new pages plus a contact mailto.

## Before relying on these

1. **No governing law or jurisdiction clause.** Letterstory's terms omit it too, so I matched rather than inventing a state. This is the single biggest gap and needs a decision.
2. **Liability cap is $100 or 12 months of fees**, chosen because the service is currently free. Revisit before charging.
3. **§12 states the service is free** — must be updated before launching paid plans.
4. **Verify the contacts are monitored.** Both are inherited from Letterstory.
5. **A lawyer should review both**, particularly the liability, indemnification, and warranty sections.

## Verification

Typecheck, lint, and a production build pass. Both render as static routes (2.13 kB each) and were checked live at `/privacy` (14 sections) and `/terms` (18 sections), with footer links resolving.

Independent of #12 and #13 — touches only new files plus the landing page footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
