### PR TITLE
OAuth 2.1 access for CLI and external systems, plus a full CLI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,8 +8,10 @@
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 
-# Service role key — ONLY needed for scheduled runs (POST /api/cron/run), which
-# must read every user's due projects. Keep it server-side; never expose it.
+# Service role key — needed for scheduled runs (POST /api/cron/run, which reads
+# every user's due projects) and for the token-authenticated surface (/api/v1,
+# /api/mcp, and the OAuth token lookups), which carry no Supabase session. Keep
+# it server-side; never expose it.
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 
 # --- Encryption (required) ---
@@ -23,8 +25,21 @@ ENCRYPTION_KEY=replace-with-a-32-byte-base64-secret
 CRON_SECRET=replace-with-a-random-secret
 
 # --- App ---
-# Public base URL of this deployment (used for auth redirects).
+# Public base URL of this deployment (used for auth redirects). This is also the
+# OAuth issuer and the base of every advertised OAuth endpoint, so it must be
+# the real public origin in production.
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
+
+# --- OAuth (optional) ---
+# Lettertrace is its own OAuth 2.1 Authorization Server, so a CLI or external
+# system can obtain scoped, expiring, revocable access WITHOUT you hand-minting
+# an API key (see scripts/oauth-login.mjs). These lifetimes have sane defaults;
+# override only if you need to. No new secret is required — OAuth reuses
+# SUPABASE_SERVICE_ROLE_KEY (token lookups) and ENCRYPTION_KEY (refresh-retry
+# idempotency). Remember to apply supabase/schema.sql after upgrading.
+OAUTH_ACCESS_TTL=3600          # access-token lifetime, seconds (default 1 hour)
+OAUTH_REFRESH_TTL=2592000      # refresh-token lifetime, seconds (default 30 days)
+OAUTH_REFRESH_GRACE=10         # refresh-retry idempotency window, seconds
 
 # --- Free trial (optional) ---
 # Let users run their first monitors against YOUR shared keys, then prompt them

--- a/README.md
+++ b/README.md
@@ -233,6 +233,36 @@ claude mcp add --transport http lettertrace https://your-app.com/api/mcp/mcp \
 
 Tools: `list_projects`, `list_runs`, `get_share_of_voice_report`, `trigger_run`. (The write endpoints above are REST-only for now.)
 
+### Command-line client (`cli/`)
+
+A full CLI ships in [`cli/`](./cli/). Its only sign-in step is the OAuth flow
+below (no API keys): the first command that needs access opens your browser to
+**sign in or create an account**, then stores a scoped, auto-refreshing token.
+Everything after that runs over the REST and MCP APIs, so an agent like Claude
+Code can set up an account end to end after that one human approval.
+
+```bash
+npm run cli -- help                 # or: node cli/lettertrace.mjs help
+npm run cli -- login --url https://your-app.com   # browser sign-in / create account
+npm run cli -- whoami --json        # machine-readable auth status (no browser)
+
+# Set up an account over the API — the agent-drivable part:
+npm run cli -- projects create --name "Acme" --brand "Acme" --domains acme.io
+npm run cli -- prompts add <projectId> --text "best crm for startups" --topic CRM
+npm run cli -- runs trigger <projectId>
+npm run cli -- runs get <runId>          # share-of-voice report (--json for full)
+
+# Talk to the MCP endpoint over the real protocol (mints an mcp-audience token):
+npm run cli -- mcp tools
+npm run cli -- mcp call get_share_of_voice_report --project_id <projectId>
+```
+
+Every command takes `--json` for scripting, exits non-zero on error, and
+resolves the deployment from `--url`, then `$LETTERTRACE_URL`, then the URL saved
+at login. Tokens live in `~/.lettertrace/config.json` (one per audience). The
+data commands use REST v1; the `mcp` commands speak the Model Context Protocol
+directly. The mechanism underneath is:
+
 ### OAuth: delegated access for CLIs and external systems
 
 Rather than hand-minting an API key and pasting it around, a CLI or external
@@ -242,18 +272,17 @@ provider: the user approves the grant from a normal logged-in browser session,
 and the token that comes back flows through the same bearer path as an API key —
 so `/api/v1` and `/api/mcp` accept it unchanged.
 
-A reference CLI ships in [`scripts/oauth-login.mjs`](./scripts/oauth-login.mjs):
+The full CLI above is the everyday tool; [`scripts/oauth-login.mjs`](./scripts/oauth-login.mjs)
+is a minimal, single-file login example if you want to see just the token
+exchange (Authorization Code + PKCE over a 127.0.0.1 loopback, no key pasted):
 
 ```bash
-# Log in via your browser (Authorization Code + PKCE over a 127.0.0.1 loopback).
-# No key is ever pasted; tokens land in ~/.lettertrace/credentials.json.
 node scripts/oauth-login.mjs --url https://your-app.com
-
 node scripts/oauth-login.mjs --resource mcp     # bind the token to the MCP surface
 node scripts/oauth-login.mjs --refresh          # silently rotate using the refresh token
 ```
 
-The flow: the CLI opens `/api/oauth/authorize`, you approve on the consent
+The flow: the client opens `/api/oauth/authorize`, you approve on the consent
 screen (which lists exactly what's being granted and where the code is
 delivered), and the CLI exchanges the code at `/api/oauth/token` for an access
 token (+ a refresh token when `offline_access` is requested).

--- a/README.md
+++ b/README.md
@@ -233,13 +233,65 @@ claude mcp add --transport http lettertrace https://your-app.com/api/mcp/mcp \
 
 Tools: `list_projects`, `list_runs`, `get_share_of_voice_report`, `trigger_run`. (The write endpoints above are REST-only for now.)
 
+### OAuth: delegated access for CLIs and external systems
+
+Rather than hand-minting an API key and pasting it around, a CLI or external
+system can obtain a **scoped, expiring, revocable** token through Lettertrace's
+built-in **OAuth 2.1 Authorization Server**. Supabase stays the identity
+provider: the user approves the grant from a normal logged-in browser session,
+and the token that comes back flows through the same bearer path as an API key —
+so `/api/v1` and `/api/mcp` accept it unchanged.
+
+A reference CLI ships in [`scripts/oauth-login.mjs`](./scripts/oauth-login.mjs):
+
+```bash
+# Log in via your browser (Authorization Code + PKCE over a 127.0.0.1 loopback).
+# No key is ever pasted; tokens land in ~/.lettertrace/credentials.json.
+node scripts/oauth-login.mjs --url https://your-app.com
+
+node scripts/oauth-login.mjs --resource mcp     # bind the token to the MCP surface
+node scripts/oauth-login.mjs --refresh          # silently rotate using the refresh token
+```
+
+The flow: the CLI opens `/api/oauth/authorize`, you approve on the consent
+screen (which lists exactly what's being granted and where the code is
+delivered), and the CLI exchanges the code at `/api/oauth/token` for an access
+token (+ a refresh token when `offline_access` is requested).
+
+- **Scopes** — `projects:read`, `projects:write`, `runs:read`, `runs:trigger`,
+  and `offline_access` (asks for a refresh token). Enforced on **every** REST
+  route and MCP tool, reads included; a classic `lt_live_` key implicitly holds
+  all of them, so nothing about existing keys changes.
+- **Audience** — pass `resource=v1` (default) or `resource=mcp`. A token is
+  bound to one surface: an MCP token can't call the REST API, and vice versa.
+- **Discovery** — MCP/OAuth clients can auto-configure from
+  `/.well-known/oauth-authorization-server` (RFC 8414). Device-code and dynamic
+  client registration (for MCP hosts that self-register) are the next phase.
+- **Revoke** — `POST /api/oauth/revoke` with a token, or (soon) from Settings →
+  Connected apps.
+
+Self-hosting a **confidential** external server? Register it with a hashed
+secret via SQL (public/loopback clients like the CLI need no secret):
+
+```sql
+insert into public.oauth_clients
+  (client_id, client_name, client_type, token_endpoint_auth_method,
+   redirect_uris, allowed_scopes, client_secret_hash)
+values
+  ('my-service', 'My Service', 'confidential', 'client_secret_basic',
+   array['https://my-service.example.com/oauth/callback'],
+   array['projects:read','runs:read','offline_access'],
+   encode(digest('THE_PLAINTEXT_SECRET', 'sha256'), 'hex'));
+```
+
 Notes:
 
 - API-triggered runs are **BYOK-only** — the account must have its own provider key; free-trial runs stay dashboard-only.
 - Projects created via the API start with `schedule: "off"` — trigger runs explicitly (or flip the schedule in the dashboard).
 - API keys grant access to all of the account's organizations. Revoke them anytime from Settings.
 - Requires `SUPABASE_SERVICE_ROLE_KEY` (the same variable scheduled runs use), since API-key requests carry no browser session.
-- Upgrading an existing deployment? Re-run `supabase/schema.sql` — it adds the `api_keys` table (safe to re-run).
+- OAuth tokens are scoped and audience-bound; a classic `lt_live_` API key stays full-access across all of the account's organizations. Revoke either anytime (API keys from Settings; OAuth grants via `/api/oauth/revoke`).
+- Upgrading an existing deployment? Re-run `supabase/schema.sql` — it adds the `api_keys` table and the OAuth tables (`oauth_clients`, `oauth_access_tokens`, …) plus the seeded `lt_cli` client (all safe to re-run).
 
 ## Deployment
 

--- a/app/.well-known/oauth-authorization-server/route.ts
+++ b/app/.well-known/oauth-authorization-server/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+import { KNOWN_SCOPES, siteBase } from "@/lib/oauth";
+
+export const dynamic = "force-dynamic";
+
+// RFC 8414 Authorization Server Metadata. Public and CORS-open so that browser
+// and desktop OAuth/MCP clients can discover how to authenticate. Only the
+// endpoints that actually exist are advertised; the device-authorization and
+// dynamic-registration endpoints are added when those flows ship.
+const CORS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+  "Access-Control-Allow-Headers": "Authorization, Content-Type",
+};
+
+export function OPTIONS() {
+  return new NextResponse(null, { status: 204, headers: CORS });
+}
+
+export function GET(request: Request) {
+  const base = siteBase(request);
+  const metadata = {
+    issuer: base,
+    authorization_endpoint: `${base}/api/oauth/authorize`,
+    token_endpoint: `${base}/api/oauth/token`,
+    revocation_endpoint: `${base}/api/oauth/revoke`,
+    scopes_supported: [...KNOWN_SCOPES],
+    response_types_supported: ["code"],
+    grant_types_supported: ["authorization_code", "refresh_token"],
+    code_challenge_methods_supported: ["S256"],
+    token_endpoint_auth_methods_supported: ["none", "client_secret_basic"],
+    revocation_endpoint_auth_methods_supported: ["none", "client_secret_basic"],
+    authorization_response_iss_parameter_supported: true,
+  };
+  return NextResponse.json(metadata, {
+    headers: { ...CORS, "cache-control": "public, max-age=600" },
+  });
+}

--- a/app/api/mcp/[transport]/route.ts
+++ b/app/api/mcp/[transport]/route.ts
@@ -1,7 +1,7 @@
 import { createMcpHandler, withMcpAuth } from "mcp-handler";
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import { z } from "zod";
-import { authenticateApiKey } from "@/lib/api-auth";
+import { allowsAudience, authenticateApiKey, type Scope } from "@/lib/api-auth";
 import { createServiceClient } from "@/lib/supabase/service";
 import { getProjects } from "@/lib/data";
 import {
@@ -17,6 +17,7 @@ import { humanError } from "@/lib/llm";
 // since SSE is disabled). Connect with:
 //   claude mcp add --transport http lettertrace https://<host>/api/mcp/mcp \
 //     -H "Authorization: Bearer lt_live_..."
+// or with an OAuth access token (aud=mcp) obtained via the OAuth flow.
 // Tools are read/trigger only: Lettertrace reports how a brand shows up in AI
 // answers; it deliberately offers no recommendations.
 
@@ -30,6 +31,13 @@ function userIdOf(extra: { authInfo?: AuthInfo }): string {
   return userId;
 }
 
+/** Scopes granted to the current caller, forwarded from verifyToken. A classic
+ *  API key carries the full set; an OAuth token carries only what was consented. */
+function scopesOf(extra: { authInfo?: AuthInfo }): string[] {
+  const s = extra.authInfo?.extra?.scopes;
+  return Array.isArray(s) ? (s as string[]) : [];
+}
+
 function json(data: unknown) {
   return {
     content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }],
@@ -39,8 +47,19 @@ function json(data: unknown) {
 function toolError(message: string) {
   return {
     content: [{ type: "text" as const, text: message }],
-    isError: true,
+    isError: true as const,
   };
+}
+
+/** Enforce a scope inside a tool, mirroring the REST guard. Returns a tool
+ *  error to short-circuit the callback, or null when the scope is held. */
+function requireScope(
+  extra: { authInfo?: AuthInfo },
+  scope: Scope,
+): ReturnType<typeof toolError> | null {
+  return scopesOf(extra).includes(scope)
+    ? null
+    : toolError(`This token is missing the required "${scope}" scope.`);
 }
 
 const handler = createMcpHandler(
@@ -50,6 +69,8 @@ const handler = createMcpHandler(
       "List the organizations (projects) this Lettertrace account monitors, including brand name, domain, and when each last ran.",
       {},
       async (_args, extra) => {
+        const denied = requireScope(extra, "projects:read");
+        if (denied) return denied;
         const supabase = createServiceClient();
         const projects = await getProjects(supabase, userIdOf(extra));
         return json({ projects: projects.map(projectSummary) });
@@ -70,6 +91,8 @@ const handler = createMcpHandler(
           .describe("Max runs to return (default 20)"),
       },
       async ({ project_id, limit }, extra) => {
+        const denied = requireScope(extra, "runs:read");
+        if (denied) return denied;
         const supabase = createServiceClient();
         const runs = await listRuns(
           supabase,
@@ -98,6 +121,8 @@ const handler = createMcpHandler(
           .describe("If run_id is omitted: use this project's latest completed run"),
       },
       async ({ run_id, project_id }, extra) => {
+        const denied = requireScope(extra, "runs:read");
+        if (denied) return denied;
         const supabase = createServiceClient();
         const userId = userIdOf(extra);
 
@@ -128,6 +153,8 @@ const handler = createMcpHandler(
         project_id: z.string().uuid().describe("Project id from list_projects"),
       },
       async ({ project_id }, extra) => {
+        const denied = requireScope(extra, "runs:trigger");
+        if (denied) return denied;
         const supabase = createServiceClient();
         try {
           const outcome = await triggerRunForProject(
@@ -156,19 +183,30 @@ const handler = createMcpHandler(
   },
 );
 
-// Bearer auth with Lettertrace API keys. verifyToken stashes the owner's user
-// id in AuthInfo.extra, which tool callbacks read via extra.authInfo.
+// Bearer auth with Lettertrace credentials (classic API keys or OAuth access
+// tokens). verifyToken stashes the owner's user id, the granted scopes, and the
+// OAuth client id in AuthInfo.extra, which tool callbacks read via
+// extra.authInfo. An OAuth token minted for the REST API (aud=v1) is rejected
+// here so a token can only ever drive the surface it was consented for.
 const verifyToken = async (
   _req: Request,
   token?: string,
 ): Promise<AuthInfo | undefined> => {
   const auth = await authenticateApiKey(token);
   if (!auth) return undefined;
+  if (!allowsAudience(auth, "mcp")) return undefined;
   return {
     token: token!,
-    clientId: auth.userId,
-    scopes: [],
-    extra: { userId: auth.userId, keyId: auth.keyId },
+    // Prefer the real OAuth client id for audit; fall back to the user id for a
+    // classic API key (preserving prior behavior for withMcpAuth).
+    clientId: auth.clientId ?? auth.userId,
+    scopes: auth.scopes ?? [],
+    extra: {
+      userId: auth.userId,
+      keyId: auth.keyId,
+      scopes: auth.scopes ?? [],
+      clientId: auth.clientId,
+    },
   };
 };
 

--- a/app/api/mcp/mcp-route.test.ts
+++ b/app/api/mcp/mcp-route.test.ts
@@ -55,6 +55,11 @@ describe("MCP endpoint auth", () => {
       supabase: {} as never,
       userId: "user-1",
       keyId: "key-1",
+      tokenType: "api_key",
+      scopes: ["projects:read", "projects:write", "runs:read", "runs:trigger"],
+      clientId: null,
+      expiresAt: null,
+      aud: null,
     });
     const res = await mcpPost(rpc(INITIALIZE, "lt_live_valid"));
     expect(res.status).toBe(200);

--- a/app/api/oauth/authorize/consent/route.ts
+++ b/app/api/oauth/authorize/consent/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import { oauthErrorPage, oauthRedirectError } from "@/lib/oauth-responses";
+import {
+  consumePendingForConsent,
+  issueAuthorizationCode,
+  OAuthError,
+  siteBase,
+  upsertAuthorization,
+} from "@/lib/oauth";
+
+export const dynamic = "force-dynamic";
+
+// POST /api/oauth/authorize/consent — the user's Approve/Deny decision.
+//
+// Session + CSRF: the user is re-derived from the Supabase session (never a
+// hidden field), and the single-use nonce must match the one stored on the
+// server-persisted request. Every grant parameter is read back from that
+// persisted request, so nothing the form submitted can widen the grant.
+export async function POST(request: Request) {
+  const base = siteBase(request);
+
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return oauthErrorPage("Your session has expired. Start the authorization again.", 401);
+  }
+
+  let form: FormData;
+  try {
+    form = await request.formData();
+  } catch {
+    return oauthErrorPage("Malformed consent submission.");
+  }
+  const reqId = String(form.get("req") ?? "");
+  const nonce = String(form.get("nonce") ?? "");
+  const decision = String(form.get("decision") ?? "");
+
+  const service = createServiceClient();
+  const pending = await consumePendingForConsent(service, reqId, user.id, nonce);
+  if (!pending) {
+    return oauthErrorPage(
+      "This authorization request has expired or was already used. Start again from your CLI or app.",
+    );
+  }
+
+  // Re-derive EVERYTHING from the persisted request.
+  const fail = (code: string) => oauthRedirectError(pending.redirect_uri, code, pending.state, base);
+
+  if (decision !== "approve") return fail("access_denied");
+
+  try {
+    const authorizationId = await upsertAuthorization(service, {
+      userId: user.id,
+      clientId: pending.client_id,
+      resource: pending.resource,
+      scopes: pending.scopes,
+    });
+    const code = await issueAuthorizationCode(service, {
+      userId: user.id,
+      clientId: pending.client_id,
+      authorizationId,
+      codeChallenge: pending.code_challenge,
+      redirectUri: pending.redirect_uri,
+      scopes: pending.scopes,
+      resource: pending.resource,
+    });
+
+    const u = new URL(pending.redirect_uri);
+    u.searchParams.set("code", code);
+    if (pending.state) u.searchParams.set("state", pending.state);
+    u.searchParams.set("iss", base);
+    return NextResponse.redirect(u, { status: 302 });
+  } catch (e) {
+    if (e instanceof OAuthError) return fail("server_error");
+    console.error("[oauth/consent] unexpected:", e instanceof Error ? e.message : e);
+    return fail("server_error");
+  }
+}

--- a/app/api/oauth/authorize/route.ts
+++ b/app/api/oauth/authorize/route.ts
@@ -1,0 +1,92 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import { clientIp, rateLimit } from "@/lib/oauth-ratelimit";
+import { oauthErrorPage, oauthRedirectError } from "@/lib/oauth-responses";
+import {
+  createPendingRequest,
+  dataScopesOf,
+  getClient,
+  parseScopeString,
+  redirectUriAllowed,
+  resolveAudience,
+  siteBase,
+  validateScopes,
+} from "@/lib/oauth";
+
+export const dynamic = "force-dynamic";
+
+// GET /api/oauth/authorize — the OAuth 2.1 authorization endpoint.
+//
+// Validates the client and redirect URI FIRST (so an error can never be
+// reflected to an unregistered destination), then PKCE, scopes, and the
+// resource audience. The validated request is persisted server-side; only an
+// opaque id travels through the (possible) login bounce and on to the consent
+// screen, so the authorize parameters cannot be tampered with in transit.
+export async function GET(request: Request) {
+  const base = siteBase(request);
+  const p = new URL(request.url).searchParams;
+
+  // Pending rows are created here, before login — cap creation per IP.
+  const rl = await rateLimit(`authorize:${clientIp(request)}`, 60, 60);
+  if (!rl.allowed) {
+    return oauthErrorPage("Too many authorization requests. Try again shortly.", 429);
+  }
+
+  const service = createServiceClient();
+  const clientId = p.get("client_id") ?? "";
+  const redirectUri = p.get("redirect_uri") ?? "";
+
+  const client = await getClient(service, clientId);
+  if (!client) return oauthErrorPage("Unknown OAuth client.");
+  if (!redirectUri || !redirectUriAllowed(client, redirectUri)) {
+    return oauthErrorPage("The redirect URI is not registered for this client.");
+  }
+
+  // Past this point the redirect_uri is trusted, so protocol errors go back to it.
+  const state = p.get("state");
+  const fail = (code: string) => oauthRedirectError(redirectUri, code, state, base);
+
+  if (p.get("response_type") !== "code") return fail("unsupported_response_type");
+
+  const codeChallenge = p.get("code_challenge") ?? "";
+  if (!codeChallenge || p.get("code_challenge_method") !== "S256") {
+    // PKCE with S256 is mandatory for every client (OAuth 2.1 baseline).
+    return fail("invalid_request");
+  }
+
+  const audience = resolveAudience(p.get("resource"));
+  if (!audience) return fail("invalid_target");
+
+  const requested = parseScopeString(p.get("scope"));
+  const { granted, invalid } = validateScopes(
+    requested.length ? requested : client.allowed_scopes,
+    client.allowed_scopes,
+  );
+  if (invalid.length > 0) return fail("invalid_scope");
+  if (dataScopesOf(granted).length === 0) return fail("invalid_scope");
+
+  // Identify the approving user via the existing Supabase cookie session.
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const pendingId = await createPendingRequest(service, {
+    userId: user?.id ?? null,
+    clientId: client.client_id,
+    redirectUri,
+    scopes: granted,
+    resource: audience,
+    state,
+    codeChallenge,
+  });
+
+  const consentPath = `/oauth/consent?req=${encodeURIComponent(pendingId)}`;
+  if (!user) {
+    const login = new URL("/login", base);
+    login.searchParams.set("next", consentPath);
+    return NextResponse.redirect(login, { status: 302 });
+  }
+  return NextResponse.redirect(new URL(consentPath, base), { status: 302 });
+}

--- a/app/api/oauth/revoke/route.ts
+++ b/app/api/oauth/revoke/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import { clientIp, rateLimit } from "@/lib/oauth-ratelimit";
+import { revokeByToken } from "@/lib/oauth";
+
+export const dynamic = "force-dynamic";
+
+// POST /api/oauth/revoke — RFC 7009 token revocation.
+// Possession of the token is the authorization; we reveal nothing about whether
+// it existed, and always return 200. Revoking any token kills its whole family.
+export async function POST(request: Request) {
+  const rl = await rateLimit(`revoke:${clientIp(request)}`, 60, 120);
+  if (!rl.allowed) return new NextResponse(null, { status: 200 });
+
+  let form: URLSearchParams;
+  try {
+    form = new URLSearchParams(await request.text());
+  } catch {
+    return new NextResponse(null, { status: 200 });
+  }
+
+  const token = form.get("token");
+  if (token) {
+    try {
+      await revokeByToken(createServiceClient(), token);
+    } catch (e) {
+      // Never surface anything: RFC 7009 wants an unconditional 200.
+      console.error("[oauth/revoke] error:", e instanceof Error ? e.message : e);
+    }
+  }
+  return new NextResponse(null, { status: 200 });
+}

--- a/app/api/oauth/token/route.ts
+++ b/app/api/oauth/token/route.ts
@@ -1,0 +1,63 @@
+import { createServiceClient } from "@/lib/supabase/service";
+import { clientIp, rateLimit } from "@/lib/oauth-ratelimit";
+import { oauthErrorJson, tokenJson } from "@/lib/oauth-responses";
+import {
+  authenticateClient,
+  exchangeAuthorizationCode,
+  exchangeRefreshToken,
+  OAuthError,
+} from "@/lib/oauth";
+
+export const dynamic = "force-dynamic";
+
+// POST /api/oauth/token — the OAuth 2.1 token endpoint.
+// Supports authorization_code (PKCE) and refresh_token (rotation + reuse
+// detection). Device-code arrives in a later phase. Returns ONLY RFC 6749 §5.2
+// error codes — never an internal message — so nothing leaks through the body.
+export async function POST(request: Request) {
+  const rl = await rateLimit(`token:${clientIp(request)}`, 60, 120);
+  if (!rl.allowed) return oauthErrorJson("slow_down", 429);
+
+  let form: URLSearchParams;
+  try {
+    const ct = request.headers.get("content-type") ?? "";
+    if (ct.includes("application/json")) {
+      const j = (await request.json()) as Record<string, string>;
+      form = new URLSearchParams(j);
+    } else {
+      form = new URLSearchParams(await request.text());
+    }
+  } catch {
+    return oauthErrorJson("invalid_request", 400);
+  }
+
+  const service = createServiceClient();
+
+  try {
+    const client = await authenticateClient(service, {
+      bodyClientId: form.get("client_id"),
+      authHeader: request.headers.get("authorization"),
+    });
+
+    switch (form.get("grant_type")) {
+      case "authorization_code":
+        return tokenJson(
+          await exchangeAuthorizationCode(service, client, {
+            code: form.get("code"),
+            redirectUri: form.get("redirect_uri"),
+            codeVerifier: form.get("code_verifier"),
+          }),
+        );
+      case "refresh_token":
+        return tokenJson(
+          await exchangeRefreshToken(service, client, form.get("refresh_token")),
+        );
+      default:
+        throw new OAuthError("unsupported_grant_type", 400);
+    }
+  } catch (e) {
+    if (e instanceof OAuthError) return oauthErrorJson(e.code, e.status);
+    console.error("[oauth/token] unexpected:", e instanceof Error ? e.message : e);
+    return oauthErrorJson("server_error", 500);
+  }
+}

--- a/app/api/v1/projects/[id]/history/route.ts
+++ b/app/api/v1/projects/[id]/history/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { authenticateApiKey, bearerToken } from "@/lib/api-auth";
+import { requireApiAuth } from "@/lib/api-guards";
 import { getProjectHistory } from "@/lib/api-service";
 
 export const dynamic = "force-dynamic";
@@ -15,15 +15,8 @@ export async function GET(
   request: Request,
   { params }: { params: { id: string } },
 ) {
-  const auth = await authenticateApiKey(
-    bearerToken(request.headers.get("authorization")),
-  );
-  if (!auth) {
-    return NextResponse.json(
-      { error: "Invalid or missing API key" },
-      { status: 401 },
-    );
-  }
+  const auth = await requireApiAuth(request, "projects:read", "v1");
+  if (auth instanceof Response) return auth;
 
   const limitParam = new URL(request.url).searchParams.get("limit");
   const limit = limitParam ? Number(limitParam) : 30;

--- a/app/api/v1/projects/[id]/prompts/route.ts
+++ b/app/api/v1/projects/[id]/prompts/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { authenticateApiKey, bearerToken } from "@/lib/api-auth";
+import { requireApiAuth } from "@/lib/api-guards";
 import { createPrompts, listProjectPrompts } from "@/lib/api-service";
 import { humanError } from "@/lib/llm";
 
@@ -10,15 +10,8 @@ export async function GET(
   request: Request,
   { params }: { params: { id: string } },
 ) {
-  const auth = await authenticateApiKey(
-    bearerToken(request.headers.get("authorization")),
-  );
-  if (!auth) {
-    return NextResponse.json(
-      { error: "Invalid or missing API key" },
-      { status: 401 },
-    );
-  }
+  const auth = await requireApiAuth(request, "projects:read", "v1");
+  if (auth instanceof Response) return auth;
 
   const prompts = await listProjectPrompts(auth.supabase, auth.userId, params.id);
   if (!prompts) {
@@ -33,15 +26,8 @@ export async function POST(
   request: Request,
   { params }: { params: { id: string } },
 ) {
-  const auth = await authenticateApiKey(
-    bearerToken(request.headers.get("authorization")),
-  );
-  if (!auth) {
-    return NextResponse.json(
-      { error: "Invalid or missing API key" },
-      { status: 401 },
-    );
-  }
+  const auth = await requireApiAuth(request, "projects:write", "v1");
+  if (auth instanceof Response) return auth;
 
   let body: unknown;
   try {

--- a/app/api/v1/projects/[id]/runs/route.ts
+++ b/app/api/v1/projects/[id]/runs/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { authenticateApiKey, bearerToken } from "@/lib/api-auth";
+import { requireApiAuth } from "@/lib/api-guards";
 import { listRuns, triggerRunForProject } from "@/lib/api-service";
 import { isProvider, PROVIDERS } from "@/lib/models";
 import { humanError } from "@/lib/llm";
@@ -13,15 +13,8 @@ export async function GET(
   request: Request,
   { params }: { params: { id: string } },
 ) {
-  const auth = await authenticateApiKey(
-    bearerToken(request.headers.get("authorization")),
-  );
-  if (!auth) {
-    return NextResponse.json(
-      { error: "Invalid or missing API key" },
-      { status: 401 },
-    );
-  }
+  const auth = await requireApiAuth(request, "runs:read", "v1");
+  if (auth instanceof Response) return auth;
 
   const limit = Number(new URL(request.url).searchParams.get("limit")) || 20;
   const runs = await listRuns(auth.supabase, auth.userId, params.id, limit);
@@ -38,15 +31,8 @@ export async function POST(
   request: Request,
   { params }: { params: { id: string } },
 ) {
-  const auth = await authenticateApiKey(
-    bearerToken(request.headers.get("authorization")),
-  );
-  if (!auth) {
-    return NextResponse.json(
-      { error: "Invalid or missing API key" },
-      { status: 401 },
-    );
-  }
+  const auth = await requireApiAuth(request, "runs:trigger", "v1");
+  if (auth instanceof Response) return auth;
 
   // An absent (or empty) body is the common case and must keep working.
   const options: { provider?: Provider; model?: string } = {};

--- a/app/api/v1/projects/route.ts
+++ b/app/api/v1/projects/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { authenticateApiKey, bearerToken } from "@/lib/api-auth";
+import { requireApiAuth } from "@/lib/api-guards";
 import { getProjects } from "@/lib/data";
 import { createProject, projectSummary } from "@/lib/api-service";
 import { humanError } from "@/lib/llm";
@@ -9,15 +9,8 @@ export const dynamic = "force-dynamic";
 // GET /api/v1/projects — list the caller's organizations.
 // Auth: Authorization: Bearer <lettertrace api key>
 export async function GET(request: Request) {
-  const auth = await authenticateApiKey(
-    bearerToken(request.headers.get("authorization")),
-  );
-  if (!auth) {
-    return NextResponse.json(
-      { error: "Invalid or missing API key" },
-      { status: 401 },
-    );
-  }
+  const auth = await requireApiAuth(request, "projects:read", "v1");
+  if (auth instanceof Response) return auth;
 
   const projects = await getProjects(auth.supabase, auth.userId);
   return NextResponse.json({ projects: projects.map(projectSummary) });
@@ -27,15 +20,8 @@ export async function GET(request: Request) {
 // Body: { name, brand_name, brand_aliases?, brand_domains?, description?,
 //         default_provider?, default_model?, use_web_search? }
 export async function POST(request: Request) {
-  const auth = await authenticateApiKey(
-    bearerToken(request.headers.get("authorization")),
-  );
-  if (!auth) {
-    return NextResponse.json(
-      { error: "Invalid or missing API key" },
-      { status: 401 },
-    );
-  }
+  const auth = await requireApiAuth(request, "projects:write", "v1");
+  if (auth instanceof Response) return auth;
 
   let body: unknown;
   try {

--- a/app/api/v1/prompts/[id]/route.ts
+++ b/app/api/v1/prompts/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { authenticateApiKey, bearerToken } from "@/lib/api-auth";
+import { requireApiAuth } from "@/lib/api-guards";
 import { setPromptActive } from "@/lib/api-service";
 import { humanError } from "@/lib/llm";
 
@@ -10,15 +10,8 @@ export async function PATCH(
   request: Request,
   { params }: { params: { id: string } },
 ) {
-  const auth = await authenticateApiKey(
-    bearerToken(request.headers.get("authorization")),
-  );
-  if (!auth) {
-    return NextResponse.json(
-      { error: "Invalid or missing API key" },
-      { status: 401 },
-    );
-  }
+  const auth = await requireApiAuth(request, "projects:write", "v1");
+  if (auth instanceof Response) return auth;
 
   let body: unknown;
   try {

--- a/app/api/v1/runs/[id]/responses/route.ts
+++ b/app/api/v1/runs/[id]/responses/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { authenticateApiKey, bearerToken } from "@/lib/api-auth";
+import { requireApiAuth } from "@/lib/api-guards";
 import { getRunResponses } from "@/lib/api-service";
 
 export const dynamic = "force-dynamic";
@@ -10,15 +10,8 @@ export async function GET(
   request: Request,
   { params }: { params: { id: string } },
 ) {
-  const auth = await authenticateApiKey(
-    bearerToken(request.headers.get("authorization")),
-  );
-  if (!auth) {
-    return NextResponse.json(
-      { error: "Invalid or missing API key" },
-      { status: 401 },
-    );
-  }
+  const auth = await requireApiAuth(request, "runs:read", "v1");
+  if (auth instanceof Response) return auth;
 
   const result = await getRunResponses(auth.supabase, auth.userId, params.id);
   if (!result) {

--- a/app/api/v1/runs/[id]/route.ts
+++ b/app/api/v1/runs/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { authenticateApiKey, bearerToken } from "@/lib/api-auth";
+import { requireApiAuth } from "@/lib/api-guards";
 import { getRunReport } from "@/lib/api-service";
 
 export const dynamic = "force-dynamic";
@@ -9,15 +9,8 @@ export async function GET(
   request: Request,
   { params }: { params: { id: string } },
 ) {
-  const auth = await authenticateApiKey(
-    bearerToken(request.headers.get("authorization")),
-  );
-  if (!auth) {
-    return NextResponse.json(
-      { error: "Invalid or missing API key" },
-      { status: 401 },
-    );
-  }
+  const auth = await requireApiAuth(request, "runs:read", "v1");
+  if (auth instanceof Response) return auth;
 
   const report = await getRunReport(auth.supabase, auth.userId, params.id);
   if (!report) {

--- a/app/api/v1/v1-routes.test.ts
+++ b/app/api/v1/v1-routes.test.ts
@@ -47,7 +47,16 @@ vi.mock("@/lib/api-service", async (importOriginal) => ({
   triggerRunForProject: vi.fn(),
 }));
 
-const AUTH_CTX = { supabase: {} as never, userId: "user-1", keyId: "key-1" };
+const AUTH_CTX = {
+  supabase: {} as never,
+  userId: "user-1",
+  keyId: "key-1",
+  tokenType: "api_key" as const,
+  scopes: ["projects:read", "projects:write", "runs:read", "runs:trigger"],
+  clientId: null,
+  expiresAt: null,
+  aud: null,
+};
 
 function req(path: string, init?: RequestInit) {
   return new Request(`http://localhost${path}`, {

--- a/app/oauth/consent/page.tsx
+++ b/app/oauth/consent/page.tsx
@@ -1,0 +1,158 @@
+import { redirect } from "next/navigation";
+import { AlertCircle, ShieldCheck } from "lucide-react";
+import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import { claimPendingForUser, getClient, SCOPE_DESCRIPTIONS } from "@/lib/oauth";
+import { Button, Card, CardBody } from "@/components/ui";
+import { Logo } from "@/components/logo";
+
+export const dynamic = "force-dynamic";
+
+function safeHost(uri: string): { loopback: boolean; host: string } {
+  try {
+    const u = new URL(uri);
+    const h = u.hostname.toLowerCase();
+    const loopback = h === "127.0.0.1" || h === "::1" || h === "[::1]" || h === "localhost";
+    return { loopback, host: u.host };
+  } catch {
+    return { loopback: false, host: uri };
+  }
+}
+
+function ConsentShell({ children }: { children: React.ReactNode }) {
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-paper px-6 py-12">
+      <div className="w-full max-w-md">
+        <div className="mb-8 flex justify-center">
+          <Logo />
+        </div>
+        <Card>
+          <CardBody className="p-8 sm:p-10">{children}</CardBody>
+        </Card>
+      </div>
+    </main>
+  );
+}
+
+function ConsentError({ message }: { message: string }) {
+  return (
+    <ConsentShell>
+      <div className="space-y-4 text-center">
+        <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-terracotta/12 text-terracotta-dark">
+          <AlertCircle className="h-6 w-6" aria-hidden />
+        </div>
+        <h1 className="font-serif text-xl font-semibold text-ink">
+          Can&apos;t complete this request
+        </h1>
+        <p className="text-sm text-ink-faint">{message}</p>
+        <Button href="/dashboard" variant="secondary" className="w-full">
+          Back to dashboard
+        </Button>
+      </div>
+    </ConsentShell>
+  );
+}
+
+export default async function ConsentPage({
+  searchParams,
+}: {
+  searchParams: { req?: string };
+}) {
+  const reqId = typeof searchParams.req === "string" ? searchParams.req : "";
+  const consentPath = `/oauth/consent?req=${encodeURIComponent(reqId)}`;
+
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect(`/login?next=${encodeURIComponent(consentPath)}`);
+
+  const service = createServiceClient();
+  const claimed = await claimPendingForUser(service, reqId, user.id);
+  if (!claimed) {
+    return (
+      <ConsentError message="This authorization request has expired or is invalid. Start again from your CLI or app." />
+    );
+  }
+  const { pending, nonce } = claimed;
+  const client = await getClient(service, pending.client_id);
+  if (!client) {
+    return (
+      <ConsentError message="The application making this request is no longer registered." />
+    );
+  }
+
+  const dest = safeHost(pending.redirect_uri);
+  const surface = pending.resource === "mcp" ? "MCP tools" : "REST API";
+
+  return (
+    <ConsentShell>
+      <div className="space-y-6">
+        <div className="text-center">
+          <h1 className="font-serif text-2xl font-semibold text-ink">Authorize access</h1>
+          <p className="mt-1 text-sm text-ink-faint">
+            Signed in as <span className="font-medium text-ink-soft">{user.email}</span>
+          </p>
+        </div>
+
+        <div className="rounded-xl border border-ink/10 bg-surface px-4 py-3.5">
+          <div className="flex items-center gap-2">
+            <span className="font-medium text-ink">{client.client_name}</span>
+            {client.is_first_party ? (
+              <span className="inline-flex items-center gap-1 rounded-full bg-mint-tint px-2 py-0.5 text-xs font-medium text-mint-ink">
+                <ShieldCheck className="h-3 w-3" aria-hidden /> First-party
+              </span>
+            ) : (
+              <span className="rounded-full bg-butter/50 px-2 py-0.5 text-xs font-medium text-ink-soft">
+                Unverified
+              </span>
+            )}
+          </div>
+          <p className="mt-1 text-sm text-ink-faint">
+            wants to access your Lettertrace account&apos;s {surface}.
+          </p>
+        </div>
+
+        <div>
+          <p className="text-xs font-medium uppercase tracking-wide text-ink-faint">
+            It will be able to
+          </p>
+          <ul className="mt-2 space-y-2">
+            {pending.scopes.map((scope) => (
+              <li key={scope} className="flex items-start gap-2 text-sm text-ink-soft">
+                <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-mint-ink" aria-hidden />
+                <span>{SCOPE_DESCRIPTIONS[scope] ?? scope}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <p className="rounded-xl border border-ink/10 bg-paper-shade px-4 py-3 text-xs text-ink-faint">
+          A code will be delivered to{" "}
+          <span className="font-medium text-ink-soft">
+            {dest.loopback ? "an application on this device" : dest.host}
+          </span>
+          . Only approve if you started this yourself.
+        </p>
+
+        <form method="post" action="/api/oauth/authorize/consent" className="space-y-3">
+          <input type="hidden" name="req" value={pending.id} />
+          <input type="hidden" name="nonce" value={nonce} />
+          <Button type="submit" name="decision" value="approve" size="lg" className="w-full">
+            Approve
+          </Button>
+          <Button
+            type="submit"
+            name="decision"
+            value="deny"
+            variant="secondary"
+            size="lg"
+            className="w-full"
+          >
+            Deny
+          </Button>
+        </form>
+      </div>
+    </ConsentShell>
+  );
+}

--- a/cli/config.mjs
+++ b/cli/config.mjs
@@ -1,0 +1,39 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// Persistent CLI state: the deployment base URL and one credential per resource
+// audience ("v1" for the REST API, "mcp" for the MCP endpoint). Because OAuth
+// access tokens are audience-bound, the CLI keeps them separate and uses the
+// right one for each command. Stored 0600 in the user's home directory.
+
+export const CONFIG_DIR = path.join(os.homedir(), ".lettertrace");
+export const CONFIG_FILE = path.join(CONFIG_DIR, "config.json");
+
+export function loadConfig() {
+  try {
+    const cfg = JSON.parse(fs.readFileSync(CONFIG_FILE, "utf8"));
+    cfg.credentials = cfg.credentials || {};
+    return cfg;
+  } catch {
+    return { credentials: {} };
+  }
+}
+
+export function saveConfig(cfg) {
+  fs.mkdirSync(CONFIG_DIR, { recursive: true });
+  fs.writeFileSync(CONFIG_FILE, JSON.stringify(cfg, null, 2), { mode: 0o600 });
+  try {
+    fs.chmodSync(CONFIG_FILE, 0o600);
+  } catch {
+    /* platforms without POSIX modes */
+  }
+}
+
+// Base URL precedence: explicit --url, then $LETTERTRACE_URL, then the base
+// saved at login, then localhost.
+export function resolveBase(cliUrl) {
+  const stored = loadConfig().base;
+  const base = cliUrl || process.env.LETTERTRACE_URL || stored || "http://localhost:3000";
+  return base.replace(/\/+$/, "");
+}

--- a/cli/http.mjs
+++ b/cli/http.mjs
@@ -1,0 +1,56 @@
+import { getAccessToken } from "./oauth.mjs";
+
+// Thin REST client for the Lettertrace v1 API. Every call carries an OAuth
+// access token bound to the "v1" audience, transparently refreshed when it has
+// expired. If the server rejects a token that our clock still thought was valid
+// (e.g. it was revoked), we force one rotation and retry a single time.
+
+export class ApiError extends Error {
+  constructor(status, code, message) {
+    super(message || code || `HTTP ${status}`);
+    this.name = "ApiError";
+    this.status = status;
+    this.code = code;
+  }
+}
+
+function safeJson(text) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+export async function rest(base, method, pathname, { query, body } = {}) {
+  const url = new URL(`${base}/api/v1${pathname}`);
+  if (query) {
+    for (const [k, v] of Object.entries(query)) {
+      if (v !== undefined && v !== null) url.searchParams.set(k, String(v));
+    }
+  }
+
+  const send = (token) =>
+    fetch(url, {
+      method,
+      headers: {
+        authorization: `Bearer ${token}`,
+        ...(body ? { "content-type": "application/json" } : {}),
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+
+  let res = await send(await getAccessToken(base, "v1"));
+  if (res.status === 401) {
+    // The token was rejected despite passing our local expiry check. Force a
+    // rotation (or NeedsLogin) and try exactly once more.
+    res = await send(await getAccessToken(base, "v1", { force: true }));
+  }
+
+  const text = await res.text();
+  const json = text ? safeJson(text) : null;
+  if (!res.ok) {
+    throw new ApiError(res.status, json?.error, json?.error || `HTTP ${res.status}`);
+  }
+  return json;
+}

--- a/cli/lettertrace.mjs
+++ b/cli/lettertrace.mjs
@@ -1,0 +1,419 @@
+#!/usr/bin/env node
+/**
+ * lettertrace: a full command-line client for a Lettertrace deployment.
+ *
+ * Authentication is OAuth 2.1 only (no API keys): the first command that needs
+ * access opens your browser to approve a scoped, expiring token, stored under
+ * ~/.lettertrace/config.json and refreshed automatically. The data commands use
+ * the REST v1 API; the `mcp` commands speak the Model Context Protocol directly
+ * to /api/mcp, exactly as an AI assistant would.
+ *
+ * Run `lettertrace help` for the command list. Base URL comes from --url, then
+ * $LETTERTRACE_URL, then the URL saved at login, then http://localhost:3000.
+ */
+
+import { resolveBase, loadConfig } from "./config.mjs";
+import { login, logout, getAccessToken, revoke, NeedsLogin } from "./oauth.mjs";
+import { rest, ApiError } from "./http.mjs";
+import { listTools, callTool, renderToolResult } from "./mcp.mjs";
+import { c, printJson, table, kv, ok, info, fail } from "./output.mjs";
+
+// --- arg parsing ----------------------------------------------------
+function parseArgs(argv) {
+  const positionals = [];
+  const flags = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith("--")) {
+      const key = a.slice(2);
+      const next = argv[i + 1];
+      if (next !== undefined && !next.startsWith("--")) {
+        flags[key] = next;
+        i++;
+      } else {
+        flags[key] = true;
+      }
+    } else {
+      positionals.push(a);
+    }
+  }
+  return { positionals, flags };
+}
+
+const { positionals, flags } = parseArgs(process.argv.slice(2));
+const [command, ...rest_] = positionals;
+const JSON_OUT = Boolean(flags.json);
+const base = resolveBase(typeof flags.url === "string" ? flags.url : undefined);
+
+// --- helpers --------------------------------------------------------
+const pct = (n) => (n === null || n === undefined ? "n/a" : `${Math.round(n * 100)}%`);
+const trunc = (s, n) => (s && s.length > n ? s.slice(0, n - 1) + "…" : s ?? "");
+const rel = (ms) => {
+  if (!ms) return "unknown";
+  const d = ms - Date.now();
+  const s = Math.round(Math.abs(d) / 1000);
+  const unit = s < 60 ? `${s}s` : s < 3600 ? `${Math.round(s / 60)}m` : `${Math.round(s / 3600)}h`;
+  return d >= 0 ? `in ${unit}` : `${unit} ago`;
+};
+const coerce = (v) => {
+  if (v === true) return true;
+  try {
+    return JSON.parse(v);
+  } catch {
+    return v;
+  }
+};
+function need(value, message) {
+  if (value === undefined || value === null || value === "" || value === true) {
+    throw new UsageError(message);
+  }
+  return value;
+}
+class UsageError extends Error {}
+
+// Build a table from whatever primitive columns the rows share (for dynamic
+// shapes like report entities).
+function dynamicTable(rows) {
+  if (!rows || rows.length === 0) return info(c.dim("(none)"));
+  const keys = Object.keys(rows[0]).filter((k) => {
+    const v = rows[0][k];
+    return v === null || ["string", "number", "boolean"].includes(typeof v);
+  });
+  table(rows, keys.map((k) => ({ key: k })));
+}
+
+// Run a data command, auto-launching the OAuth login for the exact audience it
+// needs if there is no usable credential yet, then retrying once.
+async function withAutoLogin(fn) {
+  try {
+    return await fn();
+  } catch (e) {
+    if (e instanceof NeedsLogin) {
+      info(c.yellow(`Not authenticated for "${e.resource}". Launching login...`));
+      await login(base, e.resource);
+      return await fn();
+    }
+    throw e;
+  }
+}
+
+// --- commands -------------------------------------------------------
+const commands = {
+  async login() {
+    if (flags.both) {
+      await login(base, "v1", scopeFlag());
+      await login(base, "mcp", scopeFlag());
+      ok(`Logged in to ${c.cyan(base)} for both REST (v1) and MCP.`);
+      return;
+    }
+    const resource = flags.mcp ? "mcp" : "v1";
+    const cred = await login(base, resource, scopeFlag());
+    ok(`Logged in to ${c.cyan(base)} for ${resource.toUpperCase()} (expires ${rel(cred.expires_at)}).`);
+    if (resource === "v1") info(c.dim("Tip: `lettertrace login --mcp` to also use the MCP commands."));
+  },
+
+  async logout() {
+    const { tokens } = logout();
+    await Promise.all(tokens.map((t) => revoke(base, t)));
+    ok("Logged out and revoked stored tokens.");
+  },
+
+  whoami() {
+    const cfg = loadConfig();
+    const resources = Object.values(cfg.credentials || {});
+    if (JSON_OUT) {
+      // Machine-readable auth status, safe to parse (no token values). Lets an
+      // agent decide whether it still needs the human sign-in step.
+      return printJson({
+        deployment: cfg.base ?? base,
+        authenticated: {
+          v1: Boolean(cfg.credentials?.v1),
+          mcp: Boolean(cfg.credentials?.mcp),
+        },
+        credentials: resources.map((r) => ({
+          resource: r.resource,
+          scope: r.scope,
+          access_expires_at: r.expires_at ? new Date(r.expires_at).toISOString() : null,
+          has_refresh: Boolean(r.refresh_token),
+        })),
+      });
+    }
+    if (resources.length === 0) return info("Not logged in. Run: lettertrace login");
+    info(`${c.dim("deployment")}  ${cfg.base ?? base}`);
+    table(resources, [
+      { key: "resource", label: "SURFACE", map: (v) => v.toUpperCase() },
+      { key: "scope", label: "SCOPES" },
+      { key: "expires_at", label: "ACCESS EXPIRES", map: (v) => rel(v) },
+      { key: "refresh_token", label: "REFRESH", map: (v) => (v ? "yes" : "no") },
+    ]);
+  },
+
+  async projects() {
+    const sub = rest_[0] ?? "list";
+    if (sub === "create") {
+      const body = {
+        name: need(flags.name, "projects create needs --name"),
+        brand_name: need(flags.brand ?? flags["brand-name"], "projects create needs --brand"),
+      };
+      if (flags.domains) body.brand_domains = String(flags.domains).split(",").map((s) => s.trim()).filter(Boolean);
+      if (flags.description) body.description = flags.description;
+      if (flags.provider) body.default_provider = flags.provider;
+      if (flags.model) body.default_model = flags.model;
+      const out = await withAutoLogin(() => rest(base, "POST", "/projects", { body }));
+      if (JSON_OUT) return printJson(out);
+      ok(`Created organization ${c.bold(out.project.name)} (${out.project.id}).`);
+      return;
+    }
+    // list
+    const out = await withAutoLogin(() => rest(base, "GET", "/projects"));
+    if (JSON_OUT) return printJson(out.projects);
+    table(out.projects, [
+      { key: "id", label: "ID" },
+      { key: "name", label: "NAME" },
+      { key: "brand_name", label: "BRAND" },
+      { key: "last_run_at", label: "LAST RUN", map: (v) => v ?? "never" },
+    ]);
+  },
+
+  async prompts() {
+    const sub = rest_[0];
+    if (sub === "add") {
+      const projectId = need(rest_[1], "prompts add needs a <projectId>");
+      const body = {
+        prompts: [
+          {
+            text: need(flags.text, "prompts add needs --text"),
+            topic: need(flags.topic, "prompts add needs --topic"),
+          },
+        ],
+      };
+      const out = await withAutoLogin(() =>
+        rest(base, "POST", `/projects/${projectId}/prompts`, { body }),
+      );
+      if (JSON_OUT) return printJson(out);
+      ok(`Added ${out.created.length} prompt(s), skipped ${out.skipped}.`);
+      return;
+    }
+    if (sub === "toggle") {
+      const promptId = need(rest_[1], "prompts toggle needs a <promptId>");
+      if (!flags.on && !flags.off) throw new UsageError("prompts toggle needs --on or --off");
+      const out = await withAutoLogin(() =>
+        rest(base, "PATCH", `/prompts/${promptId}`, { body: { is_active: Boolean(flags.on) } }),
+      );
+      if (JSON_OUT) return printJson(out);
+      ok(`Prompt ${promptId} is now ${out.prompt.is_active ? "active" : "inactive"}.`);
+      return;
+    }
+    // list: prompts <projectId>
+    const projectId = need(sub, "prompts needs a <projectId>");
+    const out = await withAutoLogin(() => rest(base, "GET", `/projects/${projectId}/prompts`));
+    if (JSON_OUT) return printJson(out.prompts);
+    table(out.prompts, [
+      { key: "id", label: "ID" },
+      { key: "topic", label: "TOPIC" },
+      { key: "is_active", label: "ACTIVE", map: (v) => (v ? "yes" : "no") },
+      { key: "text", label: "TEXT", map: (v) => trunc(v, 60) },
+    ]);
+  },
+
+  async runs() {
+    const sub = rest_[0];
+    if (sub === "trigger") {
+      const projectId = need(rest_[1], "runs trigger needs a <projectId>");
+      const body = {};
+      if (flags.provider) body.provider = flags.provider;
+      if (flags.model) body.model = flags.model;
+      const out = await withAutoLogin(() =>
+        rest(base, "POST", `/projects/${projectId}/runs`, {
+          body: Object.keys(body).length ? body : undefined,
+        }),
+      );
+      if (JSON_OUT) return printJson(out);
+      ok(`Run ${c.bold(out.runId)} ${out.status} (${out.totalResponses} responses).`);
+      return;
+    }
+    if (sub === "get") {
+      const runId = need(rest_[1], "runs get needs a <runId>");
+      const report = await withAutoLogin(() => rest(base, "GET", `/runs/${runId}`));
+      if (JSON_OUT) return printJson(report);
+      const s = report.summary;
+      kv({
+        Run: report.run.id,
+        Model: `${report.run.provider}/${report.run.model}`,
+        Responses: report.totalResponses,
+        "Brand mention rate": pct(s.brandMentionRate),
+        "Share of voice": pct(s.brandShareOfVoice),
+        "Owned-citation rate": pct(report.citations?.ownedCitationRate),
+      });
+      if (report.entities?.length) {
+        info("");
+        dynamicTable(report.entities);
+      }
+      info(c.dim("\nUse --json for the full report."));
+      return;
+    }
+    if (sub === "responses") {
+      const runId = need(rest_[1], "runs responses needs a <runId>");
+      const out = await withAutoLogin(() => rest(base, "GET", `/runs/${runId}/responses`));
+      if (JSON_OUT) return printJson(out);
+      info(`${out.responses.length} response(s) for run ${runId}:`);
+      table(out.responses, [
+        { key: "provider", label: "PROVIDER" },
+        { key: "model", label: "MODEL" },
+        { key: "prompt_text", label: "PROMPT", map: (v) => trunc(v, 50) },
+        { key: "response_text", label: "ANSWER", map: (v) => trunc(v, 60) },
+      ]);
+      info(c.dim("Use --json for full text, sources, and mentions."));
+      return;
+    }
+    // list: runs <projectId>
+    const projectId = need(sub, "runs needs a <projectId>");
+    const query = flags.limit ? { limit: Number(flags.limit) } : undefined;
+    const out = await withAutoLogin(() => rest(base, "GET", `/projects/${projectId}/runs`, { query }));
+    if (JSON_OUT) return printJson(out.runs);
+    table(out.runs, [
+      { key: "id", label: "ID" },
+      { key: "status", label: "STATUS" },
+      { key: "model", label: "MODEL" },
+      { key: "prompt_count", label: "PROMPTS" },
+      { key: "created_at", label: "CREATED" },
+    ]);
+  },
+
+  async history() {
+    const projectId = need(rest_[0], "history needs a <projectId>");
+    const query = flags.limit ? { limit: Number(flags.limit) } : undefined;
+    const out = await withAutoLogin(() =>
+      rest(base, "GET", `/projects/${projectId}/history`, { query }),
+    );
+    if (JSON_OUT) return printJson(out);
+    kv({
+      Brand: out.brandName,
+      "Ever mentioned": out.everMentioned ? "yes" : "no",
+      "First mention": out.firstMentionAt ?? "not yet",
+      Runs: out.points.length,
+    });
+    if (out.points.length) {
+      info("");
+      table(out.points, [
+        { key: "createdAt", label: "WHEN" },
+        { key: "model", label: "MODEL" },
+        { key: "brandMentionRate", label: "MENTION", map: (v) => pct(v) },
+        { key: "ownedCitationRate", label: "OWNED CITES", map: (v) => pct(v) },
+      ]);
+    }
+  },
+
+  async mcp() {
+    const sub = rest_[0];
+    if (sub === "tools") {
+      const tools = await withAutoLoginMcp(() => listTools(base));
+      if (JSON_OUT) return printJson(tools);
+      table(tools, [
+        { key: "name", label: "TOOL" },
+        { key: "description", label: "DESCRIPTION", map: (v) => trunc(v, 80) },
+      ]);
+      return;
+    }
+    if (sub === "call") {
+      const name = need(rest_[1], "mcp call needs a <tool> name (see `mcp tools`)");
+      const args = {};
+      for (const [k, v] of Object.entries(flags)) {
+        if (k === "json" || k === "url") continue;
+        args[k] = coerce(v);
+      }
+      const result = await withAutoLoginMcp(() => callTool(base, name, args));
+      if (JSON_OUT) return printJson(result);
+      const { text, isError } = renderToolResult(result);
+      if (isError) fail(text || "Tool returned an error.");
+      else process.stdout.write((text || "(no output)") + "\n");
+      return;
+    }
+    throw new UsageError("mcp needs a subcommand: `mcp tools` or `mcp call <tool>`");
+  },
+
+  help() {
+    printHelp();
+  },
+};
+
+function scopeFlag() {
+  return typeof flags.scope === "string" ? flags.scope : undefined;
+}
+
+// The mcp audience needs its own credential; auto-login uses NeedsLogin.resource.
+async function withAutoLoginMcp(fn) {
+  try {
+    return await fn();
+  } catch (e) {
+    if (e instanceof NeedsLogin) {
+      info(c.yellow(`Not authenticated for "mcp". Launching login...`));
+      await login(base, "mcp");
+      return await fn();
+    }
+    throw e;
+  }
+}
+
+function printHelp() {
+  const lines = [
+    `${c.bold("lettertrace")} - OAuth-authenticated CLI for a Lettertrace deployment`,
+    "",
+    c.bold("USAGE"),
+    "  lettertrace <command> [args] [--json] [--url <base>]",
+    "",
+    c.bold("AUTH"),
+    "  login [--mcp] [--both] [--scope <s>]   Browser OAuth login (default: REST/v1)",
+    "  logout                                 Forget and revoke stored tokens",
+    "  whoami                                 Show stored credentials",
+    "",
+    c.bold("DATA (REST v1)"),
+    "  projects                               List organizations",
+    "  projects create --name <n> --brand <b> [--domains a,b] [--description <d>]",
+    "  prompts <projectId>                    List a project's prompts",
+    "  prompts add <projectId> --text <t> --topic <top>",
+    "  prompts toggle <promptId> --on|--off",
+    "  runs <projectId> [--limit <n>]         List runs",
+    "  runs trigger <projectId> [--provider <p>] [--model <m>]",
+    "  runs get <runId>                       Share-of-voice report",
+    "  runs responses <runId>                 Raw answers, sources, mentions",
+    "  history <projectId> [--limit <n>]      Brand visibility over time",
+    "",
+    c.bold("MCP (Model Context Protocol)"),
+    "  mcp tools                              List the MCP tools",
+    "  mcp call <tool> [--arg value ...]      Call an MCP tool",
+    "",
+    c.dim("Tokens live in ~/.lettertrace/config.json. Base URL: --url, then"),
+    c.dim("$LETTERTRACE_URL, then the login URL, then http://localhost:3000."),
+  ];
+  process.stdout.write(lines.join("\n") + "\n");
+}
+
+// --- dispatch -------------------------------------------------------
+async function main() {
+  if (!command || command === "help" || flags.help || flags.h) {
+    printHelp();
+    return;
+  }
+  const handler = commands[command];
+  if (!handler) {
+    fail(`Unknown command: ${command}`);
+    info("Run `lettertrace help` for the command list.");
+    process.exitCode = 1;
+    return;
+  }
+  await handler();
+}
+
+main().catch((e) => {
+  if (e instanceof UsageError) {
+    fail(e.message);
+  } else if (e instanceof ApiError) {
+    fail(`API error ${e.status}: ${e.message}`);
+  } else if (e instanceof NeedsLogin) {
+    fail(e.message);
+  } else {
+    fail(e instanceof Error ? e.message : String(e));
+  }
+  process.exitCode = 1;
+});

--- a/cli/mcp.mjs
+++ b/cli/mcp.mjs
@@ -1,0 +1,44 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { getAccessToken } from "./oauth.mjs";
+
+// MCP client for the CLI's `mcp` commands. It speaks the real Model Context
+// Protocol (Streamable HTTP, JSON-RPC) to /api/mcp/mcp, authenticating with an
+// OAuth access token bound to the "mcp" audience. This is the CLI sitting
+// directly "above" the MCP surface, using the same tools an AI assistant would.
+
+/** Open an authenticated MCP session, run fn(client), and always close it. */
+export async function withMcp(base, fn) {
+  const token = await getAccessToken(base, "mcp");
+  const transport = new StreamableHTTPClientTransport(new URL(`${base}/api/mcp/mcp`), {
+    requestInit: { headers: { Authorization: `Bearer ${token}` } },
+  });
+  const client = new Client(
+    { name: "lettertrace-cli", version: "1.0.0" },
+    { capabilities: {} },
+  );
+  await client.connect(transport);
+  try {
+    return await fn(client);
+  } finally {
+    await client.close().catch(() => {});
+  }
+}
+
+export async function listTools(base) {
+  return withMcp(base, async (client) => (await client.listTools()).tools ?? []);
+}
+
+export async function callTool(base, name, args) {
+  return withMcp(base, (client) => client.callTool({ name, arguments: args ?? {} }));
+}
+
+/** Flatten an MCP tool result's content blocks into printable text. */
+export function renderToolResult(result) {
+  const blocks = Array.isArray(result?.content) ? result.content : [];
+  const text = blocks
+    .filter((b) => b.type === "text")
+    .map((b) => b.text)
+    .join("\n");
+  return { text, isError: Boolean(result?.isError) };
+}

--- a/cli/oauth.mjs
+++ b/cli/oauth.mjs
@@ -1,0 +1,197 @@
+import http from "node:http";
+import crypto from "node:crypto";
+import { spawn } from "node:child_process";
+import { loadConfig, saveConfig } from "./config.mjs";
+
+// OAuth 2.1 client for the CLI: Authorization Code + PKCE over a 127.0.0.1
+// loopback (RFC 8252), plus refresh-token rotation. No API key is ever pasted;
+// the user approves in the browser using their existing Lettertrace session.
+
+const CLIENT_ID = "lt_cli";
+export const DEFAULT_SCOPE =
+  "projects:read projects:write runs:read runs:trigger offline_access";
+
+const b64url = (buf) => buf.toString("base64url");
+
+/** Thrown when a resource has no usable credential; the caller may prompt a
+ *  login for exactly that audience. */
+export class NeedsLogin extends Error {
+  constructor(resource) {
+    super(`Not authenticated for "${resource}". Run: lettertrace login${resource === "mcp" ? " --mcp" : ""}`);
+    this.name = "NeedsLogin";
+    this.resource = resource;
+  }
+}
+
+function openBrowser(url) {
+  const cmd =
+    process.platform === "darwin" ? "open" : process.platform === "win32" ? "cmd" : "xdg-open";
+  const args = process.platform === "win32" ? ["/c", "start", "", url] : [url];
+  try {
+    const child = spawn(cmd, args, { stdio: "ignore", detached: true });
+    child.on("error", () => {});
+    child.unref();
+  } catch {
+    /* fall back to the printed URL */
+  }
+}
+
+async function tokenRequest(base, body) {
+  const res = await fetch(`${base}/api/oauth/token`, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams(body).toString(),
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    throw new Error(`token endpoint ${res.status}: ${json.error || "unknown_error"}`);
+  }
+  return json;
+}
+
+function storeCredential(base, resource, tokens) {
+  const cfg = loadConfig();
+  cfg.base = base;
+  const prev = cfg.credentials[resource] || {};
+  cfg.credentials[resource] = {
+    resource,
+    access_token: tokens.access_token,
+    // A refresh response without a new refresh_token keeps the previous one.
+    refresh_token: tokens.refresh_token || prev.refresh_token || null,
+    scope: tokens.scope ?? prev.scope ?? null,
+    expires_at: Date.now() + (Number(tokens.expires_in) || 0) * 1000,
+  };
+  saveConfig(cfg);
+  return cfg.credentials[resource];
+}
+
+/** Run the full loopback Authorization Code + PKCE flow and store the tokens. */
+export async function login(base, resource = "v1", scope = DEFAULT_SCOPE) {
+  const codeVerifier = b64url(crypto.randomBytes(48));
+  const codeChallenge = b64url(crypto.createHash("sha256").update(codeVerifier).digest());
+  const state = b64url(crypto.randomBytes(16));
+
+  let redirectUri = "";
+  const code = await new Promise((resolve, reject) => {
+    const server = http.createServer((req, res) => {
+      const url = new URL(req.url, "http://127.0.0.1");
+      if (url.pathname !== "/callback") {
+        res.writeHead(404).end();
+        return;
+      }
+      const q = url.searchParams;
+      const done = (title, body) => {
+        res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+        res.end(
+          `<!doctype html><meta charset=utf-8><title>${title}</title>` +
+            `<body style="font-family:system-ui;max-width:30rem;margin:5rem auto;text-align:center">` +
+            `<h1>${title}</h1><p>${body}</p></body>`,
+        );
+        server.close();
+      };
+      if (q.get("error")) {
+        done("Authorization failed", `Error: ${q.get("error")}. You can close this tab.`);
+        reject(new Error(`authorize error: ${q.get("error")}`));
+        return;
+      }
+      if (q.get("state") !== state) {
+        done("Authorization failed", "State mismatch. Close this tab.");
+        reject(new Error("state mismatch"));
+        return;
+      }
+      if (q.get("iss") && q.get("iss").replace(/\/+$/, "") !== base) {
+        done("Authorization failed", "Issuer mismatch. Close this tab.");
+        reject(new Error("issuer mismatch"));
+        return;
+      }
+      done("You're signed in", "Return to your terminal. You can close this tab.");
+      resolve(q.get("code"));
+    });
+
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      redirectUri = `http://127.0.0.1:${server.address().port}/callback`;
+      const authorize = new URL(`${base}/api/oauth/authorize`);
+      authorize.searchParams.set("response_type", "code");
+      authorize.searchParams.set("client_id", CLIENT_ID);
+      authorize.searchParams.set("redirect_uri", redirectUri);
+      authorize.searchParams.set("scope", scope);
+      authorize.searchParams.set("state", state);
+      authorize.searchParams.set("code_challenge", codeChallenge);
+      authorize.searchParams.set("code_challenge_method", "S256");
+      authorize.searchParams.set("resource", resource);
+      process.stderr.write(`\nOpening your browser to sign in or create your account (${resource.toUpperCase()} access)...\n`);
+      process.stderr.write(`If it doesn't open, visit:\n  ${authorize.toString()}\n\n`);
+      openBrowser(authorize.toString());
+    });
+
+    setTimeout(() => {
+      server.close();
+      reject(new Error("timed out waiting for authorization (5 min)"));
+    }, 5 * 60 * 1000).unref();
+  });
+
+  const tokens = await tokenRequest(base, {
+    grant_type: "authorization_code",
+    code,
+    redirect_uri: redirectUri,
+    client_id: CLIENT_ID,
+    code_verifier: codeVerifier,
+  });
+  return storeCredential(base, resource, tokens);
+}
+
+/**
+ * A valid access token for the resource, refreshing if needed. Pass
+ * force=true to skip the cache and rotate immediately (used after a 401, when a
+ * token was revoked before its clock expiry).
+ */
+export async function getAccessToken(base, resource, { force = false } = {}) {
+  const cfg = loadConfig();
+  const cred = cfg.credentials[resource];
+  if (!cred) throw new NeedsLogin(resource);
+
+  const stillFresh = Date.now() < cred.expires_at - 30_000;
+  if (!force && stillFresh) return cred.access_token;
+
+  if (!cred.refresh_token) throw new NeedsLogin(resource);
+  let tokens;
+  try {
+    tokens = await tokenRequest(base, {
+      grant_type: "refresh_token",
+      refresh_token: cred.refresh_token,
+      client_id: CLIENT_ID,
+    });
+  } catch {
+    // Refresh failed (expired, revoked, or reuse-detected). Force a fresh login.
+    delete cfg.credentials[resource];
+    saveConfig(cfg);
+    throw new NeedsLogin(resource);
+  }
+  return storeCredential(base, resource, tokens).access_token;
+}
+
+export function logout() {
+  const cfg = loadConfig();
+  const tokens = [];
+  for (const cred of Object.values(cfg.credentials)) {
+    if (cred?.access_token) tokens.push(cred.access_token);
+    if (cred?.refresh_token) tokens.push(cred.refresh_token);
+  }
+  cfg.credentials = {};
+  saveConfig(cfg);
+  return { base: cfg.base, tokens };
+}
+
+/** Best-effort server-side revocation of a token (RFC 7009). */
+export async function revoke(base, token) {
+  try {
+    await fetch(`${base}/api/oauth/revoke`, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({ token }).toString(),
+    });
+  } catch {
+    /* revocation is best-effort */
+  }
+}

--- a/cli/output.mjs
+++ b/cli/output.mjs
@@ -1,0 +1,61 @@
+// Tiny output helpers. Color is used only on a TTY and honors NO_COLOR; every
+// command also supports --json for raw, scriptable output.
+
+const useColor = process.stdout.isTTY && !process.env.NO_COLOR;
+const wrap = (code) => (s) => (useColor ? `\x1b[${code}m${s}\x1b[0m` : String(s));
+
+export const c = {
+  bold: wrap("1"),
+  dim: wrap("2"),
+  red: wrap("31"),
+  green: wrap("32"),
+  yellow: wrap("33"),
+  cyan: wrap("36"),
+};
+
+export function printJson(value) {
+  process.stdout.write(JSON.stringify(value, null, 2) + "\n");
+}
+
+export function ok(message) {
+  process.stderr.write(`${c.green("✓")} ${message}\n`);
+}
+
+export function info(message) {
+  process.stderr.write(`${message}\n`);
+}
+
+export function fail(message) {
+  process.stderr.write(`${c.red("✗")} ${message}\n`);
+}
+
+const cell = (v) => (v === null || v === undefined ? "" : String(v));
+
+/** Render an array of row objects as an aligned table over the given columns.
+ *  columns: [{ key, label, map? }]. */
+export function table(rows, columns) {
+  if (!rows || rows.length === 0) {
+    info(c.dim("(none)"));
+    return;
+  }
+  const headers = columns.map((col) => col.label ?? col.key);
+  const body = rows.map((row) =>
+    columns.map((col) => cell(col.map ? col.map(row[col.key], row) : row[col.key])),
+  );
+  const widths = headers.map((h, i) =>
+    Math.max(h.length, ...body.map((r) => r[i].length)),
+  );
+  const line = (cells) => cells.map((v, i) => v.padEnd(widths[i])).join("  ");
+  process.stdout.write(c.bold(line(headers)) + "\n");
+  process.stdout.write(c.dim(line(widths.map((w) => "-".repeat(w)))) + "\n");
+  for (const r of body) process.stdout.write(line(r) + "\n");
+}
+
+/** Render a flat object as aligned key: value lines. */
+export function kv(obj) {
+  const keys = Object.keys(obj);
+  const w = Math.max(0, ...keys.map((k) => k.length));
+  for (const k of keys) {
+    process.stdout.write(`${c.dim(k.padEnd(w))}  ${cell(obj[k])}\n`);
+  }
+}

--- a/components/dashboard/org-switcher.tsx
+++ b/components/dashboard/org-switcher.tsx
@@ -48,6 +48,18 @@ export function OrgSwitcher({
     }
   }, [pendingOrg, activeId, isPending]);
 
+  // Safety net: never let the overlay spin forever. If the switch hasn't taken
+  // effect within a few seconds (e.g. the write silently no-op'd), drop the
+  // loader and resync from the server instead of hanging.
+  useEffect(() => {
+    if (!pendingOrg) return;
+    const timer = setTimeout(() => {
+      setPendingOrg(null);
+      router.refresh();
+    }, 12000);
+    return () => clearTimeout(timer);
+  }, [pendingOrg, router]);
+
   async function switchTo(org: OrgOption) {
     setOpen(false);
     if (!active || org.id === active.id) return;

--- a/lib/api-auth.test.ts
+++ b/lib/api-auth.test.ts
@@ -1,19 +1,34 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { generateApiKey, hashApiKey, keyHint } from "@/lib/crypto";
-import { authenticateApiKey, bearerToken } from "@/lib/api-auth";
+import {
+  allowsAudience,
+  authenticateApiKey,
+  bearerToken,
+  FULL_SCOPES,
+  hasScope,
+  isOAuthToken,
+  type ApiAuthContext,
+} from "@/lib/api-auth";
 import { createServiceClient } from "@/lib/supabase/service";
 
 vi.mock("@/lib/supabase/service", () => ({ createServiceClient: vi.fn() }));
 
 // A minimal stand-in for the supabase client covering the exact chains
-// lib/api-auth uses: select().eq().maybeSingle() and update().eq() (awaited).
-function fakeServiceClient(row: { id: string; user_id: string } | null) {
+// lib/api-auth uses: for api_keys, select().eq().maybeSingle(); for
+// oauth_access_tokens, select().eq().is().gt().maybeSingle(); and
+// update().eq() (awaited) on both. maybeSingle returns the row registered for
+// the table being queried, so a request can hit the api_keys path, the OAuth
+// fallback, or neither.
+function fakeServiceClient(
+  apiKeyRow: { id: string; user_id: string } | null,
+  oauthRow: Record<string, unknown> | null = null,
+) {
   const eqCalls: unknown[][] = [];
   const updates: unknown[] = [];
   const client = {
     eqCalls,
     updates,
-    from(_table: string) {
+    from(table: string) {
       const q = {
         select: () => q,
         update: (patch: unknown) => {
@@ -24,7 +39,12 @@ function fakeServiceClient(row: { id: string; user_id: string } | null) {
           eqCalls.push(args);
           return q;
         },
-        maybeSingle: async () => ({ data: row, error: null }),
+        is: () => q,
+        gt: () => q,
+        maybeSingle: async () => ({
+          data: table === "api_keys" ? apiKeyRow : oauthRow,
+          error: null,
+        }),
         then: (resolve: (v: unknown) => unknown) =>
           Promise.resolve({ data: null, error: null }).then(resolve),
       };
@@ -75,20 +95,100 @@ describe("authenticateApiKey", () => {
     expect(await authenticateApiKey(generateApiKey())).toBeNull();
   });
 
-  it("resolves a valid key to its owner, looking up by hash only", async () => {
+  it("resolves a classic api key to full access, looking up by hash only", async () => {
     const client = fakeServiceClient({ id: "key-1", user_id: "user-1" });
     vi.mocked(createServiceClient).mockReturnValue(client as never);
 
     const token = generateApiKey();
     const ctx = await authenticateApiKey(token);
 
-    expect(ctx).toMatchObject({ userId: "user-1", keyId: "key-1" });
+    expect(ctx).toMatchObject({
+      userId: "user-1",
+      keyId: "key-1",
+      tokenType: "api_key",
+      clientId: null,
+      expiresAt: null,
+      aud: null,
+    });
+    // A classic key carries the full scope set and no audience binding, so it
+    // behaves exactly as it did before OAuth existed.
+    expect(ctx!.scopes).toEqual([...FULL_SCOPES]);
+    expect(hasScope(ctx!, "runs:trigger")).toBe(true);
+    expect(allowsAudience(ctx!, "v1")).toBe(true);
+    expect(allowsAudience(ctx!, "mcp")).toBe(true);
+    expect(isOAuthToken(ctx!)).toBe(false);
+
     // The plaintext must never be used as a filter — only its hash.
     expect(client.eqCalls).toContainEqual(["key_hash", hashApiKey(token)]);
     for (const call of client.eqCalls) expect(call).not.toContain(token);
-    // Usage is stamped for the settings page.
+    // Usage is stamped for the settings page (one update: the api_keys row).
     expect(client.updates).toHaveLength(1);
     expect(client.updates[0]).toHaveProperty("last_used_at");
+  });
+
+  it("falls back to an OAuth access token, carrying its scopes and audience", async () => {
+    const client = fakeServiceClient(null, {
+      id: "at-1",
+      user_id: "user-2",
+      client_id: "lt_cli",
+      scopes: ["runs:read"],
+      resource: "mcp",
+      expires_at: "2999-01-01T00:00:00.000Z",
+      authorization_id: "az-1",
+    });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const ctx = await authenticateApiKey("lt_oauth_whatever");
+
+    expect(ctx).toMatchObject({
+      userId: "user-2",
+      keyId: "at-1",
+      tokenType: "oauth",
+      clientId: "lt_cli",
+      aud: "mcp",
+      expiresAt: "2999-01-01T00:00:00.000Z",
+    });
+    expect(ctx!.scopes).toEqual(["runs:read"]);
+    // Scoped and audience-bound: it can read runs but not trigger them, and it
+    // is valid for MCP only — never the REST surface.
+    expect(hasScope(ctx!, "runs:read")).toBe(true);
+    expect(hasScope(ctx!, "runs:trigger")).toBe(false);
+    expect(allowsAudience(ctx!, "mcp")).toBe(true);
+    expect(allowsAudience(ctx!, "v1")).toBe(false);
+    expect(isOAuthToken(ctx!)).toBe(true);
+
+    // Looked up by hash, and expiry/revocation pushed into the query (is/gt).
+    expect(client.eqCalls).toContainEqual(["token_hash", hashApiKey("lt_oauth_whatever")]);
+    // Stamps last_used on both the token and its standing authorization.
+    expect(client.updates).toHaveLength(2);
+  });
+});
+
+describe("scope + audience helpers", () => {
+  const oauth: ApiAuthContext = {
+    supabase: {} as never,
+    userId: "u",
+    keyId: "at",
+    tokenType: "oauth",
+    scopes: ["projects:read"],
+    clientId: "lt_cli",
+    expiresAt: "2999-01-01T00:00:00.000Z",
+    aud: "v1",
+  };
+
+  it("hasScope is deny-by-default for a scope not granted", () => {
+    expect(hasScope(oauth, "projects:read")).toBe(true);
+    expect(hasScope(oauth, "projects:write")).toBe(false);
+  });
+
+  it("an audience-bound token is rejected on the other surface", () => {
+    expect(allowsAudience(oauth, "v1")).toBe(true);
+    expect(allowsAudience(oauth, "mcp")).toBe(false);
+  });
+
+  it("an empty-scope token grants nothing", () => {
+    const empty: ApiAuthContext = { ...oauth, scopes: [] };
+    expect(hasScope(empty, "projects:read")).toBe(false);
   });
 });
 

--- a/lib/api-auth.ts
+++ b/lib/api-auth.ts
@@ -3,14 +3,46 @@ import { createServiceClient } from "@/lib/supabase/service";
 import { hashApiKey } from "@/lib/crypto";
 
 // Bearer-token auth for the programmatic surface (/api/v1 and /api/mcp).
-// Requests carry a Lettertrace API key instead of a Supabase session, so the
+// Requests carry a Lettertrace credential instead of a Supabase session, so the
 // returned client is the service-role client: RLS is bypassed and every query
 // made with it MUST be scoped by userId explicitly.
+//
+// Two credential classes resolve through here to the SAME context shape:
+//   - classic api_keys ("lt_live_…"): indefinite, full-access, hand-minted.
+//   - OAuth access tokens ("lt_oauth_…"): short-lived, scoped, revocable,
+//     audience-bound, obtained via the OAuth flow (lib/oauth.ts). A classic key
+//     behaves exactly as before because it is handed the full scope set and no
+//     audience restriction.
+
+/** The scopes a classic api_keys credential is treated as holding. Also the
+ *  full set an OAuth client can ever be granted (minus offline_access, which is
+ *  a request-time flag for a refresh token, not a data permission). */
+export const FULL_SCOPES = [
+  "projects:read",
+  "projects:write",
+  "runs:read",
+  "runs:trigger",
+] as const;
+
+export type Scope = (typeof FULL_SCOPES)[number];
+export type TokenType = "api_key" | "oauth";
+/** RFC 8707 resource audience: which programmatic surface a token may call. */
+export type ResourceAudience = "v1" | "mcp";
 
 export interface ApiAuthContext {
   supabase: SupabaseClient;
   userId: string;
+  /** Row id of the resolving credential (api_keys.id or oauth_access_tokens.id). */
   keyId: string;
+  tokenType: TokenType;
+  /** Granted scopes. A classic api_key carries FULL_SCOPES. */
+  scopes: string[];
+  /** OAuth client id, or null for a classic api_key. */
+  clientId: string | null;
+  /** ISO expiry, or null for a (non-expiring) classic api_key. */
+  expiresAt: string | null;
+  /** Bound audience, or null for a classic api_key (which may call anything). */
+  aud: ResourceAudience | null;
 }
 
 /** Extract the token from an `Authorization: Bearer <token>` header. */
@@ -20,27 +52,95 @@ export function bearerToken(header: string | null): string | null {
   return match ? match[1].trim() : null;
 }
 
+/** True when the context is allowed to exercise `scope`. */
+export function hasScope(ctx: ApiAuthContext, scope: Scope): boolean {
+  return ctx.scopes.includes(scope);
+}
+
+/** True when the context may call the given surface. A classic api_key (aud
+ *  null) may call anything; an OAuth token is bound to exactly one audience. */
+export function allowsAudience(ctx: ApiAuthContext, aud: ResourceAudience): boolean {
+  return ctx.aud === null || ctx.aud === aud;
+}
+
+export function isOAuthToken(
+  ctx: ApiAuthContext,
+): ctx is ApiAuthContext & { tokenType: "oauth"; clientId: string; aud: ResourceAudience } {
+  return ctx.tokenType === "oauth";
+}
+
 /**
- * Resolve an API key to its owner. Returns null for a missing or unknown key.
- * Touches last_used_at so the settings page can show stale keys.
+ * Resolve a bearer token to its owner and permissions. Returns null for a
+ * missing, unknown, expired, or revoked credential.
+ *
+ * Fail-closed: expiry and revocation are pushed into the SQL WHERE clause, so a
+ * query error or a missing row yields null (no access), never a context.
+ * Touches last_used_at so the settings pages can show stale credentials.
  */
 export async function authenticateApiKey(
   token: string | null | undefined,
 ): Promise<ApiAuthContext | null> {
   if (!token) return null;
   const supabase = createServiceClient();
+  const hash = hashApiKey(token);
 
-  const { data } = await supabase
+  // 1. Classic Lettertrace API key. Unchanged behavior: full access, no expiry.
+  const { data: apiKey } = await supabase
     .from("api_keys")
     .select("id, user_id")
-    .eq("key_hash", hashApiKey(token))
+    .eq("key_hash", hash)
     .maybeSingle();
-  if (!data) return null;
+  if (apiKey) {
+    await supabase
+      .from("api_keys")
+      .update({ last_used_at: new Date().toISOString() })
+      .eq("id", apiKey.id);
+    return {
+      supabase,
+      userId: apiKey.user_id as string,
+      keyId: apiKey.id as string,
+      tokenType: "api_key",
+      scopes: [...FULL_SCOPES],
+      clientId: null,
+      expiresAt: null,
+      aud: null,
+    };
+  }
 
-  await supabase
-    .from("api_keys")
-    .update({ last_used_at: new Date().toISOString() })
-    .eq("id", data.id);
+  // 2. OAuth access token. Expiry + revocation are enforced in SQL, so this
+  //    only ever returns a live token. Revocation cascades to this row (the
+  //    revoke path and refresh-reuse detection both stamp revoked_at here), so
+  //    the grant does not need a second lookup on the hot path.
+  const nowIso = new Date().toISOString();
+  const { data: oauth } = await supabase
+    .from("oauth_access_tokens")
+    .select("id, user_id, client_id, scopes, resource, expires_at, authorization_id")
+    .eq("token_hash", hash)
+    .is("revoked_at", null)
+    .gt("expires_at", nowIso)
+    .maybeSingle();
+  if (oauth) {
+    await supabase
+      .from("oauth_access_tokens")
+      .update({ last_used_at: nowIso })
+      .eq("id", oauth.id);
+    if (oauth.authorization_id) {
+      await supabase
+        .from("oauth_authorizations")
+        .update({ last_used_at: nowIso })
+        .eq("id", oauth.authorization_id);
+    }
+    return {
+      supabase,
+      userId: oauth.user_id as string,
+      keyId: oauth.id as string,
+      tokenType: "oauth",
+      scopes: (oauth.scopes as string[]) ?? [],
+      clientId: oauth.client_id as string,
+      expiresAt: oauth.expires_at as string,
+      aud: oauth.resource as ResourceAudience,
+    };
+  }
 
-  return { supabase, userId: data.user_id as string, keyId: data.id as string };
+  return null;
 }

--- a/lib/api-guards.ts
+++ b/lib/api-guards.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import {
+  allowsAudience,
+  authenticateApiKey,
+  bearerToken,
+  hasScope,
+  type ApiAuthContext,
+  type ResourceAudience,
+  type Scope,
+} from "@/lib/api-auth";
+
+// Shared bearer-auth guard for the REST surface (/api/v1). It resolves the
+// token, then enforces — fail-closed — the resource audience and the required
+// scope. Returns the authenticated context on success, or a ready-to-return
+// 401/403 Response the caller forwards unchanged:
+//
+//   const auth = await requireApiAuth(request, "projects:read", "v1");
+//   if (auth instanceof Response) return auth;
+//   // ...use auth.supabase / auth.userId...
+//
+// A classic Lettertrace API key carries FULL_SCOPES and no audience binding, so
+// it passes every check exactly as it did before OAuth existed. An OAuth access
+// token only passes when it was granted this scope AND minted for this surface,
+// so the consent screen the user approved is enforced on every request, reads
+// included — never advisory.
+
+function unauthorized(): Response {
+  return NextResponse.json(
+    { error: "Invalid or missing API key" },
+    { status: 401, headers: { "WWW-Authenticate": 'Bearer realm="lettertrace"' } },
+  );
+}
+
+function forbidden(message: string, challenge: string): Response {
+  return NextResponse.json(
+    { error: message },
+    { status: 403, headers: { "WWW-Authenticate": `Bearer ${challenge}` } },
+  );
+}
+
+export async function requireApiAuth(
+  request: Request,
+  scope: Scope,
+  aud: ResourceAudience,
+): Promise<ApiAuthContext | Response> {
+  const auth = await authenticateApiKey(
+    bearerToken(request.headers.get("authorization")),
+  );
+  if (!auth) return unauthorized();
+
+  // Audience first: an OAuth token minted for MCP must not reach the REST API
+  // (and vice versa). A classic key (aud null) may call anything.
+  if (!allowsAudience(auth, aud)) {
+    return forbidden(
+      "This token is not authorized for the Lettertrace REST API.",
+      'error="invalid_token", error_description="wrong resource audience"',
+    );
+  }
+
+  if (!hasScope(auth, scope)) {
+    return forbidden(
+      `This token is missing the required "${scope}" scope.`,
+      `error="insufficient_scope", scope="${scope}"`,
+    );
+  }
+
+  return auth;
+}

--- a/lib/crypto.ts
+++ b/lib/crypto.ts
@@ -84,8 +84,19 @@ export function generateApiKey(): string {
   return `${API_KEY_PREFIX}${crypto.randomBytes(24).toString("base64url")}`;
 }
 
-export function hashApiKey(plaintext: string): string {
+/**
+ * The single hashing convention for every bearer secret we store — classic API
+ * keys and every OAuth token/code alike. A plain SHA-256 hex digest of the
+ * trimmed plaintext: fast (these are high-entropy random tokens, not passwords,
+ * so no KDF is needed) and non-reversible, so a database leak never yields a
+ * usable credential.
+ */
+export function sha256Hex(plaintext: string): string {
   return crypto.createHash("sha256").update(plaintext.trim()).digest("hex");
+}
+
+export function hashApiKey(plaintext: string): string {
+  return sha256Hex(plaintext);
 }
 
 // A non-reversible hint so users can recognize which key is stored, e.g. "sk-ant-…4a9c".
@@ -95,4 +106,68 @@ export function keyHint(plaintext: string): string {
   const prefix = trimmed.slice(0, 7);
   const suffix = trimmed.slice(-4);
   return `${prefix}…${suffix}`;
+}
+
+// ------------------------------------------------------------------
+// OAuth 2.1 credentials. Every one is an opaque, high-entropy random string
+// stored only as its SHA-256 digest (sha256Hex) — never in plaintext, never
+// encrypted-and-recoverable. The plaintext is handed to the client exactly once
+// (in a redirect, a token response, or on-screen) and cannot be read back.
+// Prefixes make a leaked value instantly recognizable in logs/secret scanners.
+// ------------------------------------------------------------------
+
+/** Access token: short-lived (~1h), presented as `Authorization: Bearer`. */
+export function generateOAuthAccessToken(): string {
+  return `lt_oauth_${crypto.randomBytes(24).toString("base64url")}`;
+}
+
+/** Refresh token: longer-lived, rotates on every use. */
+export function generateRefreshToken(): string {
+  return `lt_refr_${crypto.randomBytes(32).toString("base64url")}`;
+}
+
+/** Authorization code: single-use, ~5 min, delivered via the redirect. */
+export function generateAuthCode(): string {
+  return `lt_code_${crypto.randomBytes(32).toString("base64url")}`;
+}
+
+/** Device code (RFC 8628): the CLI's polling handle, single-use, ~15 min. */
+export function generateDeviceCode(): string {
+  return `lt_dev_${crypto.randomBytes(32).toString("base64url")}`;
+}
+
+// Crockford base32 (no I, L, O, U — the characters people misread). We map 40
+// random bits (5 bytes) onto exactly 8 characters, so there is no modulo bias.
+const CROCKFORD = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+/**
+ * Human-typed device code, e.g. "WXYZ-1234" (~40 bits). Short enough to read off
+ * one screen and type on another, high-entropy enough that guessing is hopeless
+ * within the 15-minute window — and we additionally cap attempts and store only
+ * its hash, so the plaintext never sits in the database.
+ */
+export function generateUserCode(): string {
+  const bytes = crypto.randomBytes(5); // 40 bits
+  let bits = 0;
+  let value = 0;
+  let out = "";
+  for (const byte of bytes) {
+    value = (value << 8) | byte;
+    bits += 8;
+    while (bits >= 5) {
+      bits -= 5;
+      out += CROCKFORD[(value >>> bits) & 0x1f];
+    }
+  }
+  return `${out.slice(0, 4)}-${out.slice(4, 8)}`;
+}
+
+/** Normalize a user-entered code for hash lookup: uppercase, strip separators. */
+export function normalizeUserCode(input: string): string {
+  return input.trim().toUpperCase().replace(/[\s-]/g, "");
+}
+
+/** A masked hint for an OAuth token, mirroring keyHint's shape. */
+export function oauthTokenHint(plaintext: string): string {
+  return keyHint(plaintext);
 }

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -59,12 +59,25 @@ export const getProject = cache(async function getProject(
   return (data as Project | null) ?? null;
 });
 
-/** Point the dashboard at another of the user's organizations. */
+/**
+ * Point the dashboard at another of the user's organizations.
+ *
+ * Goes through the set_active_project RPC, which is SECURITY DEFINER and first
+ * guarantees a profile row exists — without that, an account whose profile row
+ * is missing (older signups) silently no-ops here, leaving active_project_id
+ * unchanged and the org switcher spinning forever. If the RPC isn't present yet
+ * (deployment hasn't re-applied the schema), fall back to a direct update; the
+ * schema's profile backfill keeps that row present.
+ */
 export async function setActiveProject(
   supabase: SupabaseClient,
   userId: string,
   projectId: string,
 ): Promise<void> {
+  const { error } = await supabase.rpc("set_active_project", {
+    p_project_id: projectId,
+  });
+  if (!error) return;
   await supabase
     .from("profiles")
     .update({ active_project_id: projectId })

--- a/lib/oauth-ratelimit.ts
+++ b/lib/oauth-ratelimit.ts
@@ -1,0 +1,59 @@
+import { createServiceClient } from "@/lib/supabase/service";
+
+// A tiny fixed-window, DB-counter rate limiter. express-rate-limit (what the MCP
+// SDK's own auth router uses) is Express-only and cannot run in App Router route
+// handlers, and this deployment has no guaranteed Redis — so the counter lives
+// in Postgres (public.oauth_rate_limits) and is bumped atomically by the
+// oauth_rate_touch() function, which resets its own window.
+//
+// It fails OPEN on infrastructure error: a database blip must not lock every
+// user out of signing in. That is a deliberate availability trade — the
+// brute-force-critical paths (the device user_code) additionally carry an
+// in-SQL attempts cap that does NOT depend on this limiter, so a fail-open here
+// never removes the last line of defense.
+
+export interface RateLimitResult {
+  allowed: boolean;
+  count: number;
+}
+
+export async function rateLimit(
+  bucket: string,
+  windowSeconds: number,
+  limit: number,
+): Promise<RateLimitResult> {
+  try {
+    const supabase = createServiceClient();
+    const { data, error } = await supabase.rpc("oauth_rate_touch", {
+      p_bucket: bucket,
+      p_window_seconds: windowSeconds,
+      p_limit: limit,
+    });
+    if (error || !data) {
+      console.error("[oauth] rate limiter unavailable:", error?.message);
+      return { allowed: true, count: 0 };
+    }
+    const row = Array.isArray(data) ? data[0] : data;
+    return {
+      allowed: Boolean(row?.allowed),
+      count: Number(row?.current_count ?? 0),
+    };
+  } catch (e) {
+    console.error(
+      "[oauth] rate limiter threw:",
+      e instanceof Error ? e.message : e,
+    );
+    return { allowed: true, count: 0 };
+  }
+}
+
+/**
+ * Best-effort client IP for bucketing, read from the usual proxy headers. Only
+ * used to spread abuse counters — never as an auth signal — so a spoofed value
+ * costs the attacker nothing they didn't already have.
+ */
+export function clientIp(request: Request): string {
+  const xff = request.headers.get("x-forwarded-for");
+  if (xff) return xff.split(",")[0]!.trim() || "unknown";
+  return request.headers.get("x-real-ip")?.trim() || "unknown";
+}

--- a/lib/oauth-responses.ts
+++ b/lib/oauth-responses.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+
+// Small HTTP response helpers shared by the OAuth route handlers. Kept out of
+// lib/oauth.ts so that module (imported by node-env unit tests) doesn't pull in
+// next/server.
+
+export function escapeHtml(s: string): string {
+  return s.replace(
+    /[&<>"']/g,
+    (c) =>
+      ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c]!,
+  );
+}
+
+/** A minimal, self-contained HTML error page for the interactive endpoints —
+ *  used only when we cannot safely redirect the error back (unknown client or
+ *  unregistered redirect_uri), so we never become an open redirector. */
+export function oauthErrorPage(message: string, status = 400): NextResponse {
+  const html =
+    `<!doctype html><html lang="en"><head><meta charset="utf-8">` +
+    `<meta name="viewport" content="width=device-width, initial-scale=1">` +
+    `<title>Authorization error</title></head>` +
+    `<body style="font-family:system-ui,-apple-system,sans-serif;max-width:32rem;margin:4rem auto;padding:0 1.25rem;color:#1a1a1a">` +
+    `<h1 style="font-size:1.25rem">Authorization error</h1>` +
+    `<p style="color:#555">${escapeHtml(message)}</p>` +
+    `</body></html>`;
+  return new NextResponse(html, {
+    status,
+    headers: { "content-type": "text/html; charset=utf-8", "cache-control": "no-store" },
+  });
+}
+
+/** Redirect an OAuth error back to a (previously validated) redirect_uri, with
+ *  the state echoed and the issuer stamped (RFC 9207 mix-up defense). */
+export function oauthRedirectError(
+  redirectUri: string,
+  code: string,
+  state: string | null,
+  issuer: string,
+): NextResponse {
+  const u = new URL(redirectUri);
+  u.searchParams.set("error", code);
+  if (state) u.searchParams.set("state", state);
+  u.searchParams.set("iss", issuer);
+  return NextResponse.redirect(u, { status: 302 });
+}
+
+/** An RFC 6749 §5.2 token/authorization error body — the error CODE only, never
+ *  an internal message. Always no-store. */
+export function oauthErrorJson(
+  code: string,
+  status: number,
+  description?: string,
+): NextResponse {
+  const body: Record<string, string> = { error: code };
+  if (description) body.error_description = description;
+  return NextResponse.json(body, {
+    status,
+    headers: { "cache-control": "no-store", pragma: "no-cache" },
+  });
+}
+
+/** A successful token response — always no-store per RFC 6749 §5.1. */
+export function tokenJson(payload: Record<string, unknown>): NextResponse {
+  return NextResponse.json(payload, {
+    headers: { "cache-control": "no-store", pragma: "no-cache" },
+  });
+}

--- a/lib/oauth.test.ts
+++ b/lib/oauth.test.ts
@@ -1,0 +1,325 @@
+import crypto from "node:crypto";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  authenticateClient,
+  dataScopesOf,
+  exchangeAuthorizationCode,
+  exchangeRefreshToken,
+  OAuthError,
+  parseBasicAuth,
+  parseScopeString,
+  redirectUriAllowed,
+  resolveAudience,
+  validateScopes,
+  validCodeVerifier,
+  verifyClientSecret,
+  verifyPkce,
+  type OAuthClient,
+} from "@/lib/oauth";
+import { sha256Hex } from "@/lib/crypto";
+
+// A real 32-byte key so the refresh-retry successor pair can be encrypted.
+beforeAll(() => {
+  process.env.ENCRYPTION_KEY = Buffer.alloc(32, 7).toString("base64");
+});
+
+const cliClient: OAuthClient = {
+  client_id: "lt_cli",
+  user_id: null,
+  is_first_party: true,
+  client_name: "Lettertrace CLI",
+  client_type: "public",
+  client_secret_hash: null,
+  token_endpoint_auth_method: "none",
+  redirect_uris: ["http://127.0.0.1/callback", "http://[::1]/callback"],
+  allowed_scopes: ["projects:read", "projects:write", "runs:read", "runs:trigger", "offline_access"],
+  logo_uri: null,
+  client_uri: null,
+};
+
+const httpsClient: OAuthClient = {
+  ...cliClient,
+  client_id: "acme",
+  is_first_party: false,
+  client_type: "confidential",
+  client_secret_hash: sha256Hex("s3cret"),
+  token_endpoint_auth_method: "client_secret_basic",
+  redirect_uris: ["https://acme.example.com/oauth/callback"],
+};
+
+function s256(verifier: string): string {
+  return crypto.createHash("sha256").update(verifier).digest("base64url");
+}
+
+describe("PKCE", () => {
+  const verifier = "a".repeat(64);
+  const challenge = s256(verifier);
+
+  it("accepts a correct S256 verifier", () => {
+    expect(verifyPkce(verifier, challenge)).toBe(true);
+  });
+
+  it("rejects a wrong verifier", () => {
+    expect(verifyPkce("b".repeat(64), challenge)).toBe(false);
+  });
+
+  it("rejects a verifier that is too short or has illegal chars", () => {
+    expect(validCodeVerifier("short")).toBe(false);
+    expect(validCodeVerifier("a".repeat(42))).toBe(false);
+    expect(validCodeVerifier("a".repeat(43))).toBe(true);
+    expect(validCodeVerifier("a".repeat(129))).toBe(false);
+    expect(validCodeVerifier("has spaces " + "a".repeat(40))).toBe(false);
+    // A malformed verifier never passes PKCE even against a matching-looking hash.
+    expect(verifyPkce("short", s256("short"))).toBe(false);
+  });
+});
+
+describe("redirectUriAllowed", () => {
+  it("allows any port on a registered loopback template", () => {
+    expect(redirectUriAllowed(cliClient, "http://127.0.0.1:49152/callback")).toBe(true);
+    expect(redirectUriAllowed(cliClient, "http://127.0.0.1:1/callback")).toBe(true);
+    expect(redirectUriAllowed(cliClient, "http://[::1]:8080/callback")).toBe(true);
+  });
+
+  it("rejects a non-loopback host even on the right path", () => {
+    expect(redirectUriAllowed(cliClient, "http://evil.com/callback")).toBe(false);
+    expect(redirectUriAllowed(cliClient, "http://127.0.0.1.evil.com/callback")).toBe(false);
+    // localhost (DNS) is deliberately not accepted — only the IP literal.
+    expect(redirectUriAllowed(cliClient, "http://localhost:5000/callback")).toBe(false);
+  });
+
+  it("rejects a wrong path, embedded userinfo, query, or fragment", () => {
+    expect(redirectUriAllowed(cliClient, "http://127.0.0.1:5000/evil")).toBe(false);
+    expect(redirectUriAllowed(cliClient, "http://127.0.0.1:5000/callback/../evil")).toBe(false);
+    expect(redirectUriAllowed(cliClient, "http://user:pass@127.0.0.1:5000/callback")).toBe(false);
+    expect(redirectUriAllowed(cliClient, "http://127.0.0.1:5000/callback?x=1")).toBe(false);
+    expect(redirectUriAllowed(cliClient, "http://127.0.0.1:5000/callback#frag")).toBe(false);
+    expect(redirectUriAllowed(cliClient, "https://127.0.0.1:5000/callback")).toBe(false);
+  });
+
+  it("requires an exact match for an https client", () => {
+    expect(redirectUriAllowed(httpsClient, "https://acme.example.com/oauth/callback")).toBe(true);
+    expect(redirectUriAllowed(httpsClient, "https://acme.example.com/oauth/callback/")).toBe(false);
+    expect(redirectUriAllowed(httpsClient, "https://acme.example.com.evil.com/oauth/callback")).toBe(false);
+    expect(redirectUriAllowed(httpsClient, "https://acme.example.com/oauth/callback?x=1")).toBe(false);
+  });
+
+  it("rejects unparseable input", () => {
+    expect(redirectUriAllowed(cliClient, "not a url")).toBe(false);
+    expect(redirectUriAllowed(cliClient, "")).toBe(false);
+  });
+});
+
+describe("scopes", () => {
+  it("parses and dedupes a scope string", () => {
+    expect(parseScopeString("a  b\tb")).toEqual(["a", "b"]);
+    expect(parseScopeString("")).toEqual([]);
+    expect(parseScopeString(null)).toEqual([]);
+  });
+
+  it("grants only known scopes allowed for the client, rest are invalid", () => {
+    const v = validateScopes(
+      ["projects:read", "runs:trigger", "made:up", "runs:read"],
+      ["projects:read", "runs:read"],
+    );
+    expect(v.granted).toEqual(["projects:read", "runs:read"]);
+    expect(v.invalid).toEqual(["runs:trigger", "made:up"]);
+  });
+
+  it("drops offline_access from the data-scope set", () => {
+    expect(dataScopesOf(["projects:read", "offline_access"])).toEqual(["projects:read"]);
+  });
+});
+
+describe("resolveAudience", () => {
+  it("defaults to the REST API when absent", () => {
+    expect(resolveAudience(null)).toBe("v1");
+    expect(resolveAudience(undefined)).toBe("v1");
+  });
+  it("accepts short tokens and full resource URLs", () => {
+    expect(resolveAudience("mcp")).toBe("mcp");
+    expect(resolveAudience("v1")).toBe("v1");
+    expect(resolveAudience("https://app.example.com/api/mcp")).toBe("mcp");
+    expect(resolveAudience("https://app.example.com/api/v1/")).toBe("v1");
+  });
+  it("rejects an explicit but unrecognized resource", () => {
+    expect(resolveAudience("https://app.example.com/other")).toBeNull();
+    expect(resolveAudience("garbage")).toBeNull();
+  });
+});
+
+describe("client auth primitives", () => {
+  it("parses Basic auth, tolerating malformed input", () => {
+    const header = "Basic " + Buffer.from("acme:s3cret").toString("base64");
+    expect(parseBasicAuth(header)).toEqual({ clientId: "acme", secret: "s3cret" });
+    expect(parseBasicAuth(null)).toBeNull();
+    expect(parseBasicAuth("Bearer x")).toBeNull();
+  });
+
+  it("verifies a client secret in constant time", () => {
+    expect(verifyClientSecret(httpsClient, "s3cret")).toBe(true);
+    expect(verifyClientSecret(httpsClient, "wrong")).toBe(false);
+    expect(verifyClientSecret(cliClient, "anything")).toBe(false); // public: no secret
+  });
+});
+
+// --- programmable fake supabase client for the state machines --------
+function makeClient(
+  responder: (table: string, chain: unknown[][], terminal: string) => { data?: unknown; error?: unknown },
+) {
+  return {
+    from(table: string) {
+      const chain: unknown[][] = [];
+      const rec = (op: string) => (...a: unknown[]) => (chain.push([op, ...a]), builder);
+      const builder: Record<string, unknown> = {
+        select: rec("select"),
+        insert: rec("insert"),
+        update: rec("update"),
+        upsert: rec("upsert"),
+        delete: rec("delete"),
+        eq: rec("eq"),
+        is: rec("is"),
+        gt: rec("gt"),
+        maybeSingle: () => Promise.resolve(responder(table, chain, "maybeSingle")),
+        single: () => Promise.resolve(responder(table, chain, "single")),
+        then: (resolve: (v: unknown) => unknown, reject?: (e: unknown) => unknown) =>
+          Promise.resolve(responder(table, chain, "await")).then(resolve, reject),
+      };
+      return builder;
+    },
+  } as never;
+}
+
+const patchOf = (chain: unknown[][], op: string): Record<string, unknown> | undefined =>
+  chain.find((c) => c[0] === op)?.[1] as Record<string, unknown> | undefined;
+const hasOp = (chain: unknown[][], op: string): boolean => chain.some((c) => c[0] === op);
+
+describe("exchangeAuthorizationCode", () => {
+  const verifier = "a".repeat(64);
+  const challenge = s256(verifier);
+  const codeRow = {
+    client_id: "lt_cli",
+    redirect_uri: "http://127.0.0.1:5000/callback",
+    code_challenge: challenge,
+    scopes: ["projects:read", "offline_access"],
+    resource: "v1",
+    user_id: "u1",
+    authorization_id: "az1",
+  };
+
+  const responder =
+    (row: unknown) => (table: string, chain: unknown[][], terminal: string) => {
+      if (table === "oauth_authorization_codes") return { data: row, error: null };
+      if (table === "oauth_access_tokens") return { data: null, error: null };
+      if (table === "oauth_refresh_tokens" && terminal === "single")
+        return { data: { id: "rt1" }, error: null };
+      return { data: null, error: null };
+    };
+
+  it("mints an access + refresh pair on the happy path", async () => {
+    const client = makeClient(responder(codeRow));
+    const resp = await exchangeAuthorizationCode(client, cliClient, {
+      code: "lt_code_x",
+      redirectUri: "http://127.0.0.1:5000/callback",
+      codeVerifier: verifier,
+    });
+    expect(resp.access_token).toMatch(/^lt_oauth_/);
+    expect(resp.refresh_token).toMatch(/^lt_refr_/); // offline_access requested
+    expect(resp.scope).toBe("projects:read"); // offline_access is not a data scope
+    expect(resp.token_type).toBe("Bearer");
+  });
+
+  it("rejects a mismatched redirect_uri", async () => {
+    const client = makeClient(responder(codeRow));
+    await expect(
+      exchangeAuthorizationCode(client, cliClient, {
+        code: "lt_code_x",
+        redirectUri: "http://127.0.0.1:9999/callback",
+        codeVerifier: verifier,
+      }),
+    ).rejects.toMatchObject({ code: "invalid_grant" });
+  });
+
+  it("rejects a bad PKCE verifier", async () => {
+    const client = makeClient(responder(codeRow));
+    await expect(
+      exchangeAuthorizationCode(client, cliClient, {
+        code: "lt_code_x",
+        redirectUri: "http://127.0.0.1:5000/callback",
+        codeVerifier: "b".repeat(64),
+      }),
+    ).rejects.toMatchObject({ code: "invalid_grant" });
+  });
+
+  it("rejects an already-used or expired code (atomic consume returns nothing)", async () => {
+    const client = makeClient(responder(null));
+    await expect(
+      exchangeAuthorizationCode(client, cliClient, {
+        code: "lt_code_x",
+        redirectUri: "http://127.0.0.1:5000/callback",
+        codeVerifier: verifier,
+      }),
+    ).rejects.toMatchObject({ code: "invalid_grant" });
+  });
+});
+
+describe("exchangeRefreshToken rotation + reuse detection", () => {
+  const liveRow = {
+    id: "rt-old",
+    client_id: "lt_cli",
+    family_id: "fam1",
+    scopes: ["runs:read"],
+    resource: "v1",
+    user_id: "u1",
+    authorization_id: "az1",
+  };
+
+  it("rotates: consumes the old token and issues a new pair", async () => {
+    const client = makeClient((table, chain, terminal) => {
+      if (table === "oauth_refresh_tokens" && hasOp(chain, "update") && patchOf(chain, "update")?.used_at) {
+        return { data: liveRow, error: null }; // atomic consume succeeds
+      }
+      if (table === "oauth_refresh_tokens" && terminal === "single") return { data: { id: "rt-new" }, error: null };
+      return { data: null, error: null };
+    });
+    const resp = await exchangeRefreshToken(client, cliClient, "lt_refr_old");
+    expect(resp.access_token).toMatch(/^lt_oauth_/);
+    expect(resp.refresh_token).toMatch(/^lt_refr_/);
+  });
+
+  it("detects reuse of a spent token and revokes the whole family", async () => {
+    const revoked: string[] = [];
+    const usedAt = new Date(Date.now() - 60_000).toISOString(); // well outside grace
+    const client = makeClient((table, chain, _terminal) => {
+      // Atomic consume finds nothing (already used).
+      if (table === "oauth_refresh_tokens" && hasOp(chain, "update") && patchOf(chain, "update")?.used_at) {
+        return { data: null, error: null };
+      }
+      // Lookup-by-hash returns the spent token.
+      if (table === "oauth_refresh_tokens" && hasOp(chain, "select") && !hasOp(chain, "update")) {
+        return { data: { ...liveRow, used_at: usedAt, revoked_at: null, successor_pair: null }, error: null };
+      }
+      // Family revocation sweeps.
+      if (hasOp(chain, "update") && patchOf(chain, "update")?.revoked_at) {
+        revoked.push(table);
+        return { data: null, error: null };
+      }
+      return { data: null, error: null };
+    });
+
+    await expect(exchangeRefreshToken(client, cliClient, "lt_refr_spent")).rejects.toMatchObject({
+      code: "invalid_grant",
+    });
+    expect(revoked).toContain("oauth_access_tokens");
+    expect(revoked).toContain("oauth_refresh_tokens");
+  });
+});
+
+describe("authenticateClient", () => {
+  it("rejects an unknown client id", async () => {
+    const client = makeClient(() => ({ data: null, error: null }));
+    await expect(
+      authenticateClient(client, { bodyClientId: "nope", authHeader: null }),
+    ).rejects.toBeInstanceOf(OAuthError);
+  });
+});

--- a/lib/oauth.ts
+++ b/lib/oauth.ts
@@ -1,0 +1,696 @@
+import crypto from "node:crypto";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import {
+  decryptSecret,
+  encryptSecret,
+  generateAuthCode,
+  generateOAuthAccessToken,
+  generateRefreshToken,
+  oauthTokenHint,
+  sha256Hex,
+} from "@/lib/crypto";
+import { resolveRedirectBase } from "@/lib/utils";
+import type { ResourceAudience } from "@/lib/api-auth";
+
+// ==================================================================
+// OAuth 2.1 Authorization Server core.
+//
+// This module is the trusted center of the AS: PKCE verification, exact
+// redirect-URI matching, client authentication, and the atomic state machines
+// for authorization codes and refresh-token rotation. The pure functions here
+// (verifyPkce, redirectUriAllowed, parseScopes, resolveAudience, …) carry the
+// security-critical logic and are unit-tested without a database. The
+// DB-touching functions all run through the service-role client and scope every
+// row by a SERVER-derived user id — never a value from the request body.
+// ==================================================================
+
+// --- config ---------------------------------------------------------
+
+const int = (v: string | undefined, fallback: number): number => {
+  const n = Number(v);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+};
+
+export const ACCESS_TTL_SEC = int(process.env.OAUTH_ACCESS_TTL, 3600); // 1 hour
+export const REFRESH_TTL_SEC = int(process.env.OAUTH_REFRESH_TTL, 30 * 24 * 3600); // 30 days
+export const REFRESH_GRACE_SEC = int(process.env.OAUTH_REFRESH_GRACE, 10); // retry window
+export const CODE_TTL_SEC = 300; // 5 minutes
+export const PENDING_TTL_SEC = 600; // 10 minutes to complete login + consent
+
+// Data-access scopes (what an access token can carry) plus offline_access, the
+// request-time flag that additionally asks for a refresh token.
+export const DATA_SCOPES = [
+  "projects:read",
+  "projects:write",
+  "runs:read",
+  "runs:trigger",
+] as const;
+export const OFFLINE_ACCESS = "offline_access";
+export const KNOWN_SCOPES = [...DATA_SCOPES, OFFLINE_ACCESS] as const;
+
+// Human-readable scope descriptions for the consent screen.
+export const SCOPE_DESCRIPTIONS: Record<string, string> = {
+  "projects:read": "View your organizations and their prompts",
+  "projects:write": "Create organizations and add or edit prompts",
+  "runs:read": "Read your monitoring runs and share-of-voice reports",
+  "runs:trigger": "Start new monitoring runs (spends your provider key)",
+  [OFFLINE_ACCESS]: "Stay connected without you signing in again",
+};
+
+export interface OAuthClient {
+  client_id: string;
+  user_id: string | null;
+  is_first_party: boolean;
+  client_name: string;
+  client_type: "public" | "confidential";
+  client_secret_hash: string | null;
+  token_endpoint_auth_method: "none" | "client_secret_basic";
+  redirect_uris: string[];
+  allowed_scopes: string[];
+  logo_uri: string | null;
+  client_uri: string | null;
+}
+
+/** An OAuth error carrying an RFC 6749 §5.2 error code. Machine endpoints render
+ *  ONLY this code (never a raw message), so nothing internal leaks. */
+export class OAuthError extends Error {
+  constructor(
+    readonly code: string,
+    readonly status: number = 400,
+    readonly description?: string,
+  ) {
+    super(code);
+    this.name = "OAuthError";
+  }
+}
+
+// --- base URL -------------------------------------------------------
+
+export function siteBase(request: Request): string {
+  const origin = (() => {
+    try {
+      return new URL(request.url).origin;
+    } catch {
+      return "";
+    }
+  })();
+  return resolveRedirectBase(process.env.NEXT_PUBLIC_SITE_URL, origin).replace(/\/+$/, "");
+}
+
+// --- scopes ---------------------------------------------------------
+
+/** Split a scope string into a deduped list of recognized scopes. Unknown
+ *  scopes are dropped by the caller's validation, not silently kept. */
+export function parseScopeString(raw: string | null | undefined): string[] {
+  if (!raw) return [];
+  const seen = new Set<string>();
+  for (const s of raw.split(/\s+/)) {
+    const t = s.trim();
+    if (t) seen.add(t);
+  }
+  return [...seen];
+}
+
+export interface ScopeValidation {
+  granted: string[]; // the scopes to actually grant (intersection, order-stable)
+  invalid: string[]; // requested scopes that are unknown or not allowed for this client
+}
+
+/**
+ * Reconcile requested scopes against what exists and what this client may hold.
+ * Deny-by-default: anything unknown or outside the client's allow-list is
+ * reported as invalid and never granted.
+ */
+export function validateScopes(
+  requested: string[],
+  clientAllowed: string[],
+): ScopeValidation {
+  const known = new Set<string>(KNOWN_SCOPES);
+  const allowed = new Set(clientAllowed);
+  const granted: string[] = [];
+  const invalid: string[] = [];
+  for (const s of requested) {
+    if (known.has(s) && allowed.has(s)) granted.push(s);
+    else invalid.push(s);
+  }
+  return { granted, invalid };
+}
+
+/** The data-access subset (drops offline_access, which is not a data permission
+ *  and would violate the access-token scope CHECK if stored). */
+export function dataScopesOf(scopes: string[]): string[] {
+  return scopes.filter((s) => s !== OFFLINE_ACCESS);
+}
+
+// --- audience (RFC 8707 resource indicator) -------------------------
+
+/** Map the `resource` parameter to the surface a token is bound to. Absent =>
+ *  the REST API (the default a CLI wants). An explicit-but-unrecognized resource
+ *  returns null so the caller can reject it rather than guess. */
+export function resolveAudience(
+  resourceParam: string | null | undefined,
+): ResourceAudience | null {
+  if (!resourceParam) return "v1";
+  const v = resourceParam.trim().toLowerCase();
+  if (v === "v1" || v === "mcp") return v;
+  try {
+    const path = new URL(resourceParam).pathname.replace(/\/+$/, "");
+    if (path.endsWith("/api/mcp")) return "mcp";
+    if (path.endsWith("/api/v1")) return "v1";
+  } catch {
+    /* not a URL */
+  }
+  return null;
+}
+
+// --- PKCE (RFC 7636, S256 only) -------------------------------------
+
+/** A code_verifier per RFC 7636: 43–128 chars from the unreserved set. */
+export function validCodeVerifier(v: string | null | undefined): boolean {
+  return typeof v === "string" && /^[A-Za-z0-9\-._~]{43,128}$/.test(v);
+}
+
+/** Constant-time S256 PKCE check: base64url(sha256(verifier)) === challenge. */
+export function verifyPkce(codeVerifier: string, codeChallenge: string): boolean {
+  if (!validCodeVerifier(codeVerifier)) return false;
+  const computed = crypto.createHash("sha256").update(codeVerifier).digest("base64url");
+  const a = Buffer.from(computed);
+  const b = Buffer.from(codeChallenge);
+  return a.length === b.length && crypto.timingSafeEqual(a, b);
+}
+
+// --- redirect URI matching (RFC 8252 for loopback) ------------------
+
+function isLoopbackHost(hostname: string): boolean {
+  const h = hostname.toLowerCase();
+  return h === "127.0.0.1" || h === "::1" || h === "[::1]";
+}
+
+/**
+ * Whether `redirectUri` is permitted for `client`. Two rules:
+ *   - A registered loopback template (http + 127.0.0.1/::1) matches any port on
+ *     the same scheme/host/path — and ONLY loopback, with no embedded userinfo,
+ *     query, or fragment. This is the native-app pattern the CLI uses.
+ *   - Every other registered URI (https confidential/DCR clients) must match
+ *     the full string EXACTLY.
+ * Parsing is via the URL API, never substring checks, so userinfo, subdomain,
+ * and path-traversal evasions all fail.
+ */
+export function redirectUriAllowed(client: OAuthClient, redirectUri: string): boolean {
+  let u: URL;
+  try {
+    u = new URL(redirectUri);
+  } catch {
+    return false;
+  }
+  // Embedded credentials can disguise the true destination host.
+  if (u.username !== "" || u.password !== "") return false;
+
+  for (const registered of client.redirect_uris) {
+    let r: URL;
+    try {
+      r = new URL(registered);
+    } catch {
+      continue;
+    }
+    const registeredIsLoopback = r.protocol === "http:" && isLoopbackHost(r.hostname);
+    if (registeredIsLoopback) {
+      if (
+        u.protocol === "http:" &&
+        isLoopbackHost(u.hostname) &&
+        u.pathname === r.pathname &&
+        u.search === "" &&
+        u.hash === ""
+      ) {
+        return true;
+      }
+    } else if (redirectUri === registered) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// --- client authentication ------------------------------------------
+
+export function parseBasicAuth(
+  header: string | null,
+): { clientId: string; secret: string } | null {
+  if (!header) return null;
+  const m = header.match(/^Basic\s+(.+)$/i);
+  if (!m) return null;
+  let decoded: string;
+  try {
+    decoded = Buffer.from(m[1]!, "base64").toString("utf8");
+  } catch {
+    return null;
+  }
+  const idx = decoded.indexOf(":");
+  if (idx < 0) return null;
+  return {
+    clientId: decodeURIComponent(decoded.slice(0, idx)),
+    secret: decodeURIComponent(decoded.slice(idx + 1)),
+  };
+}
+
+export function verifyClientSecret(client: OAuthClient, presentedSecret: string): boolean {
+  if (!client.client_secret_hash) return false;
+  const a = Buffer.from(sha256Hex(presentedSecret));
+  const b = Buffer.from(client.client_secret_hash);
+  return a.length === b.length && crypto.timingSafeEqual(a, b);
+}
+
+// --- DB helpers -----------------------------------------------------
+
+const CLIENT_COLUMNS =
+  "client_id, user_id, is_first_party, client_name, client_type, client_secret_hash, token_endpoint_auth_method, redirect_uris, allowed_scopes, logo_uri, client_uri";
+
+export async function getClient(
+  supabase: SupabaseClient,
+  clientId: string,
+): Promise<OAuthClient | null> {
+  if (!clientId) return null;
+  const { data } = await supabase
+    .from("oauth_clients")
+    .select(CLIENT_COLUMNS)
+    .eq("client_id", clientId)
+    .maybeSingle();
+  return (data as OAuthClient | null) ?? null;
+}
+
+/** Resolve and authenticate the client at the token endpoint. Confidential
+ *  clients MUST present a valid client_secret_basic; public clients must NOT
+ *  present a secret (they are identified by PKCE + exact redirect match). */
+export async function authenticateClient(
+  supabase: SupabaseClient,
+  opts: { bodyClientId?: string | null; authHeader: string | null },
+): Promise<OAuthClient> {
+  const basic = parseBasicAuth(opts.authHeader);
+  const clientId = basic?.clientId ?? opts.bodyClientId ?? "";
+  const client = await getClient(supabase, clientId);
+  if (!client) throw new OAuthError("invalid_client", 401);
+
+  if (client.token_endpoint_auth_method === "client_secret_basic") {
+    if (!basic || basic.clientId !== client.client_id || !verifyClientSecret(client, basic.secret)) {
+      throw new OAuthError("invalid_client", 401);
+    }
+  } else if (basic && basic.secret) {
+    // A public client that suddenly presents a secret is misconfigured or spoofed.
+    throw new OAuthError("invalid_client", 401);
+  }
+  return client;
+}
+
+// --- pending authorize requests -------------------------------------
+
+export interface PendingRequest {
+  id: string;
+  user_id: string | null;
+  client_id: string;
+  redirect_uri: string;
+  scopes: string[];
+  resource: string;
+  state: string | null;
+  code_challenge: string;
+  consent_nonce: string | null;
+  expires_at: string;
+}
+
+export async function createPendingRequest(
+  supabase: SupabaseClient,
+  data: {
+    userId: string | null;
+    clientId: string;
+    redirectUri: string;
+    scopes: string[];
+    resource: string;
+    state: string | null;
+    codeChallenge: string;
+  },
+): Promise<string> {
+  const expires = new Date(Date.now() + PENDING_TTL_SEC * 1000).toISOString();
+  const { data: row, error } = await supabase
+    .from("oauth_pending_requests")
+    .insert({
+      user_id: data.userId,
+      client_id: data.clientId,
+      redirect_uri: data.redirectUri,
+      scopes: data.scopes,
+      resource: data.resource,
+      state: data.state,
+      code_challenge: data.codeChallenge,
+      expires_at: expires,
+    })
+    .select("id")
+    .single();
+  if (error || !row) throw new OAuthError("server_error", 500);
+  return row.id as string;
+}
+
+export async function getPendingRequest(
+  supabase: SupabaseClient,
+  id: string,
+): Promise<PendingRequest | null> {
+  if (!id) return null;
+  const { data } = await supabase
+    .from("oauth_pending_requests")
+    .select("*")
+    .eq("id", id)
+    .gt("expires_at", new Date().toISOString())
+    .maybeSingle();
+  return (data as PendingRequest | null) ?? null;
+}
+
+/**
+ * Bind a logged-in user to their pending request and set a fresh consent nonce.
+ * Refuses if the request already belongs to a different user. Returns the nonce
+ * the consent form must echo back, or null if the request is gone/mismatched.
+ */
+export async function claimPendingForUser(
+  supabase: SupabaseClient,
+  id: string,
+  userId: string,
+): Promise<{ pending: PendingRequest; nonce: string } | null> {
+  const pending = await getPendingRequest(supabase, id);
+  if (!pending) return null;
+  if (pending.user_id && pending.user_id !== userId) return null;
+
+  const nonce = crypto.randomBytes(24).toString("base64url");
+  const { data, error } = await supabase
+    .from("oauth_pending_requests")
+    .update({ user_id: userId, consent_nonce: nonce })
+    .eq("id", id)
+    .select("*")
+    .maybeSingle();
+  if (error || !data) return null;
+  return { pending: data as PendingRequest, nonce };
+}
+
+/** Atomically single-use-consume a pending request at consent time: it must
+ *  match the id, the current user, and the nonce shown on the page. Returns the
+ *  row (and removes it) or null. */
+export async function consumePendingForConsent(
+  supabase: SupabaseClient,
+  id: string,
+  userId: string,
+  nonce: string,
+): Promise<PendingRequest | null> {
+  if (!id || !nonce) return null;
+  const { data } = await supabase
+    .from("oauth_pending_requests")
+    .delete()
+    .eq("id", id)
+    .eq("user_id", userId)
+    .eq("consent_nonce", nonce)
+    .gt("expires_at", new Date().toISOString())
+    .select("*")
+    .maybeSingle();
+  return (data as PendingRequest | null) ?? null;
+}
+
+// --- authorizations + codes -----------------------------------------
+
+export async function upsertAuthorization(
+  supabase: SupabaseClient,
+  data: { userId: string; clientId: string; resource: string; scopes: string[] },
+): Promise<string> {
+  const { data: row, error } = await supabase
+    .from("oauth_authorizations")
+    .upsert(
+      {
+        user_id: data.userId,
+        client_id: data.clientId,
+        resource: data.resource,
+        scopes: data.scopes,
+        granted_at: new Date().toISOString(),
+        revoked_at: null,
+      },
+      { onConflict: "user_id,client_id,resource" },
+    )
+    .select("id")
+    .single();
+  if (error || !row) throw new OAuthError("server_error", 500);
+  return row.id as string;
+}
+
+/** Mint a single-use authorization code, returning the plaintext (delivered via
+ *  the redirect). Only the hash is stored. */
+export async function issueAuthorizationCode(
+  supabase: SupabaseClient,
+  data: {
+    userId: string;
+    clientId: string;
+    authorizationId: string;
+    codeChallenge: string;
+    redirectUri: string;
+    scopes: string[];
+    resource: string;
+  },
+): Promise<string> {
+  const code = generateAuthCode();
+  const { error } = await supabase.from("oauth_authorization_codes").insert({
+    user_id: data.userId,
+    client_id: data.clientId,
+    authorization_id: data.authorizationId,
+    code_hash: sha256Hex(code),
+    code_challenge: data.codeChallenge,
+    code_challenge_method: "S256",
+    redirect_uri: data.redirectUri,
+    scopes: data.scopes,
+    resource: data.resource,
+    expires_at: new Date(Date.now() + CODE_TTL_SEC * 1000).toISOString(),
+  });
+  if (error) throw new OAuthError("server_error", 500);
+  return code;
+}
+
+// --- token minting + rotation ---------------------------------------
+
+interface MintResult {
+  response: Record<string, unknown>;
+  refreshId: string | null;
+}
+
+async function mintTokenPair(
+  supabase: SupabaseClient,
+  data: {
+    userId: string;
+    clientId: string;
+    authorizationId: string | null;
+    familyId: string;
+    dataScopes: string[];
+    resource: string;
+    withRefresh: boolean;
+  },
+): Promise<MintResult> {
+  const now = Date.now();
+  const accessPlain = generateOAuthAccessToken();
+  const { error: atErr } = await supabase.from("oauth_access_tokens").insert({
+    user_id: data.userId,
+    client_id: data.clientId,
+    authorization_id: data.authorizationId,
+    family_id: data.familyId,
+    token_hash: sha256Hex(accessPlain),
+    token_hint: oauthTokenHint(accessPlain),
+    scopes: data.dataScopes,
+    resource: data.resource,
+    expires_at: new Date(now + ACCESS_TTL_SEC * 1000).toISOString(),
+  });
+  if (atErr) throw new OAuthError("server_error", 500);
+
+  const response: Record<string, unknown> = {
+    access_token: accessPlain,
+    token_type: "Bearer",
+    expires_in: ACCESS_TTL_SEC,
+    scope: data.dataScopes.join(" "),
+  };
+
+  let refreshId: string | null = null;
+  if (data.withRefresh) {
+    const refreshPlain = generateRefreshToken();
+    const { data: rt, error: rtErr } = await supabase
+      .from("oauth_refresh_tokens")
+      .insert({
+        user_id: data.userId,
+        client_id: data.clientId,
+        authorization_id: data.authorizationId,
+        family_id: data.familyId,
+        token_hash: sha256Hex(refreshPlain),
+        scopes: data.dataScopes,
+        resource: data.resource,
+        expires_at: new Date(now + REFRESH_TTL_SEC * 1000).toISOString(),
+      })
+      .select("id")
+      .single();
+    if (rtErr || !rt) throw new OAuthError("server_error", 500);
+    refreshId = rt.id as string;
+    response.refresh_token = refreshPlain;
+  }
+  return { response, refreshId };
+}
+
+/** Revoke an entire token family (all access + refresh tokens sharing the id).
+ *  Used both by explicit revocation and by refresh-reuse detection. */
+export async function revokeFamily(
+  supabase: SupabaseClient,
+  familyId: string,
+  nowIso: string = new Date().toISOString(),
+): Promise<void> {
+  await supabase
+    .from("oauth_access_tokens")
+    .update({ revoked_at: nowIso })
+    .eq("family_id", familyId)
+    .is("revoked_at", null);
+  await supabase
+    .from("oauth_refresh_tokens")
+    .update({ revoked_at: nowIso })
+    .eq("family_id", familyId)
+    .is("revoked_at", null);
+}
+
+/** authorization_code grant. Atomically consumes the code, then verifies client,
+ *  exact redirect_uri, and PKCE before minting tokens. */
+export async function exchangeAuthorizationCode(
+  supabase: SupabaseClient,
+  client: OAuthClient,
+  params: { code?: string | null; redirectUri?: string | null; codeVerifier?: string | null },
+): Promise<Record<string, unknown>> {
+  const { code, redirectUri, codeVerifier } = params;
+  if (!code || !redirectUri) throw new OAuthError("invalid_request", 400);
+  if (!validCodeVerifier(codeVerifier ?? "")) throw new OAuthError("invalid_grant", 400);
+
+  const nowIso = new Date().toISOString();
+  const { data: row } = await supabase
+    .from("oauth_authorization_codes")
+    .update({ used_at: nowIso })
+    .eq("code_hash", sha256Hex(code))
+    .is("used_at", null)
+    .gt("expires_at", nowIso)
+    .select("*")
+    .maybeSingle();
+  if (!row) throw new OAuthError("invalid_grant", 400);
+  if (row.client_id !== client.client_id) throw new OAuthError("invalid_grant", 400);
+  if (row.redirect_uri !== redirectUri) throw new OAuthError("invalid_grant", 400);
+  if (!verifyPkce(codeVerifier!, row.code_challenge)) throw new OAuthError("invalid_grant", 400);
+
+  const scopes = row.scopes as string[];
+  const dataScopes = dataScopesOf(scopes);
+  if (dataScopes.length === 0) throw new OAuthError("invalid_scope", 400);
+
+  const { response } = await mintTokenPair(supabase, {
+    userId: row.user_id,
+    clientId: row.client_id,
+    authorizationId: row.authorization_id,
+    familyId: crypto.randomUUID(),
+    dataScopes,
+    resource: row.resource,
+    withRefresh: scopes.includes(OFFLINE_ACCESS),
+  });
+  return response;
+}
+
+/** refresh_token grant with rotation, reuse detection, and an encrypted
+ *  idempotency window so a network-retried refresh does not self-revoke. */
+export async function exchangeRefreshToken(
+  supabase: SupabaseClient,
+  client: OAuthClient,
+  refreshTokenPlain: string | null | undefined,
+): Promise<Record<string, unknown>> {
+  if (!refreshTokenPlain) throw new OAuthError("invalid_request", 400);
+  const hash = sha256Hex(refreshTokenPlain);
+  const nowIso = new Date().toISOString();
+
+  // Atomic single-use consume of a live token.
+  const { data: consumed } = await supabase
+    .from("oauth_refresh_tokens")
+    .update({ used_at: nowIso })
+    .eq("token_hash", hash)
+    .is("used_at", null)
+    .is("revoked_at", null)
+    .gt("expires_at", nowIso)
+    .select("*")
+    .maybeSingle();
+
+  if (consumed) {
+    if (consumed.client_id !== client.client_id) {
+      await revokeFamily(supabase, consumed.family_id, nowIso);
+      throw new OAuthError("invalid_grant", 400);
+    }
+    const dataScopes = dataScopesOf(consumed.scopes as string[]);
+    const { response } = await mintTokenPair(supabase, {
+      userId: consumed.user_id,
+      clientId: consumed.client_id,
+      authorizationId: consumed.authorization_id,
+      familyId: consumed.family_id,
+      dataScopes,
+      resource: consumed.resource,
+      withRefresh: true,
+    });
+    // Record the successor pair (encrypted) so a retried refresh replays it.
+    let successor: string | null = null;
+    try {
+      successor = encryptSecret(JSON.stringify(response));
+    } catch {
+      successor = null; // encryption unavailable: degrade to no-replay, not a crash
+    }
+    await supabase
+      .from("oauth_refresh_tokens")
+      .update({ successor_pair: successor })
+      .eq("id", consumed.id);
+    return response;
+  }
+
+  // Consume failed. Distinguish reuse (revoke family) from a retriable replay.
+  const { data: existing } = await supabase
+    .from("oauth_refresh_tokens")
+    .select("*")
+    .eq("token_hash", hash)
+    .maybeSingle();
+  if (!existing || existing.revoked_at) throw new OAuthError("invalid_grant", 400);
+
+  if (existing.used_at) {
+    const withinGrace =
+      Date.now() - new Date(existing.used_at).getTime() <= REFRESH_GRACE_SEC * 1000;
+    if (withinGrace && existing.successor_pair) {
+      try {
+        return JSON.parse(decryptSecret(existing.successor_pair as string));
+      } catch {
+        /* fall through to reuse handling */
+      }
+    }
+    // A used refresh token presented outside the grace window is a leak signal.
+    await revokeFamily(supabase, existing.family_id, nowIso);
+    throw new OAuthError("invalid_grant", 400);
+  }
+
+  throw new OAuthError("invalid_grant", 400);
+}
+
+/** RFC 7009 revoke-by-token: possession is the authorization. Revokes the whole
+ *  family so presenting any token in a session kills the session. Always a no-op
+ *  when the token is unknown (the endpoint still returns 200). */
+export async function revokeByToken(
+  supabase: SupabaseClient,
+  tokenPlain: string,
+): Promise<void> {
+  const hash = sha256Hex(tokenPlain);
+  const nowIso = new Date().toISOString();
+
+  const { data: at } = await supabase
+    .from("oauth_access_tokens")
+    .select("family_id")
+    .eq("token_hash", hash)
+    .maybeSingle();
+  if (at?.family_id) {
+    await revokeFamily(supabase, at.family_id, nowIso);
+    return;
+  }
+  const { data: rt } = await supabase
+    .from("oauth_refresh_tokens")
+    .select("family_id")
+    .eq("token_hash", hash)
+    .maybeSingle();
+  if (rt?.family_id) {
+    await revokeFamily(supabase, rt.family_id, nowIso);
+  }
+}

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -3,6 +3,28 @@ import { NextResponse, type NextRequest } from "next/server";
 
 // Refreshes the Supabase auth session on every request and guards /dashboard.
 export async function updateSession(request: NextRequest) {
+  const path = request.nextUrl.pathname;
+
+  // Machine and metadata endpoints must never be touched by session handling:
+  // no cookie refresh (a Set-Cookie on a token response is noise at best), no
+  // redirect (a 302-to-login would break discovery for an MCP client), and no
+  // getUser() network hop. These carry their own credential (a client secret,
+  // PKCE, a device code) or are fully public.
+  //
+  // The INTERACTIVE OAuth endpoints are deliberately NOT listed here —
+  // /api/oauth/authorize, /oauth/consent, and /activate need the Supabase
+  // session to identify the human approving the grant, so they must fall
+  // through to the normal handling below.
+  if (
+    path.startsWith("/.well-known/") ||
+    path === "/api/oauth/token" ||
+    path === "/api/oauth/device" ||
+    path === "/api/oauth/register" ||
+    path === "/api/oauth/revoke"
+  ) {
+    return NextResponse.next({ request });
+  }
+
   let response = NextResponse.next({ request });
 
   const supabase = createServerClient(
@@ -34,8 +56,6 @@ export async function updateSession(request: NextRequest) {
   const {
     data: { user },
   } = await supabase.auth.getUser();
-
-  const path = request.nextUrl.pathname;
 
   // Gate the app behind auth.
   if (!user && path.startsWith("/dashboard")) {

--- a/middleware.ts
+++ b/middleware.ts
@@ -9,6 +9,15 @@ export const config = {
   matcher: [
     // Run on everything except static assets, image files, and the
     // token-authenticated programmatic surface (API keys, not cookies).
+    //
+    // Load-bearing: /api/oauth and /.well-known are deliberately NOT excluded.
+    // The interactive OAuth endpoints (/api/oauth/authorize, /oauth/consent,
+    // /activate) need the Supabase cookie session to identify the approving
+    // user, so they MUST pass through here. updateSession itself early-returns
+    // for the machine OAuth endpoints and metadata (see lib/supabase/
+    // middleware.ts), so those run no session logic. Never add `api/oauth` to
+    // this negative-lookahead: it would strip the session from the consent
+    // screen and make every approval anonymous.
     "/((?!_next/static|_next/image|favicon.ico|api/v1|api/mcp|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
   ],
 };

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,6 +5,22 @@ const nextConfig = {
     // Lint is run separately in CI; don't fail production builds on lint.
     ignoreDuringBuilds: true,
   },
+  // Refuse to be framed anywhere. This matters most for the OAuth consent and
+  // device-activation screens: a click on "Approve" inside an invisible iframe
+  // would otherwise let an attacker's page harvest a grant (clickjacking).
+  // frame-ancestors governs who may embed US; it does not restrict iframes we
+  // embed (e.g. the BYOK explainer video), so nothing else is affected.
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "Content-Security-Policy", value: "frame-ancestors 'none'" },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,9 @@
         "recharts": "^2.12.7",
         "zod": "^3.25.76"
       },
+      "bin": {
+        "lettertrace": "cli/lettertrace.mjs"
+      },
       "devDependencies": {
         "@types/node": "^20.16.11",
         "@types/react": "^18.3.11",

--- a/package.json
+++ b/package.json
@@ -7,13 +7,17 @@
   "engines": {
     "node": ">=20 <23"
   },
+  "bin": {
+    "lettertrace": "cli/lettertrace.mjs"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "cli": "node cli/lettertrace.mjs"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.30.1",

--- a/scripts/oauth-login.mjs
+++ b/scripts/oauth-login.mjs
@@ -1,0 +1,228 @@
+#!/usr/bin/env node
+/**
+ * Reference Lettertrace CLI login — the "homebuilt CLI utility" this OAuth
+ * mechanism exists for. It obtains a scoped, expiring access token via the
+ * OAuth 2.1 Authorization Code + PKCE flow over a loopback redirect (RFC 8252),
+ * with NO api key ever pasted by hand.
+ *
+ *   node scripts/oauth-login.mjs                       # log in (REST API scope)
+ *   node scripts/oauth-login.mjs --resource mcp        # bind the token to MCP
+ *   node scripts/oauth-login.mjs --scope "projects:read runs:read offline_access"
+ *   node scripts/oauth-login.mjs --refresh             # rotate using saved refresh token
+ *
+ * Base URL: --url <origin>, else $LETTERTRACE_URL, else http://localhost:3000.
+ * Tokens are written to ~/.lettertrace/credentials.json (chmod 600).
+ *
+ * Depends only on Node built-ins (Node >= 18 for global fetch).
+ */
+
+import http from "node:http";
+import crypto from "node:crypto";
+import { spawn } from "node:child_process";
+import os from "node:os";
+import fs from "node:fs";
+import path from "node:path";
+
+const CLIENT_ID = "lt_cli";
+
+// --- args -----------------------------------------------------------
+const argv = process.argv.slice(2);
+const flag = (name, fallback) => {
+  const i = argv.indexOf(`--${name}`);
+  return i >= 0 && argv[i + 1] ? argv[i + 1] : fallback;
+};
+const has = (name) => argv.includes(`--${name}`);
+
+const BASE = (flag("url", process.env.LETTERTRACE_URL || "http://localhost:3000")).replace(/\/+$/, "");
+const RESOURCE = flag("resource", "v1"); // "v1" | "mcp"
+const SCOPE = flag("scope", "projects:read projects:write runs:read runs:trigger offline_access");
+
+const CRED_DIR = path.join(os.homedir(), ".lettertrace");
+const CRED_FILE = path.join(CRED_DIR, "credentials.json");
+
+// --- helpers --------------------------------------------------------
+const b64url = (buf) => buf.toString("base64url");
+
+function saveCredentials(tokens) {
+  fs.mkdirSync(CRED_DIR, { recursive: true });
+  const payload = {
+    base: BASE,
+    resource: RESOURCE,
+    obtained_at: new Date().toISOString(),
+    ...tokens,
+  };
+  fs.writeFileSync(CRED_FILE, JSON.stringify(payload, null, 2), { mode: 0o600 });
+  try {
+    fs.chmodSync(CRED_FILE, 0o600);
+  } catch {
+    /* best effort on platforms without POSIX modes */
+  }
+  console.log(`\nSaved credentials to ${CRED_FILE}`);
+}
+
+function loadCredentials() {
+  try {
+    return JSON.parse(fs.readFileSync(CRED_FILE, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function openBrowser(url) {
+  const cmd =
+    process.platform === "darwin" ? "open" : process.platform === "win32" ? "cmd" : "xdg-open";
+  const args = process.platform === "win32" ? ["/c", "start", "", url] : [url];
+  try {
+    const child = spawn(cmd, args, { stdio: "ignore", detached: true });
+    child.on("error", () => {});
+    child.unref();
+  } catch {
+    /* fall back to the printed URL */
+  }
+}
+
+async function tokenRequest(body) {
+  const res = await fetch(`${BASE}/api/oauth/token`, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams(body).toString(),
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    throw new Error(`token endpoint ${res.status}: ${json.error || "unknown_error"}`);
+  }
+  return json;
+}
+
+// --- refresh mode ---------------------------------------------------
+async function refreshFlow() {
+  const creds = loadCredentials();
+  if (!creds?.refresh_token) {
+    console.error("No saved refresh token. Run without --refresh to log in first.");
+    process.exit(1);
+  }
+  console.log("Rotating access token via refresh_token grant…");
+  const tokens = await tokenRequest({
+    grant_type: "refresh_token",
+    refresh_token: creds.refresh_token,
+    client_id: CLIENT_ID,
+  });
+  saveCredentials(tokens);
+  console.log(`New access token (expires in ${tokens.expires_in}s): ${tokens.access_token.slice(0, 18)}…`);
+}
+
+// --- login (authorization_code + PKCE + loopback) -------------------
+async function loginFlow() {
+  // 1. PKCE + CSRF material.
+  const codeVerifier = b64url(crypto.randomBytes(48)); // 64 chars, within 43–128
+  const codeChallenge = b64url(crypto.createHash("sha256").update(codeVerifier).digest());
+  const state = b64url(crypto.randomBytes(16));
+
+  // 2. Loopback listener on an ephemeral port.
+  let redirectUri = "";
+  const code = await new Promise((resolve, reject) => {
+    const server = http.createServer((req, res) => {
+      const url = new URL(req.url, "http://127.0.0.1");
+      if (url.pathname !== "/callback") {
+        res.writeHead(404).end();
+        return;
+      }
+      const params = url.searchParams;
+      const finish = (title, body) => {
+        res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+        res.end(
+          `<!doctype html><meta charset=utf-8><title>${title}</title>` +
+            `<body style="font-family:system-ui;max-width:30rem;margin:5rem auto;text-align:center">` +
+            `<h1>${title}</h1><p>${body}</p></body>`,
+        );
+        server.close();
+      };
+
+      if (params.get("error")) {
+        finish("Authorization failed", `Error: ${params.get("error")}. You can close this tab.`);
+        reject(new Error(`authorize error: ${params.get("error")}`));
+        return;
+      }
+      if (params.get("state") !== state) {
+        finish("Authorization failed", "State mismatch — possible tampering. Close this tab.");
+        reject(new Error("state mismatch"));
+        return;
+      }
+      if (params.get("iss") && params.get("iss").replace(/\/+$/, "") !== BASE) {
+        finish("Authorization failed", "Issuer mismatch. Close this tab.");
+        reject(new Error("issuer mismatch"));
+        return;
+      }
+      finish("You're signed in", "Return to your terminal — you can close this tab.");
+      resolve(params.get("code"));
+    });
+
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address();
+      redirectUri = `http://127.0.0.1:${port}/callback`;
+
+      const authorize = new URL(`${BASE}/api/oauth/authorize`);
+      authorize.searchParams.set("response_type", "code");
+      authorize.searchParams.set("client_id", CLIENT_ID);
+      authorize.searchParams.set("redirect_uri", redirectUri);
+      authorize.searchParams.set("scope", SCOPE);
+      authorize.searchParams.set("state", state);
+      authorize.searchParams.set("code_challenge", codeChallenge);
+      authorize.searchParams.set("code_challenge_method", "S256");
+      authorize.searchParams.set("resource", RESOURCE);
+
+      console.log("\nOpening your browser to approve access…");
+      console.log(`If it doesn't open, visit:\n  ${authorize.toString()}\n`);
+      openBrowser(authorize.toString());
+    });
+
+    // Give up rather than hang forever.
+    setTimeout(() => {
+      server.close();
+      reject(new Error("timed out waiting for authorization (5 min)"));
+    }, 5 * 60 * 1000).unref();
+  });
+
+  // 3. Exchange the code for tokens (PKCE proves this is the same process).
+  console.log("Exchanging authorization code for tokens…");
+  const tokens = await tokenRequest({
+    grant_type: "authorization_code",
+    code,
+    redirect_uri: redirectUri,
+    client_id: CLIENT_ID,
+    code_verifier: codeVerifier,
+  });
+
+  saveCredentials(tokens);
+  console.log(`\nAccess token (expires in ${tokens.expires_in}s, scope "${tokens.scope}"):`);
+  console.log(`  ${tokens.access_token}`);
+  if (tokens.refresh_token) console.log("Refresh token stored for silent re-auth.");
+
+  // 4. Prove it works against the surface it was bound to.
+  if (RESOURCE === "v1") {
+    const res = await fetch(`${BASE}/api/v1/projects`, {
+      headers: { authorization: `Bearer ${tokens.access_token}` },
+    });
+    const body = await res.json().catch(() => ({}));
+    console.log(
+      `\nGET /api/v1/projects -> ${res.status}` +
+        (Array.isArray(body.projects) ? ` (${body.projects.length} organization(s))` : ""),
+    );
+  } else {
+    console.log("\nToken is bound to MCP. Add it to an MCP client with:");
+    console.log(`  claude mcp add --transport http lettertrace ${BASE}/api/mcp/mcp \\`);
+    console.log(`    -H "Authorization: Bearer ${tokens.access_token}"`);
+  }
+}
+
+// --- main -----------------------------------------------------------
+(async () => {
+  try {
+    if (has("refresh")) await refreshFlow();
+    else await loginFlow();
+  } catch (e) {
+    console.error(`\nLogin failed: ${e instanceof Error ? e.message : e}`);
+    process.exit(1);
+  }
+})();

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -470,3 +470,259 @@ drop policy if exists "api_keys_owner" on public.api_keys;
 create policy "api_keys_owner" on public.api_keys
   for all using (user_id = auth.uid())
   with check (user_id = auth.uid());
+
+-- ==================================================================
+-- OAuth 2.1 Authorization Server
+-- Lets a CLI or external system obtain DELEGATED, user-scoped, expiring,
+-- revocable access WITHOUT the user hand-minting a static api_keys row.
+-- Lettertrace is the authorization server; Supabase is the identity provider
+-- (the user approves each grant from a logged-in browser session).
+--
+-- Every secret below is stored ONLY as a sha256 hex digest, exactly like
+-- api_keys.key_hash. Access tokens issued here resolve through the very same
+-- authenticateApiKey() path /api/v1 and /api/mcp already use, so those surfaces
+-- keep working unchanged (see lib/api-auth.ts).
+--
+-- The api_keys table above is deliberately untouched: OAuth tokens live in
+-- their own tables so the two credential classes never share a keyspace and so
+-- revocation here can be soft (revoked_at) rather than a hard row delete.
+-- All statements are idempotent. Safe to re-run.
+-- ==================================================================
+
+-- ---------- oauth_clients -------------------------------------------
+-- A registered client (the CLI, an MCP host, an external server). The
+-- first-party CLI is seeded below with a fixed, secret-less (public) client id;
+-- it authenticates by exact redirect-URI match + PKCE, per the OAuth 2.1
+-- native-app model. Confidential clients additionally hold a client_secret_hash.
+create table if not exists public.oauth_clients (
+  client_id                  text primary key,
+  user_id                    uuid references auth.users (id) on delete cascade,   -- null = first-party / global
+  is_first_party             boolean not null default false,
+  client_name                text not null,
+  client_type                text not null default 'public'
+                               check (client_type in ('public', 'confidential')),
+  client_secret_hash         text,                                                -- null for public clients
+  token_endpoint_auth_method text not null default 'none'
+                               check (token_endpoint_auth_method in ('none', 'client_secret_basic')),
+  redirect_uris              text[] not null,
+  allowed_scopes             text[] not null default '{}',
+  logo_uri                   text,
+  client_uri                 text,
+  created_at                 timestamptz not null default now()
+);
+create index if not exists oauth_clients_user_idx on public.oauth_clients (user_id);
+
+-- Seed the first-party CLI / MCP client. Loopback redirect templates: the host
+-- and path must match exactly; only the port varies at authorize time (RFC
+-- 8252). Safe to re-run.
+insert into public.oauth_clients
+  (client_id, is_first_party, client_name, client_type, token_endpoint_auth_method, redirect_uris, allowed_scopes)
+values
+  ('lt_cli', true, 'Lettertrace CLI & MCP', 'public', 'none',
+   array['http://127.0.0.1/callback', 'http://[::1]/callback'],
+   array['projects:read', 'projects:write', 'runs:read', 'runs:trigger', 'offline_access'])
+on conflict (client_id) do nothing;
+
+-- ---------- oauth_authorizations ------------------------------------
+-- The standing user<->client grant. One row per (user, client, resource); it is
+-- what the "Connected apps" settings screen lists and what a user revokes.
+-- Revoking it cascade-revokes the access/refresh tokens minted under it.
+create table if not exists public.oauth_authorizations (
+  id            uuid primary key default gen_random_uuid(),
+  user_id       uuid not null references auth.users (id) on delete cascade,
+  client_id     text not null references public.oauth_clients (client_id) on delete cascade,
+  scopes        text[] not null,
+  resource      text not null,
+  granted_at    timestamptz not null default now(),
+  last_used_at  timestamptz,
+  revoked_at    timestamptz,
+  unique (user_id, client_id, resource)
+);
+create index if not exists oauth_authorizations_user_idx on public.oauth_authorizations (user_id);
+
+-- ---------- oauth_pending_requests ----------------------------------
+-- A validated /authorize request, persisted server-side so the login bounce and
+-- the consent screen round-trip only an opaque id (?req=<id>) rather than the
+-- full, tamperable authorize query string. user_id is filled in only AFTER the
+-- browser proves its Supabase session; consent_nonce is generated on the consent
+-- page (post-login) for CSRF.
+create table if not exists public.oauth_pending_requests (
+  id             uuid primary key default gen_random_uuid(),
+  user_id        uuid references auth.users (id) on delete cascade,   -- set only after login
+  client_id      text not null references public.oauth_clients (client_id) on delete cascade,
+  redirect_uri   text not null,
+  scopes         text[] not null,
+  resource       text not null,
+  state          text,
+  code_challenge text not null,
+  consent_nonce  text,
+  expires_at     timestamptz not null,
+  created_at     timestamptz not null default now()
+);
+create index if not exists oauth_pending_exp_idx on public.oauth_pending_requests (expires_at);
+
+-- ---------- oauth_authorization_codes -------------------------------
+-- Single-use authorization codes (~5 min). Bound to the client, the exact
+-- redirect_uri, the PKCE challenge, the granted scopes, and the resource
+-- audience; every one of those is re-verified at the token endpoint.
+create table if not exists public.oauth_authorization_codes (
+  id                    uuid primary key default gen_random_uuid(),
+  user_id               uuid not null references auth.users (id) on delete cascade,
+  client_id             text not null references public.oauth_clients (client_id) on delete cascade,
+  authorization_id      uuid references public.oauth_authorizations (id) on delete cascade,
+  code_hash             text not null unique,
+  code_challenge        text not null,
+  code_challenge_method text not null check (code_challenge_method in ('S256')),  -- 'plain' is rejected
+  redirect_uri          text not null,
+  scopes                text[] not null,
+  resource              text not null check (resource in ('v1', 'mcp')),          -- RFC 8707 audience
+  expires_at            timestamptz not null,
+  used_at               timestamptz,
+  created_at            timestamptz not null default now()
+);
+create index if not exists oauth_auth_codes_hash_idx on public.oauth_authorization_codes (code_hash);
+create index if not exists oauth_auth_codes_exp_idx  on public.oauth_authorization_codes (expires_at);
+
+-- ---------- oauth_access_tokens -------------------------------------
+-- The bearer tokens presented to /api/v1 and /api/mcp. Resolved by hash on the
+-- hot path (see authenticateApiKey). expires_at is NOT NULL and scopes may never
+-- be empty or '*' — an OAuth token is never immortal and never implicitly
+-- full-access (that would silently defeat the consent screen).
+create table if not exists public.oauth_access_tokens (
+  id               uuid primary key default gen_random_uuid(),
+  user_id          uuid not null references auth.users (id) on delete cascade,
+  client_id        text not null references public.oauth_clients (client_id) on delete cascade,
+  authorization_id uuid references public.oauth_authorizations (id) on delete cascade,
+  family_id        uuid not null,                                                -- shared with the refresh-token lineage
+  token_hash       text not null unique,
+  token_hint       text not null,
+  scopes           text[] not null
+                     check (array_length(scopes, 1) is not null and not ('*' = any (scopes))),
+  resource         text not null,
+  expires_at       timestamptz not null,
+  revoked_at       timestamptz,
+  last_used_at     timestamptz,
+  issued_at        timestamptz not null default now()
+);
+create index if not exists oauth_at_hash_idx   on public.oauth_access_tokens (token_hash);
+create index if not exists oauth_at_exp_idx    on public.oauth_access_tokens (expires_at);
+create index if not exists oauth_at_auth_idx   on public.oauth_access_tokens (authorization_id);
+create index if not exists oauth_at_family_idx on public.oauth_access_tokens (family_id);
+
+-- ---------- oauth_refresh_tokens ------------------------------------
+-- Long-lived, single-use, ROTATING. Each rotation issues a new access+refresh
+-- pair sharing a family_id; presenting an already-used refresh token trips reuse
+-- detection and the whole family is revoked. successor_pair records the pair a
+-- consumed token minted, so a network-retried refresh within a short grace
+-- window replays the same result instead of self-revoking.
+create table if not exists public.oauth_refresh_tokens (
+  id               uuid primary key default gen_random_uuid(),
+  user_id          uuid not null references auth.users (id) on delete cascade,
+  client_id        text not null references public.oauth_clients (client_id) on delete cascade,
+  authorization_id uuid references public.oauth_authorizations (id) on delete cascade,
+  family_id        uuid not null,
+  token_hash       text not null unique,
+  scopes           text[] not null,
+  resource         text not null,
+  expires_at       timestamptz not null,
+  used_at          timestamptz,
+  rotated_to       uuid,
+  successor_pair   jsonb,
+  revoked_at       timestamptz,
+  issued_at        timestamptz not null default now()
+);
+create index if not exists oauth_rt_hash_idx   on public.oauth_refresh_tokens (token_hash);
+create index if not exists oauth_rt_family_idx on public.oauth_refresh_tokens (family_id);
+
+-- ---------- oauth_device_codes (RFC 8628) ---------------------------
+-- The device-authorization grant for headless CLIs. Both device_code and the
+-- human-typed user_code are stored hashed and looked up by hash; user_id is set
+-- ONLY when a logged-in user approves, and the token endpoint reads the user
+-- from this row alone (never from the polling request).
+create table if not exists public.oauth_device_codes (
+  id                uuid primary key default gen_random_uuid(),
+  client_id         text not null references public.oauth_clients (client_id) on delete cascade,
+  user_id           uuid references auth.users (id) on delete cascade,            -- null until approved
+  authorization_id  uuid references public.oauth_authorizations (id) on delete cascade,
+  device_code_hash  text not null unique,
+  user_code_hash    text not null unique,
+  scopes            text[] not null,
+  resource          text not null,
+  status            text not null default 'pending'
+                      check (status in ('pending', 'approved', 'denied', 'consumed', 'expired')),
+  interval_seconds  int not null default 5,
+  attempts          int not null default 0,
+  poll_count        int not null default 0,
+  last_polled_at    timestamptz,
+  expires_at        timestamptz not null,
+  created_at        timestamptz not null default now()
+);
+create index if not exists oauth_dc_dhash_idx on public.oauth_device_codes (device_code_hash);
+create index if not exists oauth_dc_uhash_idx on public.oauth_device_codes (user_code_hash);
+
+-- ---------- oauth_rate_limits ---------------------------------------
+-- A tiny DB-counter limiter. express-rate-limit is Express-only and unusable in
+-- App Router route handlers, and this deployment has no guaranteed Redis, so
+-- abuse-prone endpoints (register, device, activate, token polling) count
+-- against fixed windows here. See lib/oauth-ratelimit.ts.
+create table if not exists public.oauth_rate_limits (
+  bucket       text primary key,
+  count        int not null default 0,
+  window_start timestamptz not null default now()
+);
+
+-- Atomic fixed-window increment. Resets the window when it has elapsed, then
+-- bumps the counter, and returns the count WITHIN the current window. Runs as a
+-- security-definer so the service-role AS logic can call it; self-contained so a
+-- burst of concurrent calls can't race past the limit.
+create or replace function public.oauth_rate_touch(p_bucket text, p_window_seconds int, p_limit int)
+returns table (allowed boolean, current_count int)
+language plpgsql
+security definer set search_path = public
+as $$
+declare
+  v_count int;
+begin
+  insert into public.oauth_rate_limits (bucket, count, window_start)
+    values (p_bucket, 1, now())
+  on conflict (bucket) do update
+    set count = case
+                  when public.oauth_rate_limits.window_start < now() - make_interval(secs => p_window_seconds)
+                  then 1
+                  else public.oauth_rate_limits.count + 1
+                end,
+        window_start = case
+                  when public.oauth_rate_limits.window_start < now() - make_interval(secs => p_window_seconds)
+                  then now()
+                  else public.oauth_rate_limits.window_start
+                end
+  returning count into v_count;
+  return query select (v_count <= p_limit), v_count;
+end;
+$$;
+
+-- ---------- OAuth RLS -----------------------------------------------
+-- All OAuth tables enable RLS (default-deny). The authorization-server logic
+-- runs with the service-role client, which bypasses RLS, and ALWAYS scopes its
+-- queries by the server-derived user_id. Only the two tables the settings UI
+-- reads through the cookie-bound client get per-user policies.
+alter table public.oauth_clients               enable row level security;
+alter table public.oauth_authorizations        enable row level security;
+alter table public.oauth_pending_requests      enable row level security;
+alter table public.oauth_authorization_codes   enable row level security;
+alter table public.oauth_access_tokens         enable row level security;
+alter table public.oauth_refresh_tokens        enable row level security;
+alter table public.oauth_device_codes          enable row level security;
+alter table public.oauth_rate_limits           enable row level security;
+
+-- A user may SELECT the clients they personally registered (for a future
+-- management view). First-party/global clients (user_id null) are not exposed
+-- to the cookie client; the AS reads them service-role.
+drop policy if exists "oauth_clients_owner" on public.oauth_clients;
+create policy "oauth_clients_owner" on public.oauth_clients
+  for select using (user_id = auth.uid());
+
+-- A user reads and revokes their own standing grants ("Connected apps").
+drop policy if exists "oauth_authorizations_owner" on public.oauth_authorizations;
+create policy "oauth_authorizations_owner" on public.oauth_authorizations
+  for all using (user_id = auth.uid()) with check (user_id = auth.uid());

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -148,6 +148,40 @@ end $$;
 alter table public.profiles
   add column if not exists active_project_id uuid references public.projects (id) on delete set null;
 
+-- Backfill: every auth user MUST have a profile row. Accounts created before the
+-- signup trigger existed (or provisioned out of band) can be missing one, which
+-- silently breaks org switching: setActiveProject updates profiles by id, and
+-- with no row that update matches zero rows (no error), so active_project_id
+-- never changes and the dashboard's org switcher spins forever. Safe to re-run.
+insert into public.profiles (id, email)
+select u.id, u.email
+from auth.users u
+left join public.profiles p on p.id = u.id
+where p.id is null;
+
+-- Point the dashboard at one of the caller's own organizations. SECURITY
+-- DEFINER so it can guarantee a profile row exists (the client-write guard below
+-- forbids client inserts) and self-scoped via auth.uid(), so a caller can only
+-- move their OWN pointer, and only to a project they own. This makes switching
+-- self-healing even if a profile row is somehow still missing. Safe to re-run.
+create or replace function public.set_active_project(p_project_id uuid)
+returns void
+language plpgsql
+security definer set search_path = public
+as $$
+begin
+  insert into public.profiles (id) values (auth.uid())
+    on conflict (id) do nothing;
+  update public.profiles
+    set active_project_id = p_project_id
+    where id = auth.uid()
+      and exists (
+        select 1 from public.projects
+        where id = p_project_id and user_id = auth.uid()
+      );
+end;
+$$;
+
 -- How many times each active prompt is asked per run. Answers vary between
 -- identical calls, so a single ask can't distinguish "not mentioned" from
 -- "mentioned, unlucky this time" — at a true 50% mention rate one ask reads


### PR DESCRIPTION
Makes Lettertrace its own OAuth 2.1 Authorization Server on top of Supabase identity so a CLI or external system gets scoped, expiring, revocable tokens without hand-minting an API key: issued tokens flow through the existing bearer path, and scopes plus resource audience are now enforced on every `/api/v1` route and MCP tool while classic `lt_live_` keys keep full access.

Adds a full command-line client in `cli/` whose only interactive step is the browser sign-in, after which projects/prompts/runs/history run over REST v1 and `mcp tools`/`mcp call` speak the Model Context Protocol to `/api/mcp`, so an agent (e.g. Claude Code) can set up an account non-interactively; a minimal `scripts/oauth-login.mjs` shows just the token exchange.

Also fixes an org-switch bug where accounts missing a `profiles` row silently failed the `active_project_id` write and the switcher spun forever, via a self-healing SECURITY DEFINER RPC, a profile backfill, and a UI safety timeout.

Deploying requires re-running `supabase/schema.sql` (idempotent; adds the OAuth tables and the profile backfill/RPC) with no new required env var; verified with typecheck, 178 unit tests, a production build, and lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)