### PR TITLE
Polish landing header and dashboard sidebar

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -4,7 +4,7 @@ import { DashboardNav } from "@/components/dashboard/nav";
 import { OrgSwitcher } from "@/components/dashboard/org-switcher";
 import { SignOutButton } from "@/components/dashboard/signout";
 import { TrialBanner } from "@/components/dashboard/trial-banner";
-import { ThemeSwitch, ThemeToggle } from "@/components/theme";
+import { ThemeToggle } from "@/components/theme";
 import { createClient } from "@/lib/supabase/server";
 import { getProject, getProjects, getConfiguredProviders } from "@/lib/data";
 import { trialEnabled, trialRunLimit, getTrialRunsUsed } from "@/lib/trial";
@@ -47,7 +47,10 @@ export default async function DashboardLayout({
     <div className="min-h-screen bg-paper md:flex">
       <aside className="flex flex-col border-b border-ink/10 bg-paper md:h-screen md:w-[260px] md:shrink-0 md:border-b-0 md:border-r">
         <div className="flex flex-col gap-6 px-5 py-6 md:h-full">
-          <Logo />
+          <div className="flex items-center justify-between gap-2">
+            <Logo />
+            <ThemeToggle className="hidden md:inline-flex" />
+          </div>
 
           {project ? (
             <OrgSwitcher
@@ -68,11 +71,10 @@ export default async function DashboardLayout({
           <DashboardNav />
 
           <div className="mt-auto hidden flex-col gap-3 border-t border-ink/10 pt-4 md:flex">
-            <ThemeSwitch />
             <p className="truncate text-xs text-ink-faint" title={user.email ?? undefined}>
               {user.email}
             </p>
-            <SignOutButton />
+            <SignOutButton className="w-full justify-start" />
           </div>
 
           <div className="flex items-center justify-between gap-2 border-t border-ink/10 pt-4 md:hidden">

--- a/app/dashboard/onboarding.tsx
+++ b/app/dashboard/onboarding.tsx
@@ -223,8 +223,8 @@ export function Onboarding() {
         <div>
           <h1 className="text-3xl font-semibold text-ink">Set up your brand</h1>
           <p className="mt-2 text-ink-soft">
-            Tell us who to watch for. We&apos;ll scan your site and suggest what to monitor. No API
-            key needed, you start on free credits.
+            Let&apos;s start with your brand. We&apos;ll scan your website and predict what AI search
+            queries to look out for.
           </p>
 
           <Card className="mt-6">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,7 +16,7 @@ import { Badge, Button, Card } from "@/components/ui";
 import { Logo } from "@/components/logo";
 import { ThemeToggle } from "@/components/theme";
 
-const GITHUB_URL = "https://github.com";
+const GITHUB_URL = "https://github.com/letterstory/lettertrace";
 
 // ------------------------------------------------------------------
 // Small presentational helpers (local to the landing page)
@@ -148,11 +148,13 @@ const toneBg: Record<string, string> = {
 
 export default function LandingPage() {
   return (
-    <div className="min-h-screen bg-paper text-ink">
+    <div id="top" className="min-h-screen bg-paper text-ink">
       {/* Nav */}
       <header className="sticky top-0 z-40 border-b border-ink/10 bg-paper/80 backdrop-blur">
         <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-5">
-          <Logo />
+          <a href="#top" aria-label="Back to top" className="w-fit">
+            <Logo />
+          </a>
           <nav className="hidden items-center gap-8 text-sm text-ink-soft md:flex">
             <a href="#how" className="transition hover:text-ink">How it works</a>
             <a href="#features" className="transition hover:text-ink">Features</a>

--- a/components/dashboard/signout.tsx
+++ b/components/dashboard/signout.tsx
@@ -5,7 +5,7 @@ import { LogOut } from "lucide-react";
 import { Button } from "@/components/ui";
 import { createClient } from "@/lib/supabase/client";
 
-export function SignOutButton() {
+export function SignOutButton({ className }: { className?: string }) {
   const router = useRouter();
 
   async function handleSignOut() {
@@ -16,7 +16,7 @@ export function SignOutButton() {
   }
 
   return (
-    <Button variant="ghost" size="sm" onClick={handleSignOut}>
+    <Button variant="ghost" size="sm" onClick={handleSignOut} className={className}>
       <LogOut className="h-4 w-4" aria-hidden />
       Sign out
     </Button>


### PR DESCRIPTION
Refines a few landing-page and dashboard details. On the landing page, the header logo now scrolls back to the top and the GitHub link points at the real `letterstory/lettertrace` repo. In the dashboard sidebar, dark mode is now a compact icon toggle beside the logo (replacing the labeled switch) and the sign-out button is left-aligned. The onboarding brand step copy was also updated to explain the website scan more clearly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)