### PR TITLE
Let trial users press the run button

### DIFF
--- a/app/dashboard/runs/page.tsx
+++ b/app/dashboard/runs/page.tsx
@@ -1,6 +1,7 @@
 import { ArrowRight, PlayCircle } from "lucide-react";
 import { createClient } from "@/lib/supabase/server";
-import { getProject, getConfiguredProviders } from "@/lib/data";
+import { getProject } from "@/lib/data";
+import { resolveKey } from "@/lib/trial";
 import { PROVIDERS, modelLabel } from "@/lib/models";
 import { timeAgo } from "@/lib/utils";
 import type { Run, RunStatus } from "@/lib/types";
@@ -48,8 +49,16 @@ export default async function RunsPage() {
     );
   }
 
-  const configuredProviders = await getConfiguredProviders(supabase, user.id);
-  const hasKey = configuredProviders.includes(project.default_provider);
+  // Ask the same resolver the run endpoint uses. Gating the button on a BYOK
+  // key alone disabled it for trial users who had free runs left — the server
+  // would have accepted the request the UI refused to send.
+  const key = await resolveKey(
+    supabase,
+    user.id,
+    project.default_provider,
+    project.default_model,
+  );
+  const canRun = key.source === "own" || key.source === "trial";
 
   const { count: activePrompts } = await supabase
     .from("prompts")
@@ -68,13 +77,17 @@ export default async function RunsPage() {
     <div className="space-y-8">
       <SectionHeading
         title="Runs"
+        // The model that will ACTUALLY run: a trial run is forced onto the
+        // provider's cheap model, so naming the project default here told
+        // users to expect Opus and then handed them Haiku.
         description={`Each run asks your active prompts to ${modelLabel(
-          project.default_provider,
-          project.default_model,
+          key.provider,
+          key.model,
         )} and records where your brand shows up.`}
         action={
           <RunNow
-            hasKey={hasKey}
+            canRun={canRun}
+            keySource={key.source}
             activePrompts={activePrompts ?? 0}
             providerLabel={PROVIDERS[project.default_provider].label}
           />

--- a/app/dashboard/runs/run-now.tsx
+++ b/app/dashboard/runs/run-now.tsx
@@ -7,11 +7,14 @@ import { Play } from "lucide-react";
 import { Button, Spinner } from "@/components/ui";
 
 export function RunNow({
-  hasKey,
+  canRun,
+  keySource,
   activePrompts,
   providerLabel,
 }: {
-  hasKey: boolean;
+  canRun: boolean;
+  /** Why we can or can't run, so the hint names the actual blocker. */
+  keySource: "own" | "trial" | "none" | "exhausted";
   activePrompts: number;
   providerLabel: string;
 }) {
@@ -19,7 +22,7 @@ export function RunNow({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const disabled = loading || !hasKey || activePrompts === 0;
+  const disabled = loading || !canRun || activePrompts === 0;
 
   async function run() {
     setLoading(true);
@@ -54,16 +57,25 @@ export function RunNow({
         )}
       </Button>
 
-      {!hasKey && (
+      {keySource === "exhausted" && (
         <p className="text-xs text-ink-faint">
-          Add a {providerLabel} key in{" "}
+          Your free runs are used up. Add your {providerLabel} key in{" "}
+          <Link href="/dashboard/settings" className="text-terracotta-dark hover:text-terracotta">
+            Settings
+          </Link>{" "}
+          to keep going.
+        </p>
+      )}
+      {keySource === "none" && (
+        <p className="text-xs text-ink-faint">
+          Add your {providerLabel} key in{" "}
           <Link href="/dashboard/settings" className="text-terracotta-dark hover:text-terracotta">
             Settings
           </Link>{" "}
           to run.
         </p>
       )}
-      {hasKey && activePrompts === 0 && (
+      {canRun && activePrompts === 0 && (
         <p className="text-xs text-ink-faint">
           Add active prompts in{" "}
           <Link href="/dashboard/topics" className="text-terracotta-dark hover:text-terracotta">

--- a/lib/trial.test.ts
+++ b/lib/trial.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getDecryptedKey } from "@/lib/data";
+import { resolveKey } from "@/lib/trial";
+
+vi.mock("@/lib/data", () => ({ getDecryptedKey: vi.fn() }));
+
+// getTrialRunsUsed reads profiles.trial_runs_used; everything else in resolveKey
+// is env + the mocked key lookup.
+function db(runsUsed: number) {
+  return {
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: async () => ({ data: { trial_runs_used: runsUsed } }),
+        }),
+      }),
+    }),
+  } as never;
+}
+
+const ENV = { ...process.env };
+beforeEach(() => {
+  vi.mocked(getDecryptedKey).mockReset().mockResolvedValue(null);
+  delete process.env.TRIAL_ANTHROPIC_API_KEY;
+  delete process.env.TRIAL_OPENAI_API_KEY;
+  process.env.TRIAL_RUN_LIMIT = "5";
+});
+afterEach(() => {
+  process.env = { ...ENV };
+});
+
+describe("resolveKey", () => {
+  it("uses the user's own key when they have one", async () => {
+    vi.mocked(getDecryptedKey).mockResolvedValue("sk-ant-own");
+    const k = await resolveKey(db(0), "user-1", "anthropic");
+    expect(k.source).toBe("own");
+    expect(k.apiKey).toBe("sk-ant-own");
+  });
+
+  // The bug this guards: the runs page gated its button on a BYOK key alone,
+  // so a trial user with free runs left saw it disabled even though the run
+  // endpoint — which calls this same resolver — would have accepted it.
+  it("falls back to the trial key when none of the user's own exist and runs remain", async () => {
+    process.env.TRIAL_ANTHROPIC_API_KEY = "sk-ant-trial";
+    const k = await resolveKey(db(1), "user-1", "anthropic");
+    expect(k.source).toBe("trial");
+    expect(k.remaining).toBe(4);
+    expect(k.limit).toBe(5);
+  });
+
+  it("reports exhausted once the allowance is spent", async () => {
+    process.env.TRIAL_ANTHROPIC_API_KEY = "sk-ant-trial";
+    const k = await resolveKey(db(5), "user-1", "anthropic");
+    expect(k.source).toBe("exhausted");
+    expect(k.remaining).toBe(0);
+  });
+
+  it("reports none when no trial key is configured at all", async () => {
+    const k = await resolveKey(db(0), "user-1", "anthropic");
+    expect(k.source).toBe("none");
+  });
+
+  // A trial run is forced onto the provider's cheap model, which is why the
+  // runs page must name k.model rather than the project's default — it said
+  // "Claude Opus 4.8" and then ran Haiku.
+  it("returns the trial model, not the requested one", async () => {
+    process.env.TRIAL_ANTHROPIC_API_KEY = "sk-ant-trial";
+    process.env.TRIAL_ANTHROPIC_MODEL = "claude-haiku-4-5";
+    const k = await resolveKey(db(0), "user-1", "anthropic", "claude-opus-4-8");
+    expect(k.model).toBe("claude-haiku-4-5");
+  });
+
+  it("honours the requested model when using the user's own key", async () => {
+    vi.mocked(getDecryptedKey).mockResolvedValue("sk-ant-own");
+    const k = await resolveKey(db(0), "user-1", "anthropic", "claude-opus-4-8");
+    expect(k.model).toBe("claude-opus-4-8");
+  });
+
+  it("respects a configured TRIAL_RUN_LIMIT", async () => {
+    process.env.TRIAL_ANTHROPIC_API_KEY = "sk-ant-trial";
+    process.env.TRIAL_RUN_LIMIT = "2";
+    expect((await resolveKey(db(1), "u", "anthropic")).source).toBe("trial");
+    expect((await resolveKey(db(2), "u", "anthropic")).source).toBe("exhausted");
+  });
+});


### PR DESCRIPTION
The runs page decided whether you could run from BYOK keys alone:

```ts
// app/dashboard/runs/page.tsx:52
const hasKey = configuredProviders.includes(project.default_provider);
```

Trial access never entered into it. A user with **4 of 5 free runs left** saw "Run monitor now" greyed out under *"Add a Anthropic (Claude) key in Settings to run"* — while the banner directly above advertised those free runs, and `POST /api/runs` (which resolves keys through `resolveKey`) would have happily accepted the request the UI refused to send. That same user's previous run had already completed on the trial key.

## Fix

The page now asks `resolveKey` — the resolver the run endpoint itself uses — so the button reflects what the server will actually do. The hint names the real blocker instead of assuming one:

| `key.source` | Button | Hint |
|---|---|---|
| `own` | enabled | — |
| `trial` | **enabled** (was disabled) | — |
| `exhausted` | disabled | "Your free runs are used up. Add your … key to keep going." |
| `none` | disabled | "Add your … key in Settings to run." |

## Second bug, same screenshot

The heading read *"Each run asks your active prompts to **Claude Opus 4.8**"* while the completed run below it said **Claude Haiku 4.5**. A trial run is forced onto the provider's cheap model (`TRIAL_ANTHROPIC_MODEL`), so naming the project default promised one model and delivered another. It now names the model that will actually answer.

## Tests

Seven new tests over `resolveKey` covering all four sources — including the one this bug turned on, no own key with runs remaining → `trial` — plus the trial model override and a configured `TRIAL_RUN_LIMIT`. 119 tests pass; lint and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
