### PR TITLE
Rename free trial banner copy to complimentary tokens

### DIFF
--- a/components/dashboard/trial-banner.tsx
+++ b/components/dashboard/trial-banner.tsx
@@ -38,7 +38,7 @@ export function TrialBanner({
           </span>
           <div>
             <p className="text-sm font-medium text-ink">
-              {exhausted ? "Your free runs are used up" : "You're on the free trial"}
+              {exhausted ? "Your free runs are used up" : "You're currently on complimentary tokens"}
             </p>
             <p className="mt-0.5 text-xs text-ink-faint">
               {exhausted


### PR DESCRIPTION
Updates the dashboard trial banner heading from "You're on the free trial" to "You're currently on complimentary tokens" so the app-facing copy reflects the new complimentary-tokens language. This is a copy-only change in `components/dashboard/trial-banner.tsx`.