### PR TITLE
Say why share of voice is empty instead of "not yet"

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -377,9 +377,32 @@ export default async function DashboardPage() {
             <p className="mt-0.5 text-sm text-ink-faint">
               You vs. tracked competitors in the latest run.
             </p>
-            <div className="mt-4">
-              <ShareBars data={shareBarData} />
-            </div>
+            {/* Mention detection only looks for the brand and the competitors
+                this project tracks, so with none configured the chart can
+                never populate no matter what the answers said. "No share of
+                voice yet" gave no hint of that — say which of the two is
+                actually the problem. */}
+            {competitors === 0 ? (
+              <div className="mt-4 rounded-2xl border border-dashed border-ink/15 px-5 py-8 text-center">
+                <p className="text-sm text-ink-soft">
+                  No competitors tracked yet, so there is nothing to compare against.
+                </p>
+                <p className="mt-1 text-sm text-ink-faint">
+                  We only look for brands you list — companies named in an answer are
+                  invisible until you add them.
+                </p>
+                <Link
+                  href="/dashboard/competitors"
+                  className="mt-3 inline-block text-sm font-medium text-terracotta-dark transition hover:text-terracotta"
+                >
+                  Add competitors →
+                </Link>
+              </div>
+            ) : (
+              <div className="mt-4">
+                <ShareBars data={shareBarData} />
+              </div>
+            )}
             <ul className="mt-4 space-y-2">
               {shareEntities.map((s, i) => (
                 <li


### PR DESCRIPTION
Reported against the Doss project: companies **are** named in the run's answers, but the share-of-voice card reads "No share of voice yet".

## Why it's empty

Mention detection is a closed set. `lib/engine.ts:180` only looks for the brand and the competitors the project tracks:

```ts
for (const c of competitors) {                    // ← the project's competitor rows
  const hit = detectMention(answer, [c.name, ...c.aliases]);
```

A company named in an answer that isn't on that list produces **no mention row at all**. And a project created through onboarding has no competitors — the flow builds topics and prompts and never touches them (`grep -c competitor` on both onboarding files returns 0).

So the chart could never populate, however good the answers were. "No share of voice yet" reads like a matter of waiting, which sent the reporter looking for a bug in the chart rather than at the empty competitor list.

## Change

The card now distinguishes the two causes. With no competitors tracked it says so, explains that companies named in an answer stay invisible until they're listed, and links to the page that fixes it. With competitors tracked it renders as before.

Presentation only — no change to detection or metrics.

## Two related gaps this does *not* close

1. **Onboarding still produces a project with no competitors**, so every new project starts unable to show share of voice. Adding a competitors step, or seeding from `suggestCompetitors`, is a product decision rather than a bug fix — worth a deliberate call.
2. **An unmentioned brand is dropped from the report entirely** rather than shown at 0%. That's why "Doss" appears nowhere in the chart even as a zero bar, which is the other half of what was expected here. Fixed by the metrics work in #13, which synthesises the zero row.

Typecheck, lint, 119 tests, and a production build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
