### PR TITLE
Require your own API key before adding a second organization

### DIFF
--- a/app/api/onboarding/complete/route.ts
+++ b/app/api/onboarding/complete/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
-import { setActiveProject } from "@/lib/data";
+import { getConfiguredProviders, getProjects, setActiveProject } from "@/lib/data";
 import { executeRun } from "@/lib/engine";
 import { humanError } from "@/lib/llm";
 import { resolveRunKey, consumeTrialRun, recordTrialUsage, pickDefaultProvider } from "@/lib/trial";
@@ -49,6 +49,25 @@ export async function POST(request: Request) {
   const brand_name = typeof body.brand_name === "string" ? body.brand_name.trim() : "";
   if (!brand_name) {
     return NextResponse.json({ error: "Brand name is required." }, { status: 400 });
+  }
+
+  // The first organization is free; another one needs the user's own key.
+  // Enforced here as well as in the UI: without it, a second org could be
+  // created by posting straight to this route, and its first monitor would
+  // quietly spend one of the account's free runs.
+  const [existingProjects, providers] = await Promise.all([
+    getProjects(supabase, user.id),
+    getConfiguredProviders(supabase, user.id),
+  ]);
+  if (existingProjects.length > 0 && providers.length === 0) {
+    return NextResponse.json(
+      {
+        error:
+          "Add your own API key before monitoring another brand. Free credits cover your first organization.",
+        needsKey: true,
+      },
+      { status: 403 },
+    );
   }
   const name =
     typeof body.name === "string" && body.name.trim() ? body.name.trim() : brand_name;

--- a/app/api/onboarding/onboarding-route.test.ts
+++ b/app/api/onboarding/onboarding-route.test.ts
@@ -12,7 +12,11 @@ vi.mock("@/lib/supabase/server", () => ({
 }));
 // lib/data uses React's cache(), which only exists in a server-component
 // runtime — same treatment the v1 route tests give it.
-vi.mock("@/lib/data", () => ({ setActiveProject: vi.fn() }));
+vi.mock("@/lib/data", () => ({
+  setActiveProject: vi.fn(),
+  getProjects: vi.fn(async () => []),
+  getConfiguredProviders: vi.fn(async () => []),
+}));
 vi.mock("@/lib/llm", () => ({ humanError: (e: unknown) => String(e) }));
 vi.mock("@/lib/trial", () => ({
   pickDefaultProvider: () => "anthropic",
@@ -22,6 +26,7 @@ vi.mock("@/lib/trial", () => ({
 }));
 vi.mock("@/lib/engine", () => ({ executeRun: vi.fn() }));
 
+const { getProjects, getConfiguredProviders } = await import("@/lib/data");
 const { POST } = await import("@/app/api/onboarding/complete/route");
 
 function req(body: unknown) {
@@ -87,5 +92,39 @@ describe("POST /api/onboarding/complete — topic validation", () => {
   it("still requires a brand name", async () => {
     const res = await POST(req({ topics: [{ name: "CDN", prompts: ["best cdn?"] }] }));
     expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /api/onboarding/complete — second-organization gate", () => {
+  const good = { ...BASE, topics: [{ name: "CDN", prompts: ["best cdn?"] }] };
+
+  it("refuses a second org on the trial, before spending a free run", async () => {
+    vi.mocked(getProjects).mockResolvedValue([{ id: "p1" } as never]);
+    vi.mocked(getConfiguredProviders).mockResolvedValue([]);
+    const res = await POST(req(good));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.needsKey).toBe(true);
+    expect(body.error).toMatch(/own API key/);
+  });
+
+  it("allows a second org once the user has their own key", async () => {
+    vi.mocked(getProjects).mockResolvedValue([{ id: "p1" } as never]);
+    vi.mocked(getConfiguredProviders).mockResolvedValue(["anthropic"]);
+    // Reaching the database mock proves the gate let it through.
+    await expect(POST(req(good))).rejects.toThrow(/before touching the database/);
+  });
+
+  it("always allows the first org, key or not", async () => {
+    vi.mocked(getProjects).mockResolvedValue([]);
+    vi.mocked(getConfiguredProviders).mockResolvedValue([]);
+    await expect(POST(req(good))).rejects.toThrow(/before touching the database/);
+  });
+
+  it("gates before validating topics, so no free run is risked either way", async () => {
+    vi.mocked(getProjects).mockResolvedValue([{ id: "p1" } as never]);
+    vi.mocked(getConfiguredProviders).mockResolvedValue([]);
+    const res = await POST(req({ ...BASE, topics: [{ name: "", prompts: [] }] }));
+    expect(res.status).toBe(403);
   });
 });

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -30,16 +30,17 @@ export default async function DashboardLayout({
   // Trial banner state: only when a trial is offered and the user is relying on
   // shared keys. Key resolution prefers the user's own key from EITHER
   // provider, so any own key at all means they're never on the trial.
+  const providers = await getConfiguredProviders(supabase, user.id);
+
+  // The first organization is free; another one needs the user's own key.
+  // Existing orgs are untouched — this only gates creating more.
+  const canAddOrg = projects.length === 0 || providers.length > 0;
+
   let trial: { used: number; limit: number; exhausted: boolean } | null = null;
-  if (project && trialEnabled()) {
-    const [providers, used] = await Promise.all([
-      getConfiguredProviders(supabase, user.id),
-      getTrialRunsUsed(supabase, user.id),
-    ]);
-    if (providers.length === 0) {
-      const limit = trialRunLimit();
-      trial = { used, limit, exhausted: used >= limit };
-    }
+  if (project && trialEnabled() && providers.length === 0) {
+    const used = await getTrialRunsUsed(supabase, user.id);
+    const limit = trialRunLimit();
+    trial = { used, limit, exhausted: used >= limit };
   }
 
   return (
@@ -56,6 +57,7 @@ export default async function DashboardLayout({
                 brandName: p.brand_name,
               }))}
               activeId={project.id}
+              canAddOrg={canAddOrg}
             />
           ) : (
             <div className="rounded-2xl border border-ink/10 bg-paper-shade/50 px-4 py-3">

--- a/app/dashboard/new/page.tsx
+++ b/app/dashboard/new/page.tsx
@@ -1,9 +1,31 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { getConfiguredProviders, getProjects } from "@/lib/data";
 import { Onboarding } from "../onboarding";
 
 export const dynamic = "force-dynamic";
 
 // Add another organization to the account: same wizard as first-run onboarding.
 // Completing it creates the org, makes it active, and runs its first monitor.
-export default function NewOrganizationPage() {
+//
+// Gated to match the switcher — the nav item is hidden without a key, but the
+// route is reachable by URL, and completing it would spend a free run on an
+// org that can't produce a usable result yet.
+export default async function NewOrganizationPage() {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return null;
+
+  const [projects, providers] = await Promise.all([
+    getProjects(supabase, user.id),
+    getConfiguredProviders(supabase, user.id),
+  ]);
+
+  if (projects.length > 0 && providers.length === 0) {
+    redirect("/dashboard/settings?needKey=1");
+  }
+
   return <Onboarding />;
 }

--- a/components/dashboard/org-switcher.tsx
+++ b/components/dashboard/org-switcher.tsx
@@ -18,7 +18,19 @@ export interface OrgOption {
 // dashboard shows, or jump to creating a new one. Switching is optimistic: the
 // menu closes and the button shows the new org immediately, while a full-screen
 // loader covers the server round-trip + dashboard re-render.
-export function OrgSwitcher({ orgs, activeId }: { orgs: OrgOption[]; activeId: string }) {
+export function OrgSwitcher({
+  orgs,
+  activeId,
+  canAddOrg,
+}: {
+  orgs: OrgOption[];
+  activeId: string;
+  /** False while the account is on the trial with one org already set up.
+   *  A second org can't produce a usable result on free credits — no
+   *  competitors, no calibrated prompts — and each one silently spends a
+   *  free run on its first monitor. */
+  canAddOrg: boolean;
+}) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
   const [pendingOrg, setPendingOrg] = useState<OrgOption | null>(null);
@@ -124,14 +136,33 @@ export function OrgSwitcher({ orgs, activeId }: { orgs: OrgOption[]; activeId: s
                 );
               })}
             </ul>
-            <Link
-              href="/dashboard/new"
-              onClick={() => setOpen(false)}
-              className="flex items-center gap-2 border-t border-ink/10 px-4 py-2.5 text-sm font-medium text-terracotta-dark transition hover:bg-ink/5"
-            >
-              <Plus className="h-4 w-4" aria-hidden />
-              New organization
-            </Link>
+            {canAddOrg ? (
+              <Link
+                href="/dashboard/new"
+                onClick={() => setOpen(false)}
+                className="flex items-center gap-2 border-t border-ink/10 px-4 py-2.5 text-sm font-medium text-terracotta-dark transition hover:bg-ink/5"
+              >
+                <Plus className="h-4 w-4" aria-hidden />
+                New organization
+              </Link>
+            ) : (
+              <div className="border-t border-ink/10 px-4 py-3">
+                <p className="flex items-center gap-2 text-sm font-medium text-ink-faint">
+                  <Plus className="h-4 w-4 shrink-0" aria-hidden />
+                  New organization
+                </p>
+                <p className="mt-1 text-xs text-ink-faint">
+                  Add your own API key to monitor another brand.
+                </p>
+                <Link
+                  href="/dashboard/settings"
+                  onClick={() => setOpen(false)}
+                  className="mt-1 inline-block text-xs font-medium text-terracotta-dark transition hover:text-terracotta"
+                >
+                  Add a key →
+                </Link>
+              </div>
+            )}
           </div>
         </>
       )}


### PR DESCRIPTION
Implements the product note: the first organization is free, a second requires the user's own API key.

## Why this is more than a nudge

Onboarding **consumes a trial run** for the new org's first monitor (`complete/route.ts`, before `executeRun`). So five organizations exhausts all five free runs — and none of them produces anything useful, because a fresh org has no competitors to compare against and no calibrated prompts. The user collects several 0% dashboards and concludes the product doesn't work.

That's roughly what happened on the Doss project tonight: an empty share-of-voice chart, not because the chart was broken, but because a new org has nothing configured to measure against.

## Rule

| Situation | Can add an org |
|---|---|
| No organizations yet | **Yes** — first one is always free |
| Has an org, no provider key | **No** — "Add your own API key to monitor another brand" |
| Has an org and any provider key | **Yes** |

"Any provider" rather than the project's default, since the default is auto-picked and requiring a specific one would be confusing.

**Existing organizations are untouched.** This gates *creating* more, never access to what's already there — nobody loses a workspace or gets locked out of one they built.

## Enforced in three places

The first two are bypassable on their own:

1. **Switcher** — the item renders disabled with the reason and a link to Settings, rather than vanishing silently.
2. **`/dashboard/new`** — redirects instead of rendering a wizard that would fail at the very end, after the user filled it all in.
3. **`POST /api/onboarding/complete`** — 403 with `needsKey: true`, **before any work**, including before topic validation. No path into this route can spend a free run.

## Tests

Four new: refused on the trial, allowed with a key, first org always allowed, and the ordering guarantee that a free run is never at risk. 151 tests pass; typecheck, lint, and build clean.

## Separately — the stale switcher

The other half of the report was the switcher reading "Doss" while onboarding acme.com. Cause: `setActiveProject` runs at line 122 but the response is withheld until `executeRun` finishes ~a minute later, so the server-rendered sidebar can't re-render until then. This PR makes that path unreachable for trial users, which removes the common case, but it will still occur for a key-holding user adding their third org. Worth a follow-up — the honest fix is not showing the old org's name on a page that's setting up a different one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
