### PR TITLE
Stop the legal pages promising a public repo

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -367,8 +367,8 @@ export default function LandingPage() {
             title="Open source"
             links={[
               { label: "GitHub", href: GITHUB_URL },
-              { label: "MIT License", href: `${GITHUB_URL}/blob/main/LICENSE` },
-              { label: "Self-host guide", href: `${GITHUB_URL}#getting-started` },
+              { label: "MIT License", href: GITHUB_URL },
+              { label: "Self-host guide", href: GITHUB_URL },
             ]}
           />
           <FooterCol

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -14,7 +14,7 @@ export default function PrivacyPage() {
     <LegalPage
       title="Privacy Policy"
       updated={UPDATED}
-      intro="Lettertrace is operated by The Letter Company. This policy explains what we collect when you use the hosted service at lettertrace.com, why we collect it, and who else sees it. Lettertrace is also open source — if you self-host it, this policy does not apply to your deployment, because we never receive your data."
+      intro="Lettertrace is operated by The Letter Company. This policy explains what we collect when you use the hosted service at lettertrace.com, why we collect it, and who else sees it."
     >
       <Section n={1} title="Information we collect">
         <p><strong>Account information.</strong> Your email address, and — if you sign in with Google or GitHub — the name and profile picture that provider returns. We never receive your Google or GitHub password.</p>
@@ -96,8 +96,8 @@ export default function PrivacyPage() {
         <p>The Letter Company operates in the United States, and our service providers process data in the United States and other countries. Using Lettertrace means your information may be transferred to and processed in those countries.</p>
       </Section>
 
-      <Section n={12} title="Self-hosting">
-        <p>Lettertrace is open source under the MIT licence. If you run your own instance, your data stays in your own infrastructure and we receive none of it. This policy covers only the hosted service we operate at lettertrace.com.</p>
+      <Section n={12} title="Scope of this policy">
+        <p>This policy covers the hosted Lettertrace service that we operate at lettertrace.com. It does not cover any separately operated deployment of the software, where we would neither hold nor receive the data.</p>
       </Section>
 
       <Section n={13} title="Changes to this policy">

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -14,7 +14,7 @@ export default function TermsPage() {
     <LegalPage
       title="Terms of Service"
       updated={UPDATED}
-      intro="These terms govern your use of the hosted Lettertrace service at lettertrace.com, operated by The Letter Company. Lettertrace's source code is separately available under the MIT licence; these terms apply to the service we run, not to the code."
+      intro="These terms govern your use of the hosted Lettertrace service at lettertrace.com, operated by The Letter Company."
     >
       <Section n={1} title="Agreement">
         <p>By creating an account or using Lettertrace, you agree to these terms. If you are using it on behalf of a company, you confirm you have authority to bind that company, and &quot;you&quot; means that company. If you do not agree, do not use the service.</p>
@@ -71,8 +71,8 @@ export default function TermsPage() {
         <p>Lettertrace depends on Anthropic, OpenAI, Supabase, Vercel, and — if you use social sign-in — Google and GitHub. We do not control those services. Outages, changes, price increases, or policy changes on their side may affect or interrupt Lettertrace, and we are not liable for them.</p>
       </Section>
 
-      <Section n={10} title="Open source and self-hosting">
-        <p>Lettertrace&apos;s source is released under the MIT licence, and you are free to run your own instance under that licence. These terms govern only the hosted service we operate. We provide no warranty or support for self-hosted deployments, and we are not responsible for how they behave.</p>
+      <Section n={10} title="Scope of these terms">
+        <p>These terms govern the hosted service we operate at lettertrace.com. They do not grant any licence to the Lettertrace software itself, and they do not cover any separately operated deployment of it — we provide no warranty or support for those and are not responsible for how they behave.</p>
       </Section>
 
       <Section n={11} title="Availability and changes">


### PR DESCRIPTION
The privacy policy and terms both claimed Lettertrace is open source under MIT and that users may run their own instance. The repo is private, so neither is true for a reader — and an inaccurate claim in a privacy policy matters more than a broken link.

Both sections are reframed as **scope** rather than deleted, so section numbers stay stable for anyone who has already cited them. They now state that the documents cover the hosted service at lettertrace.com, grant no licence to the software, and do not cover separately operated deployments. That stays accurate whether or not the source is published later.

Also reverts two footer links I built on `GITHUB_URL`, which is still the placeholder `https://github.com` — appending `/blob/main/LICENSE` to it produced a 404 where the link had previously just been unhelpful.

### Still open for you to decide

The **landing page** still markets the product as open source: the hero badge reads `open-source · bring-your-own-key`, there's a "Star on GitHub" CTA, and an entire "Open source" section — all pointing at `https://github.com` because `GITHUB_URL` was never set to a real repo. With the repo private those claims have the same problem the legal pages did, but changing marketing copy is your call rather than mine.

Typecheck, lint, and a production build pass.
