### PR TITLE
Reject incomplete onboarding topics instead of dropping them

### DIFF
--- a/app/api/onboarding/complete/route.ts
+++ b/app/api/onboarding/complete/route.ts
@@ -60,17 +60,36 @@ export async function POST(request: Request) {
       : null;
   const brand_aliases = toStringArray(body.brand_aliases);
 
+  // toStringArray already drops blank entries, so an unused question input is
+  // simply ignored — but a topic with NO usable question, or no name, is a
+  // mistake we refuse rather than quietly drop. Silently filtering these meant
+  // a caller could send three topics, get 201, and find one saved.
   const topics: TopicInput[] = Array.isArray(body.topics)
-    ? (body.topics as unknown[])
-        .map((t) => {
-          const o = (t ?? {}) as Record<string, unknown>;
-          return {
-            name: typeof o.name === "string" ? o.name.trim() : "",
-            prompts: toStringArray(o.prompts),
-          };
-        })
-        .filter((t) => t.name.length > 0 && t.prompts.length > 0)
+    ? (body.topics as unknown[]).map((t) => {
+        const o = (t ?? {}) as Record<string, unknown>;
+        return {
+          name: typeof o.name === "string" ? o.name.trim() : "",
+          prompts: toStringArray(o.prompts),
+        };
+      })
     : [];
+
+  const incomplete = topics
+    .map((t, i) => ({ i, t }))
+    .filter(({ t }) => !t.name || t.prompts.length === 0);
+
+  if (incomplete.length > 0) {
+    const { i, t } = incomplete[0];
+    return NextResponse.json(
+      {
+        error: !t.name
+          ? `Topic ${i + 1} needs a name.`
+          : `Topic "${t.name}" needs at least one question.`,
+        incompleteTopics: incomplete.map(({ i }) => i),
+      },
+      { status: 400 },
+    );
+  }
 
   const provider = pickDefaultProvider();
   const model = defaultModelFor(provider);

--- a/app/api/onboarding/onboarding-route.test.ts
+++ b/app/api/onboarding/onboarding-route.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// The route pulls in the Supabase server client (next/headers) and the trial
+// layer; we only care about the request validation that runs before any of it.
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: () => ({
+    auth: { getUser: async () => ({ data: { user: { id: "user-1" } } }) },
+    from: () => {
+      throw new Error("validation should reject before touching the database");
+    },
+  }),
+}));
+// lib/data uses React's cache(), which only exists in a server-component
+// runtime — same treatment the v1 route tests give it.
+vi.mock("@/lib/data", () => ({ setActiveProject: vi.fn() }));
+vi.mock("@/lib/llm", () => ({ humanError: (e: unknown) => String(e) }));
+vi.mock("@/lib/trial", () => ({
+  pickDefaultProvider: () => "anthropic",
+  resolveRunKey: vi.fn(),
+  recordTrialUsage: vi.fn(),
+  consumeTrialRun: vi.fn(),
+}));
+vi.mock("@/lib/engine", () => ({ executeRun: vi.fn() }));
+
+const { POST } = await import("@/app/api/onboarding/complete/route");
+
+function req(body: unknown) {
+  return new Request("http://localhost/api/onboarding/complete", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+const BASE = { brand_name: "Acme", name: "Acme", brand_domains: ["acme.com"] };
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("POST /api/onboarding/complete — topic validation", () => {
+  // The reported bug: both of these used to be silently dropped, the request
+  // succeeded, and the user's remaining topics were quietly not saved.
+  it("rejects a topic with questions but no name", async () => {
+    const res = await POST(
+      req({ ...BASE, topics: [{ name: "", prompts: ["what is an ai native erp?"] }] }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/needs a name/);
+    expect(body.incompleteTopics).toEqual([0]);
+  });
+
+  it("rejects a topic with a name but no questions", async () => {
+    const res = await POST(req({ ...BASE, topics: [{ name: "tbd", prompts: [] }] }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/needs at least one question/);
+  });
+
+  it("rejects a topic whose only question is blank", async () => {
+    const res = await POST(req({ ...BASE, topics: [{ name: "CDN", prompts: ["   "] }] }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/needs at least one question/);
+  });
+
+  it("does not let one good topic mask a bad one", async () => {
+    const res = await POST(
+      req({
+        ...BASE,
+        topics: [
+          { name: "CDN", prompts: ["best cdn?"] },
+          { name: "", prompts: ["what is an ai native erp?"] },
+          { name: "tbd", prompts: [] },
+        ],
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).incompleteTopics).toEqual([1, 2]);
+  });
+
+  // Explicitly allowed: an unused blank question row alongside a real one.
+  // Reaching the database mock (which throws by design) is the proof that
+  // validation let this through rather than rejecting it.
+  it("accepts a topic with a filled question plus an empty input", async () => {
+    await expect(
+      POST(req({ ...BASE, topics: [{ name: "CDN", prompts: ["best cdn?", "  "] }] })),
+    ).rejects.toThrow("validation should reject before touching the database");
+  });
+
+  it("still requires a brand name", async () => {
+    const res = await POST(req({ topics: [{ name: "CDN", prompts: ["best cdn?"] }] }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/dashboard/onboarding.tsx
+++ b/app/dashboard/onboarding.tsx
@@ -12,6 +12,7 @@ import {
   X,
 } from "lucide-react";
 import { Badge, Button, Card, CardBody, Input, Label, Spinner, Textarea } from "@/components/ui";
+import { cn } from "@/lib/utils";
 
 interface Topic {
   name: string;
@@ -32,6 +33,10 @@ export function Onboarding() {
 
   // Step 2: topics
   const [topics, setTopics] = useState<Topic[]>([]);
+  // Per-block validation, keyed by topic index. Blocks used to be dropped
+  // silently when incomplete, so a user could "start monitoring" with three
+  // topics on screen and have one saved.
+  const [issues, setIssues] = useState<Record<number, "name" | "prompts">>({});
   const [note, setNote] = useState<string | null>(null);
 
   const [busy, setBusy] = useState(false);
@@ -118,17 +123,38 @@ export function Onboarding() {
 
   // --- Step 2 -> complete + run ----------------------------------------------
   async function handleStart() {
-    const cleaned = topics
-      .map((t) => ({
-        name: t.name.trim(),
-        prompts: t.prompts.map((p) => p.trim()).filter(Boolean),
-      }))
-      .filter((t) => t.name && t.prompts.length);
+    const cleaned = topics.map((t) => ({
+      name: t.name.trim(),
+      // Blank question rows are fine — they're just unused inputs, so drop
+      // them. A block is only invalid when it has no filled question at all.
+      prompts: t.prompts.map((p) => p.trim()).filter(Boolean),
+    }));
 
     if (cleaned.length === 0) {
       setError("Add at least one topic with a question before you start.");
       return;
     }
+
+    // Flag every incomplete block rather than discarding it. Missing name is
+    // reported first so a block with neither shows the topmost problem.
+    const found: Record<number, "name" | "prompts"> = {};
+    cleaned.forEach((t, i) => {
+      if (!t.name) found[i] = "name";
+      else if (t.prompts.length === 0) found[i] = "prompts";
+    });
+
+    if (Object.keys(found).length > 0) {
+      setIssues(found);
+      const n = Object.keys(found).length;
+      setError(
+        n === 1
+          ? "One topic is incomplete. Every topic needs a name and at least one question."
+          : `${n} topics are incomplete. Every topic needs a name and at least one question.`,
+      );
+      return;
+    }
+
+    setIssues({});
     setError(null);
     setBusy(true);
     setStep("searching");
@@ -265,9 +291,16 @@ export function Onboarding() {
                   <div className="flex items-center gap-2">
                     <Input
                       value={topic.name}
-                      onChange={(e) => setTopicName(ti, e.target.value)}
+                      onChange={(e) => {
+                        setTopicName(ti, e.target.value);
+                        if (issues[ti]) setIssues((m) => ({ ...m, [ti]: undefined! }));
+                      }}
                       placeholder="Topic (e.g. project management software)"
-                      className="font-medium"
+                      aria-invalid={issues[ti] === "name" || undefined}
+                      className={cn(
+                        "font-medium",
+                        issues[ti] === "name" && "border-terracotta focus:border-terracotta",
+                      )}
                     />
                     <button
                       type="button"
@@ -286,9 +319,16 @@ export function Onboarding() {
                         </span>
                         <Input
                           value={prompt}
-                          onChange={(e) => setPrompt(ti, pi, e.target.value)}
+                          onChange={(e) => {
+                            setPrompt(ti, pi, e.target.value);
+                            if (issues[ti]) setIssues((m) => ({ ...m, [ti]: undefined! }));
+                          }}
                           placeholder="A question someone asks an AI assistant"
-                          className="text-sm"
+                          aria-invalid={issues[ti] === "prompts" || undefined}
+                          className={cn(
+                            "text-sm",
+                            issues[ti] === "prompts" && "border-terracotta focus:border-terracotta",
+                          )}
                         />
                         <button
                           type="button"
@@ -309,6 +349,13 @@ export function Onboarding() {
                       Add question
                     </button>
                   </div>
+                  {issues[ti] && (
+                    <p className="text-sm text-terracotta-dark">
+                      {issues[ti] === "name"
+                        ? "Give this topic a name, or remove it."
+                        : "Add at least one question, or remove this topic."}
+                    </p>
+                  )}
                 </CardBody>
               </Card>
             ))}


### PR DESCRIPTION
You could press **Start monitoring** with a topic that had a question but no name, or a name but no questions, and the run would begin.

## The bug is worse than missing validation

Both layers *filtered* the bad blocks out rather than rejecting them:

```ts
onboarding.tsx:125     .filter((t) => t.name && t.prompts.length)
complete/route.ts:72   .filter((t) => t.name.length > 0 && t.prompts.length > 0)
```

So a user who set up three topics could get one saved and never be told. That's worse than an error — nothing looks wrong until the results come back thinner than expected, and by then the cause is invisible.

## Behaviour now

Every block needs a name and at least one non-blank question.

- **Client** flags each offending block inline ("Give this topic a name, or remove it." / "Add at least one question, or remove this topic."), marks the field, and clears the flag as soon as you type in it. The summary line reports how many blocks are incomplete.
- **API** returns 400 naming the first problem, plus `incompleteTopics` with every offending index — rather than a 201 that quietly did less than asked.

**Blank question rows are still allowed**, per the requirement: an unused input alongside a filled one is ignored. That's the common case where someone hits "Add question" and changes their mind. Only a block with *no* usable question is an error.

## Tests

Six route tests: both reported cases, a blank-only question, one bad topic hiding behind a good one (`incompleteTopics: [1, 2]`), the allowed empty-row case, and the existing brand-name requirement. 112 tests pass overall; lint and build clean.

## One to confirm with Matthew

Casey flagged "at least one question per block" as worth checking. It's implemented as a hard requirement. If a named topic with zero questions should instead be allowed — saved for later, generating nothing — that's a one-line relaxation on each side and I'd rather change it than have you work around it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
