### PR TITLE
Cap all UI corner radii at 4px (2px for fine elements)

### DIFF
--- a/app/dashboard/competitors/competitors-client.tsx
+++ b/app/dashboard/competitors/competitors-client.tsx
@@ -196,7 +196,7 @@ export function CompetitorsClient({ competitors }: { competitors: Competitor[] }
         <CardBody>
           <div className="flex flex-wrap items-center justify-between gap-3">
             <div className="flex items-start gap-3">
-              <span className="mt-0.5 rounded-xl bg-terracotta/10 p-2 text-terracotta">
+              <span className="mt-0.5 rounded bg-terracotta/10 p-2 text-terracotta">
                 <Sparkles className="h-5 w-5" />
               </span>
               <div>
@@ -226,7 +226,7 @@ export function CompetitorsClient({ competitors }: { competitors: Competitor[] }
               {suggestions.map((s) => (
                 <li
                   key={s.name}
-                  className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-ink/10 bg-paper p-4"
+                  className="flex flex-wrap items-center justify-between gap-3 rounded border border-ink/10 bg-paper p-4"
                 >
                   <div className="min-w-0">
                     <div className="flex flex-wrap items-center gap-2">
@@ -261,7 +261,7 @@ export function CompetitorsClient({ competitors }: { competitors: Competitor[] }
                     <button
                       type="button"
                       onClick={() => dismissSuggestion(s.name)}
-                      className="rounded-lg p-2 text-ink-faint transition hover:bg-ink/5 hover:text-terracotta-dark"
+                      className="rounded p-2 text-ink-faint transition hover:bg-ink/5 hover:text-terracotta-dark"
                       aria-label={`Dismiss ${s.name}`}
                     >
                       <X className="h-4 w-4" />

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -63,7 +63,7 @@ export default async function DashboardLayout({
               canAddOrg={canAddOrg}
             />
           ) : (
-            <div className="rounded-2xl border border-ink/10 bg-paper-shade/50 px-4 py-3">
+            <div className="rounded border border-ink/10 bg-paper-shade/50 px-4 py-3">
               <p className="text-sm text-ink-faint">No organization yet</p>
             </div>
           )}

--- a/app/dashboard/logs/logs-explorer.tsx
+++ b/app/dashboard/logs/logs-explorer.tsx
@@ -182,7 +182,7 @@ export function LogsExplorer({
                 setQ("");
                 router.push(pathname);
               }}
-              className="inline-flex items-center gap-1.5 rounded-xl border border-ink/15 px-3 py-2 text-sm text-ink-soft transition hover:bg-ink/[0.03]"
+              className="inline-flex items-center gap-1.5 rounded border border-ink/15 px-3 py-2 text-sm text-ink-soft transition hover:bg-ink/[0.03]"
             >
               <X className="h-3.5 w-3.5" /> Clear
             </button>
@@ -350,7 +350,7 @@ function PageButton({
       type="button"
       disabled={disabled}
       onClick={onClick}
-      className="inline-flex h-9 items-center rounded-lg border border-ink/15 px-3 text-sm text-ink-soft transition hover:bg-ink/[0.03] disabled:opacity-40 disabled:pointer-events-none"
+      className="inline-flex h-9 items-center rounded border border-ink/15 px-3 text-sm text-ink-soft transition hover:bg-ink/[0.03] disabled:opacity-40 disabled:pointer-events-none"
     >
       {children}
     </button>
@@ -381,7 +381,7 @@ function LogRow({
       >
         <span
           className={cn(
-            "mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg",
+            "mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded",
             row.status === "failure" ? "bg-terracotta/10 text-terracotta-dark" : "bg-ink/[0.05] text-ink-soft",
           )}
         >
@@ -462,7 +462,7 @@ function LogRow({
               <p className="mb-1.5 flex items-center gap-1.5 text-xs font-medium text-ink-soft">
                 <Braces className="h-3 w-3" /> Metadata
               </p>
-              <pre className="overflow-x-auto rounded-lg border border-ink/10 bg-surface p-3 text-xs text-ink-soft">
+              <pre className="overflow-x-auto rounded border border-ink/10 bg-surface p-3 text-xs text-ink-soft">
                 {JSON.stringify(row.metadata, null, 2)}
               </pre>
             </div>

--- a/app/dashboard/onboarding.tsx
+++ b/app/dashboard/onboarding.tsx
@@ -194,8 +194,8 @@ export function Onboarding() {
     return (
       <div className="mx-auto flex min-h-[60vh] max-w-lg flex-col items-center justify-center text-center">
         <div className="relative flex h-16 w-16 items-center justify-center">
-          <span className="absolute inset-0 animate-ping rounded-full bg-terracotta/20" />
-          <span className="flex h-16 w-16 items-center justify-center rounded-2xl bg-terracotta/10 text-terracotta">
+          <span className="absolute inset-0 animate-ping rounded bg-terracotta/20" />
+          <span className="flex h-16 w-16 items-center justify-center rounded bg-terracotta/10 text-terracotta">
             <Sparkles className="h-7 w-7" />
           </span>
         </div>
@@ -305,7 +305,7 @@ export function Onboarding() {
                     <button
                       type="button"
                       onClick={() => removeTopic(ti)}
-                      className="shrink-0 rounded-lg p-2 text-ink-faint transition hover:bg-ink/5 hover:text-terracotta-dark"
+                      className="shrink-0 rounded p-2 text-ink-faint transition hover:bg-ink/5 hover:text-terracotta-dark"
                       aria-label="Remove topic"
                     >
                       <X className="h-4 w-4" />
@@ -333,7 +333,7 @@ export function Onboarding() {
                         <button
                           type="button"
                           onClick={() => removePrompt(ti, pi)}
-                          className="shrink-0 rounded-lg p-2 text-ink-faint transition hover:bg-ink/5"
+                          className="shrink-0 rounded p-2 text-ink-faint transition hover:bg-ink/5"
                           aria-label="Remove question"
                         >
                           <X className="h-3.5 w-3.5" />
@@ -364,7 +364,7 @@ export function Onboarding() {
           <button
             type="button"
             onClick={addTopic}
-            className="mt-4 inline-flex items-center gap-1.5 rounded-xl border border-dashed border-ink/20 px-4 py-2.5 text-sm font-medium text-ink-soft transition hover:border-ink/40 hover:bg-ink/[0.02]"
+            className="mt-4 inline-flex items-center gap-1.5 rounded border border-dashed border-ink/20 px-4 py-2.5 text-sm font-medium text-ink-soft transition hover:border-ink/40 hover:bg-ink/[0.02]"
           >
             <Plus className="h-4 w-4" />
             Add topic
@@ -395,7 +395,7 @@ function StepDot({ active, done, label }: { active: boolean; done: boolean; labe
   return (
     <span
       className={
-        "flex h-7 w-7 items-center justify-center rounded-full text-xs font-semibold " +
+        "flex h-7 w-7 items-center justify-center rounded text-xs font-semibold " +
         (done
           ? "bg-terracotta text-paper"
           : active

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -180,7 +180,7 @@ export default async function DashboardPage() {
                   <li key={step.title}>
                     <Link
                       href={step.href}
-                      className="group flex items-start gap-4 rounded-2xl border border-ink/10 bg-paper p-4 transition hover:border-ink/25 hover:shadow-card"
+                      className="group flex items-start gap-4 rounded border border-ink/10 bg-paper p-4 transition hover:border-ink/25 hover:shadow-card"
                     >
                       <span className="mt-0.5 shrink-0">
                         {step.done ? (
@@ -411,7 +411,7 @@ export default async function DashboardPage() {
                 voice yet" gave no hint of that — say which of the two is
                 actually the problem. */}
             {competitors === 0 ? (
-              <div className="mt-4 rounded-2xl border border-dashed border-ink/15 px-5 py-8 text-center">
+              <div className="mt-4 rounded border border-dashed border-ink/15 px-5 py-8 text-center">
                 <p className="text-sm text-ink-soft">
                   No competitors tracked yet, so there is nothing to compare against.
                 </p>
@@ -439,7 +439,7 @@ export default async function DashboardPage() {
                 >
                   <span className="flex items-center gap-2 truncate">
                     <span
-                      className={`h-2.5 w-2.5 shrink-0 rounded-full ${
+                      className={`h-2.5 w-2.5 shrink-0 rounded-sm ${
                         s.type === "brand" ? "bg-terracotta" : "bg-teal"
                       }`}
                     />
@@ -494,9 +494,9 @@ export default async function DashboardPage() {
                           </td>
                           <td className="py-2.5 pl-3">
                             <div className="flex items-center gap-2">
-                              <div className="h-1.5 w-16 overflow-hidden rounded-full bg-ink/[0.08]">
+                              <div className="h-1.5 w-16 overflow-hidden rounded-sm bg-ink/[0.08]">
                                 <div
-                                  className="h-full rounded-full bg-terracotta"
+                                  className="h-full rounded-sm bg-terracotta"
                                   style={{
                                     width: `${Math.round(t.mentionRate * 100)}%`,
                                   }}
@@ -519,7 +519,7 @@ export default async function DashboardPage() {
       </div>
 
       {/* Latest run caption */}
-      <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-ink/10 bg-paper-shade/50 px-5 py-4">
+      <div className="flex flex-wrap items-center justify-between gap-3 rounded border border-ink/10 bg-paper-shade/50 px-5 py-4">
         <p className="text-sm text-ink-faint">
           Latest run:{" "}
           <span className="font-medium text-ink">

--- a/app/dashboard/runs/[id]/page.tsx
+++ b/app/dashboard/runs/[id]/page.tsx
@@ -28,7 +28,7 @@ function SentimentDot({ sentiment }: { sentiment: Sentiment | null }) {
   const color = SENTIMENT_COLORS[sentiment ?? "neutral"];
   return (
     <span
-      className="inline-block h-2 w-2 rounded-full"
+      className="inline-block h-2 w-2 rounded-sm"
       style={{ backgroundColor: color }}
       aria-label={sentiment ?? "neutral"}
     />
@@ -154,7 +154,7 @@ export default async function RunDetailPage({ params }: { params: { id: string }
       </div>
 
       {anySources && (
-        <div className="flex flex-wrap items-center gap-2 rounded-2xl border border-ink/10 bg-paper-shade/50 px-5 py-4 text-sm">
+        <div className="flex flex-wrap items-center gap-2 rounded border border-ink/10 bg-paper-shade/50 px-5 py-4 text-sm">
           <Globe className="h-4 w-4 text-ink-faint" />
           {ownedResponseIds.size > 0 ? (
             <p className="text-ink">
@@ -199,7 +199,7 @@ export default async function RunDetailPage({ params }: { params: { id: string }
                     <p className="mb-1.5 text-xs font-medium uppercase tracking-wide text-ink-faint">
                       Answer
                     </p>
-                    <div className="max-h-72 overflow-y-auto whitespace-pre-wrap rounded-2xl bg-paper-shade p-4 text-sm leading-relaxed text-ink-soft">
+                    <div className="max-h-72 overflow-y-auto whitespace-pre-wrap rounded bg-paper-shade p-4 text-sm leading-relaxed text-ink-soft">
                       {response.response_text}
                     </div>
                   </div>

--- a/app/dashboard/settings/api-keys-manager.tsx
+++ b/app/dashboard/settings/api-keys-manager.tsx
@@ -81,12 +81,12 @@ export default function ApiKeysManager({ keys }: { keys: ApiKeyPublic[] }) {
     <div className="space-y-4">
       {/* One-time reveal of a freshly created key */}
       {freshKey && (
-        <div className="rounded-xl border border-emerald-700/20 bg-mint/30 p-4">
+        <div className="rounded border border-emerald-700/20 bg-mint/30 p-4">
           <p className="text-sm font-medium text-ink">
             Copy your new key now — it won&apos;t be shown again.
           </p>
           <div className="mt-2 flex items-center gap-2">
-            <code className="min-w-0 flex-1 truncate rounded-lg bg-paper px-3 py-2 font-mono text-sm text-ink">
+            <code className="min-w-0 flex-1 truncate rounded bg-paper px-3 py-2 font-mono text-sm text-ink">
               {freshKey}
             </code>
             <Button type="button" size="sm" variant="secondary" onClick={handleCopy}>
@@ -99,7 +99,7 @@ export default function ApiKeysManager({ keys }: { keys: ApiKeyPublic[] }) {
 
       {/* Existing keys */}
       {keys.length > 0 && (
-        <ul className="divide-y divide-ink/10 rounded-xl border border-ink/10 bg-paper">
+        <ul className="divide-y divide-ink/10 rounded border border-ink/10 bg-paper">
           {keys.map((k) => (
             <li key={k.id} className="flex items-center gap-3 px-4 py-3">
               <div className="min-w-0 flex-1">

--- a/app/dashboard/settings/keys-manager.tsx
+++ b/app/dashboard/settings/keys-manager.tsx
@@ -126,13 +126,13 @@ function ProviderCard({
   }
 
   return (
-    <div className="flex flex-col rounded-2xl border border-ink/10 bg-paper p-5">
+    <div className="flex flex-col rounded border border-ink/10 bg-paper p-5">
       {/* Header: identity + status */}
       <div className="flex items-start justify-between gap-3">
         <div className="flex items-center gap-3">
           <span
             className={cn(
-              "grid h-11 w-11 shrink-0 place-items-center rounded-xl font-serif text-lg font-semibold",
+              "grid h-11 w-11 shrink-0 place-items-center rounded font-serif text-lg font-semibold",
               style.markClass,
             )}
             aria-hidden
@@ -162,7 +162,7 @@ function ProviderCard({
       {/* Body */}
       <div className="mt-4 flex-1">
         {existing && !editing && (
-          <div className="flex items-center justify-between gap-3 rounded-xl border border-ink/10 bg-paper-shade/50 px-4 py-3">
+          <div className="flex items-center justify-between gap-3 rounded border border-ink/10 bg-paper-shade/50 px-4 py-3">
             <p className="font-mono text-sm text-ink">{existing.key_hint}</p>
             <p className="shrink-0 text-xs text-ink-faint">
               Added {formatDate(existing.created_at)}
@@ -186,7 +186,7 @@ function ProviderCard({
               <button
                 type="button"
                 onClick={() => setReveal((v) => !v)}
-                className="absolute right-2.5 top-1/2 -translate-y-1/2 rounded-lg p-1 text-ink-faint transition hover:text-ink"
+                className="absolute right-2.5 top-1/2 -translate-y-1/2 rounded p-1 text-ink-faint transition hover:text-ink"
                 aria-label={reveal ? "Hide key" : "Show key"}
                 tabIndex={-1}
               >

--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -38,7 +38,7 @@ export default async function SettingsPage() {
       <Card>
         <CardBody className="space-y-5">
           <div className="flex items-start gap-3">
-            <span className="mt-0.5 rounded-xl bg-mint-tint p-2 text-mint-ink">
+            <span className="mt-0.5 rounded bg-mint-tint p-2 text-mint-ink">
               <KeyRound className="h-5 w-5" />
             </span>
             <div>
@@ -57,7 +57,7 @@ export default async function SettingsPage() {
       <Card>
         <CardBody className="space-y-5">
           <div className="flex items-start gap-3">
-            <span className="mt-0.5 rounded-xl bg-butter-tint p-2 text-butter-ink">
+            <span className="mt-0.5 rounded bg-butter-tint p-2 text-butter-ink">
               <Building2 className="h-5 w-5" />
             </span>
             <div>
@@ -76,7 +76,7 @@ export default async function SettingsPage() {
       <Card>
         <CardBody className="space-y-5">
           <div className="flex items-start gap-3">
-            <span className="mt-0.5 rounded-xl bg-teal/15 p-2 text-teal-dark">
+            <span className="mt-0.5 rounded bg-teal/15 p-2 text-teal-dark">
               <Plug className="h-5 w-5" />
             </span>
             <div>
@@ -97,7 +97,7 @@ export default async function SettingsPage() {
       <Card>
         <CardBody className="space-y-5">
           <div className="flex items-start gap-3">
-            <span className="mt-0.5 rounded-xl bg-sand-tint p-2 text-ink-soft">
+            <span className="mt-0.5 rounded bg-sand-tint p-2 text-ink-soft">
               <Palette className="h-5 w-5" />
             </span>
             <div>

--- a/app/dashboard/settings/project-form.tsx
+++ b/app/dashboard/settings/project-form.tsx
@@ -167,7 +167,7 @@ export default function ProjectForm({ project }: { project: Project | null }) {
 
       <label
         htmlFor="p-websearch"
-        className="flex cursor-pointer items-start justify-between gap-4 rounded-2xl border border-ink/10 bg-paper-shade/40 p-4"
+        className="flex cursor-pointer items-start justify-between gap-4 rounded border border-ink/10 bg-paper-shade/40 p-4"
       >
         <span>
           <span className="text-sm font-medium text-ink">Web search</span>
@@ -186,13 +186,13 @@ export default function ProjectForm({ project }: { project: Project | null }) {
             setSaved(false);
           }}
           className={
-            "relative mt-0.5 inline-flex h-6 w-11 shrink-0 items-center rounded-full transition " +
+            "relative mt-0.5 inline-flex h-6 w-11 shrink-0 items-center rounded transition " +
             (useWebSearch ? "bg-terracotta" : "bg-ink/15")
           }
         >
           <span
             className={
-              "inline-block h-4 w-4 transform rounded-full bg-white transition " +
+              "inline-block h-4 w-4 transform rounded-sm bg-white transition " +
               (useWebSearch ? "translate-x-6" : "translate-x-1")
             }
           />

--- a/app/dashboard/topics/topics-client.tsx
+++ b/app/dashboard/topics/topics-client.tsx
@@ -245,7 +245,7 @@ function TopicCard({
         </div>
 
         {/* Generate + manual controls */}
-        <div className="grid gap-4 rounded-2xl border border-ink/10 bg-paper-shade/40 p-4 md:grid-cols-2">
+        <div className="grid gap-4 rounded border border-ink/10 bg-paper-shade/40 p-4 md:grid-cols-2">
           {/* Generate variations */}
           <div className="space-y-2">
             <Label>Generate variations</Label>
@@ -344,7 +344,7 @@ function PromptRow({ prompt }: { prompt: Prompt }) {
         onChange={toggleActive}
         disabled={busy}
         aria-label={prompt.is_active ? "Deactivate prompt" : "Activate prompt"}
-        className="mt-1 h-4 w-4 shrink-0 cursor-pointer rounded border-ink/30 text-terracotta-dark accent-terracotta focus:ring-terracotta/40"
+        className="mt-1 h-4 w-4 shrink-0 cursor-pointer rounded-sm border-ink/30 text-terracotta-dark accent-terracotta focus:ring-terracotta/40"
       />
       <div className="min-w-0 flex-1">
         <p className={prompt.is_active ? "text-sm text-ink" : "text-sm text-ink-faint line-through"}>

--- a/app/globals.css
+++ b/app/globals.css
@@ -197,7 +197,7 @@
   font-size: 12px;
 }
 .recharts-default-tooltip {
-  border-radius: 12px !important;
+  border-radius: 4px !important;
   border: 1px solid rgb(var(--c-ink) / 0.1) !important;
   box-shadow: 0 8px 24px rgb(0 0 0 / 0.18) !important;
   font-family: var(--font-dm-sans), sans-serif !important;

--- a/app/login/auth-form.tsx
+++ b/app/login/auth-form.tsx
@@ -118,7 +118,7 @@ export function AuthForm({
   if (confirmSent) {
     return (
       <div className="space-y-5 text-center">
-        <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-mint-tint text-mint-ink">
+        <div className="mx-auto flex h-12 w-12 items-center justify-center rounded bg-mint-tint text-mint-ink">
           <CheckCircle2 className="h-6 w-6" aria-hidden />
         </div>
         <div>
@@ -156,7 +156,7 @@ export function AuthForm({
       </div>
 
       {error && (
-        <div className="flex items-start gap-2 rounded-xl border border-terracotta/30 bg-terracotta/10 px-3.5 py-3 text-sm text-terracotta-dark">
+        <div className="flex items-start gap-2 rounded border border-terracotta/30 bg-terracotta/10 px-3.5 py-3 text-sm text-terracotta-dark">
           <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden />
           <span>{error}</span>
         </div>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -38,11 +38,11 @@ export default async function LoginPage({
       {/* Left: branded panel */}
       <aside className="relative hidden w-1/2 flex-col justify-between overflow-hidden bg-paper-shade px-12 py-14 lg:flex">
         <div
-          className="pointer-events-none absolute -right-24 -top-24 h-72 w-72 rounded-full bg-butter/50 blur-3xl"
+          className="pointer-events-none absolute -right-24 -top-24 h-72 w-72 rounded bg-butter/50 blur-3xl"
           aria-hidden
         />
         <div
-          className="pointer-events-none absolute -bottom-24 -left-16 h-80 w-80 rounded-full bg-mint/40 blur-3xl"
+          className="pointer-events-none absolute -bottom-24 -left-16 h-80 w-80 rounded bg-mint/40 blur-3xl"
           aria-hidden
         />
 
@@ -62,7 +62,7 @@ export default async function LoginPage({
           <ul className="mt-10 space-y-5">
             {bullets.map(({ icon: Icon, title, body }) => (
               <li key={title} className="flex gap-3.5">
-                <span className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-terracotta/12 text-terracotta-dark">
+                <span className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded bg-terracotta/12 text-terracotta-dark">
                   <Icon className="h-5 w-5" aria-hidden />
                 </span>
                 <div>

--- a/app/oauth/consent/page.tsx
+++ b/app/oauth/consent/page.tsx
@@ -38,7 +38,7 @@ function ConsentError({ message }: { message: string }) {
   return (
     <ConsentShell>
       <div className="space-y-4 text-center">
-        <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-terracotta/12 text-terracotta-dark">
+        <div className="mx-auto flex h-12 w-12 items-center justify-center rounded bg-terracotta/12 text-terracotta-dark">
           <AlertCircle className="h-6 w-6" aria-hidden />
         </div>
         <h1 className="font-serif text-xl font-semibold text-ink">
@@ -95,15 +95,15 @@ export default async function ConsentPage({
           </p>
         </div>
 
-        <div className="rounded-xl border border-ink/10 bg-surface px-4 py-3.5">
+        <div className="rounded border border-ink/10 bg-surface px-4 py-3.5">
           <div className="flex items-center gap-2">
             <span className="font-medium text-ink">{client.client_name}</span>
             {client.is_first_party ? (
-              <span className="inline-flex items-center gap-1 rounded-full bg-mint-tint px-2 py-0.5 text-xs font-medium text-mint-ink">
+              <span className="inline-flex items-center gap-1 rounded-sm bg-mint-tint px-2 py-0.5 text-xs font-medium text-mint-ink">
                 <ShieldCheck className="h-3 w-3" aria-hidden /> First-party
               </span>
             ) : (
-              <span className="rounded-full bg-butter/50 px-2 py-0.5 text-xs font-medium text-ink-soft">
+              <span className="rounded-sm bg-butter/50 px-2 py-0.5 text-xs font-medium text-ink-soft">
                 Unverified
               </span>
             )}
@@ -127,7 +127,7 @@ export default async function ConsentPage({
           </ul>
         </div>
 
-        <p className="rounded-xl border border-ink/10 bg-paper-shade px-4 py-3 text-xs text-ink-faint">
+        <p className="rounded border border-ink/10 bg-paper-shade px-4 py-3 text-xs text-ink-faint">
           A code will be delivered to{" "}
           <span className="font-medium text-ink-soft">
             {dest.loopback ? "an application on this device" : dest.host}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,16 +25,16 @@ const GITHUB_URL = "https://github.com/letterstory/lettertrace";
 function TerminalDots() {
   return (
     <div className="flex items-center gap-1.5">
-      <span className="h-3 w-3 rounded-full bg-[#FF5F57]" />
-      <span className="h-3 w-3 rounded-full bg-[#FEBC2E]" />
-      <span className="h-3 w-3 rounded-full bg-[#28C840]" />
+      <span className="h-3 w-3 rounded-sm bg-[#FF5F57]" />
+      <span className="h-3 w-3 rounded-sm bg-[#FEBC2E]" />
+      <span className="h-3 w-3 rounded-sm bg-[#28C840]" />
     </div>
   );
 }
 
 function Terminal() {
   return (
-    <div className="overflow-hidden rounded-2xl border border-ink/10 bg-terminal text-terminal-ink shadow-lift">
+    <div className="overflow-hidden rounded border border-ink/10 bg-terminal text-terminal-ink shadow-lift">
       <div className="flex items-center justify-between border-b border-white/10 px-4 py-3">
         <TerminalDots />
         <span className="font-mono text-[11px] text-white/40">lettertrace · monitor</span>
@@ -170,8 +170,8 @@ export default function LandingPage() {
 
       {/* Hero */}
       <section className="relative overflow-hidden bg-grid">
-        <div className="pointer-events-none absolute -left-24 top-10 h-72 w-72 rounded-full bg-terracotta/50 glow-blob" />
-        <div className="pointer-events-none absolute right-0 top-40 h-72 w-72 rounded-full bg-mint glow-blob" />
+        <div className="pointer-events-none absolute -left-24 top-10 h-72 w-72 rounded bg-terracotta/50 glow-blob" />
+        <div className="pointer-events-none absolute right-0 top-40 h-72 w-72 rounded bg-mint glow-blob" />
         <div className="relative mx-auto grid max-w-6xl items-center gap-12 px-5 py-20 lg:grid-cols-2 lg:py-28">
           <div className="animate-fade-up">
             <Badge tone="terracotta">
@@ -220,7 +220,7 @@ export default function LandingPage() {
               <Card key={step.n} className="p-6">
                 <div className="flex items-center justify-between">
                   <span className="font-mono text-sm text-ink-faint">{step.n}</span>
-                  <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-ink/[0.04] text-terracotta-dark">
+                  <span className="flex h-9 w-9 items-center justify-center rounded bg-ink/[0.04] text-terracotta-dark">
                     <Icon className="h-5 w-5" />
                   </span>
                 </div>
@@ -286,7 +286,7 @@ export default function LandingPage() {
             return (
               <Card key={f.title} className="p-6">
                 <span
-                  className={`flex h-10 w-10 items-center justify-center rounded-xl ${toneBg[f.tone]}`}
+                  className={`flex h-10 w-10 items-center justify-center rounded ${toneBg[f.tone]}`}
                 >
                   <Icon className="h-5 w-5" />
                 </span>
@@ -312,7 +312,7 @@ export default function LandingPage() {
               <OSPoint icon={Layers}>Your data lives in your own Supabase, no vendor lock-in.</OSPoint>
             </ul>
           </div>
-          <div className="overflow-hidden rounded-2xl border border-ink/10 bg-terminal text-terminal-ink shadow-lift">
+          <div className="overflow-hidden rounded border border-ink/10 bg-terminal text-terminal-ink shadow-lift">
             <div className="flex items-center gap-2 border-b border-white/10 px-4 py-3">
               <TerminalDots />
               <span className="ml-2 font-mono text-[11px] text-white/40">self-host</span>
@@ -331,7 +331,7 @@ export default function LandingPage() {
 
       {/* Final CTA */}
       <section className="relative overflow-hidden">
-        <div className="pointer-events-none absolute left-1/2 top-0 h-64 w-[36rem] -translate-x-1/2 rounded-full bg-terracotta/50 glow-blob" />
+        <div className="pointer-events-none absolute left-1/2 top-0 h-64 w-[36rem] -translate-x-1/2 rounded bg-terracotta/50 glow-blob" />
         <div className="relative mx-auto max-w-3xl px-5 py-24 text-center">
           <h2 className="text-4xl font-semibold tracking-tight text-ink sm:text-5xl">
             Find out what AI says about you.
@@ -397,14 +397,14 @@ export default function LandingPage() {
 
 function Mark({ children }: { children: React.ReactNode }) {
   // butter is a light amber in both themes, so the highlight text stays dark.
-  return <mark className="rounded bg-butter px-1 text-[#1A1917]">{children}</mark>;
+  return <mark className="rounded-sm bg-butter px-1 text-[#1A1917]">{children}</mark>;
 }
 
 function PreviewStat({ label, value, dot }: { label: string; value: string; dot: string }) {
   return (
-    <div className="rounded-xl border border-ink/10 bg-surface p-4">
+    <div className="rounded border border-ink/10 bg-surface p-4">
       <div className="flex items-center gap-2">
-        <span className={`h-2 w-2 rounded-full ${dot}`} />
+        <span className={`h-2 w-2 rounded-sm ${dot}`} />
         <span className="text-xs font-medium text-ink-faint">{label}</span>
       </div>
       <p className="mt-1.5 font-serif text-2xl font-semibold text-ink">{value}</p>
@@ -416,9 +416,9 @@ function ShareRow({ name, pct, brand = false }: { name: string; pct: number; bra
   return (
     <div className="flex items-center gap-3 text-sm">
       <span className="w-16 shrink-0 truncate text-ink-soft">{name}</span>
-      <div className="h-2 flex-1 overflow-hidden rounded-full bg-ink/[0.06]">
+      <div className="h-2 flex-1 overflow-hidden rounded-sm bg-ink/[0.06]">
         <div
-          className={`h-full rounded-full ${brand ? "bg-terracotta" : "bg-teal"}`}
+          className={`h-full rounded-sm ${brand ? "bg-terracotta" : "bg-teal"}`}
           style={{ width: `${pct}%` }}
         />
       </div>
@@ -430,7 +430,7 @@ function ShareRow({ name, pct, brand = false }: { name: string; pct: number; bra
 function OSPoint({ icon: Icon, children }: { icon: typeof ShieldCheck; children: React.ReactNode }) {
   return (
     <li className="flex items-start gap-3">
-      <span className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-lg bg-mint-tint text-mint-ink">
+      <span className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded bg-mint-tint text-mint-ink">
         <Icon className="h-3.5 w-3.5" />
       </span>
       <span className="text-sm">{children}</span>

--- a/components/dashboard/charts-lazy.tsx
+++ b/components/dashboard/charts-lazy.tsx
@@ -7,7 +7,7 @@ import dynamic from "next/dynamic";
 // dashboard bundle so first paint isn't blocked on chart code.
 
 function ChartSkeleton({ height }: { height: number }) {
-  return <div className="shimmer rounded-2xl" style={{ height }} aria-hidden />;
+  return <div className="shimmer rounded" style={{ height }} aria-hidden />;
 }
 
 export const TrendChart = dynamic(() => import("./charts").then((m) => m.TrendChart), {

--- a/components/dashboard/charts.tsx
+++ b/components/dashboard/charts.tsx
@@ -56,7 +56,7 @@ function useChartTheme() {
     ...p,
     axisTick: { fill: p.faint, fontSize: 12 },
     tooltipStyle: {
-      borderRadius: 12,
+      borderRadius: 4,
       border: `1px solid ${p.grid}`,
       background: p.surface,
       boxShadow: "0 8px 24px rgba(0,0,0,0.18)",
@@ -70,7 +70,7 @@ function useChartTheme() {
 function Placeholder({ label, height }: { label: string; height: number }) {
   return (
     <div
-      className="flex items-center justify-center rounded-2xl border border-dashed border-ink/10 bg-paper-shade/40 text-sm text-ink-faint"
+      className="flex items-center justify-center rounded border border-dashed border-ink/10 bg-paper-shade/40 text-sm text-ink-faint"
       style={{ height }}
     >
       {label}
@@ -175,7 +175,7 @@ export function ShareBars({
           contentStyle={t.tooltipStyle}
           formatter={(value: number) => [`${Math.round(value)}%`, "Share of voice"]}
         />
-        <Bar dataKey="value" radius={[0, 8, 8, 0]}>
+        <Bar dataKey="value" radius={[0, 4, 4, 0]}>
           {data.map((entry, i) => (
             <Cell key={i} fill={entry.isBrand ? BRAND : TEAL} />
           ))}

--- a/components/dashboard/nav.tsx
+++ b/components/dashboard/nav.tsx
@@ -35,7 +35,7 @@ export function DashboardNav() {
             key={href}
             href={href}
             className={cn(
-              "group flex items-center gap-3 rounded-xl px-3 py-2 text-sm font-medium transition-colors",
+              "group flex items-center gap-3 rounded px-3 py-2 text-sm font-medium transition-colors",
               active
                 ? "bg-terracotta/10 text-terracotta-dark"
                 : "text-ink-soft hover:bg-ink/5",

--- a/components/dashboard/org-switcher.tsx
+++ b/components/dashboard/org-switcher.tsx
@@ -91,7 +91,7 @@ export function OrgSwitcher({
         onClick={() => setOpen((v) => !v)}
         aria-haspopup="listbox"
         aria-expanded={open}
-        className="flex w-full items-center justify-between gap-2 rounded-2xl border border-ink/10 bg-paper-shade/50 px-4 py-3 text-left transition hover:border-ink/25"
+        className="flex w-full items-center justify-between gap-2 rounded border border-ink/10 bg-paper-shade/50 px-4 py-3 text-left transition hover:border-ink/25"
       >
         <span className="min-w-0">
           <span className="block truncate font-serif text-sm font-semibold text-ink">
@@ -116,7 +116,7 @@ export function OrgSwitcher({
           />
           <div
             role="listbox"
-            className="absolute left-0 right-0 z-20 mt-2 overflow-hidden rounded-2xl border border-ink/10 bg-paper shadow-card"
+            className="absolute left-0 right-0 z-20 mt-2 overflow-hidden rounded border border-ink/10 bg-paper shadow-card"
           >
             <p className="px-4 pb-1 pt-3 text-[11px] font-medium uppercase tracking-wide text-ink-faint">
               Organizations
@@ -187,8 +187,8 @@ export function OrgSwitcher({
           aria-live="polite"
         >
           <div className="relative flex h-16 w-16 items-center justify-center">
-            <span className="absolute inset-0 animate-ping rounded-full bg-terracotta/20" />
-            <span className="flex h-16 w-16 items-center justify-center rounded-2xl bg-terracotta/10 text-terracotta">
+            <span className="absolute inset-0 animate-ping rounded bg-terracotta/20" />
+            <span className="flex h-16 w-16 items-center justify-center rounded bg-terracotta/10 text-terracotta">
               <ArrowLeftRight className="h-7 w-7" aria-hidden />
             </span>
           </div>

--- a/components/dashboard/page-skeleton.tsx
+++ b/components/dashboard/page-skeleton.tsx
@@ -5,21 +5,21 @@ export function PageSkeleton() {
   return (
     <div className="space-y-8" aria-hidden>
       <div className="space-y-2.5">
-        <div className="shimmer h-8 w-52 rounded-xl" />
-        <div className="shimmer h-4 w-80 max-w-full rounded-lg" />
+        <div className="shimmer h-8 w-52 rounded" />
+        <div className="shimmer h-4 w-80 max-w-full rounded" />
       </div>
       <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
         {[0, 1, 2, 3].map((i) => (
-          <div key={i} className="shimmer h-28 rounded-2xl" />
+          <div key={i} className="shimmer h-28 rounded" />
         ))}
       </div>
       <div className="grid gap-6 lg:grid-cols-3">
-        <div className="shimmer h-80 rounded-2xl lg:col-span-2" />
-        <div className="shimmer h-80 rounded-2xl" />
+        <div className="shimmer h-80 rounded lg:col-span-2" />
+        <div className="shimmer h-80 rounded" />
       </div>
       <div className="grid gap-6 lg:grid-cols-2">
-        <div className="shimmer h-64 rounded-2xl" />
-        <div className="shimmer h-64 rounded-2xl" />
+        <div className="shimmer h-64 rounded" />
+        <div className="shimmer h-64 rounded" />
       </div>
     </div>
   );

--- a/components/dashboard/trial-banner.tsx
+++ b/components/dashboard/trial-banner.tsx
@@ -22,7 +22,7 @@ export function TrialBanner({
   return (
     <div
       className={cn(
-        "mb-6 rounded-2xl border px-5 py-4",
+        "mb-6 rounded border px-5 py-4",
         exhausted ? "border-terracotta/30 bg-terracotta/[0.07]" : "border-teal/25 bg-teal/[0.06]",
       )}
     >
@@ -30,7 +30,7 @@ export function TrialBanner({
         <div className="flex items-start gap-3">
           <span
             className={cn(
-              "mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg",
+              "mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded",
               exhausted ? "bg-terracotta/15 text-terracotta-dark" : "bg-teal/15 text-teal-dark",
             )}
           >
@@ -53,7 +53,7 @@ export function TrialBanner({
                   <span
                     key={i}
                     className={cn(
-                      "h-1.5 w-6 rounded-full",
+                      "h-1.5 w-6 rounded-sm",
                       i < used ? "bg-teal" : "bg-ink/[0.08]",
                     )}
                   />
@@ -73,7 +73,7 @@ export function TrialBanner({
       </div>
 
       {exhausted && videoUrl && (
-        <div className="mt-4 overflow-hidden rounded-xl border border-ink/10">
+        <div className="mt-4 overflow-hidden rounded border border-ink/10">
           <iframe
             src={videoUrl}
             title="Why you bring your own key"

--- a/components/legal.tsx
+++ b/components/legal.tsx
@@ -76,7 +76,7 @@ export function Section({
         <span className="mr-2 text-ink-faint/70">{n}.</span>
         {title}
       </h2>
-      <div className="mt-4 space-y-4 text-base leading-relaxed text-ink-soft [&_a]:text-terracotta-dark [&_a:hover]:text-terracotta [&_code]:rounded [&_code]:bg-ink/5 [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-sm [&_li]:leading-relaxed [&_strong]:font-semibold [&_strong]:text-ink [&_ul]:list-disc [&_ul]:space-y-2 [&_ul]:pl-6">
+      <div className="mt-4 space-y-4 text-base leading-relaxed text-ink-soft [&_a]:text-terracotta-dark [&_a:hover]:text-terracotta [&_code]:rounded-sm [&_code]:bg-ink/5 [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-sm [&_li]:leading-relaxed [&_strong]:font-semibold [&_strong]:text-ink [&_ul]:list-disc [&_ul]:space-y-2 [&_ul]:pl-6">
         {children}
       </div>
     </section>

--- a/components/theme.tsx
+++ b/components/theme.tsx
@@ -110,7 +110,7 @@ export function ThemeToggle({ className }: { className?: string }) {
       aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
       title={isDark ? "Switch to light mode" : "Switch to dark mode"}
       className={cn(
-        "inline-flex h-9 w-9 items-center justify-center rounded-xl border border-ink/15 text-ink-soft transition hover:border-ink/35 hover:text-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-terracotta/40",
+        "inline-flex h-9 w-9 items-center justify-center rounded border border-ink/15 text-ink-soft transition hover:border-ink/35 hover:text-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-terracotta/40",
         className,
       )}
     >
@@ -149,13 +149,13 @@ export function ThemeSwitch({
         aria-label="Toggle light mode"
         onClick={toggle}
         className={cn(
-          "relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition focus:outline-none focus-visible:ring-2 focus-visible:ring-terracotta/40",
+          "relative inline-flex h-6 w-11 shrink-0 items-center rounded transition focus:outline-none focus-visible:ring-2 focus-visible:ring-terracotta/40",
           isDark ? "bg-ink/15" : "bg-terracotta",
         )}
       >
         <span
           className={cn(
-            "inline-block h-4 w-4 transform rounded-full bg-white shadow-sm transition",
+            "inline-block h-4 w-4 transform rounded-sm bg-white shadow-sm transition",
             isDark ? "translate-x-1" : "translate-x-6",
           )}
         />

--- a/components/ui.tsx
+++ b/components/ui.tsx
@@ -12,7 +12,7 @@ type ButtonVariant = "primary" | "secondary" | "ghost" | "danger";
 type ButtonSize = "sm" | "md" | "lg";
 
 const buttonBase =
-  "inline-flex items-center justify-center gap-2 rounded-xl font-medium tracking-tight transition-all disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus-visible:ring-2 focus-visible:ring-terracotta/40 focus-visible:ring-offset-2 focus-visible:ring-offset-paper";
+  "inline-flex items-center justify-center gap-2 rounded font-medium tracking-tight transition-all disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus-visible:ring-2 focus-visible:ring-terracotta/40 focus-visible:ring-offset-2 focus-visible:ring-offset-paper";
 
 const buttonVariants: Record<ButtonVariant, string> = {
   primary: "bg-ink text-paper hover:bg-ink/90 shadow-sm",
@@ -64,7 +64,7 @@ export function Card({
   children: ReactNode;
 }) {
   return (
-    <div className={cn("rounded-2xl border border-ink/10 bg-surface shadow-card", className)}>
+    <div className={cn("rounded border border-ink/10 bg-surface shadow-card", className)}>
       {children}
     </div>
   );
@@ -123,7 +123,7 @@ export function Badge({
   return (
     <span
       className={cn(
-        "inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium",
+        "inline-flex items-center gap-1 rounded-sm px-2.5 py-0.5 text-xs font-medium",
         badgeTones[tone],
         className,
       )}
@@ -150,7 +150,7 @@ export function Label({
 }
 
 const fieldBase =
-  "w-full rounded-xl border border-ink/15 bg-surface px-3.5 py-2.5 text-sm text-ink placeholder:text-ink-faint/70 transition focus:border-terracotta focus:outline-none focus:ring-2 focus:ring-terracotta/20";
+  "w-full rounded border border-ink/15 bg-surface px-3.5 py-2.5 text-sm text-ink placeholder:text-ink-faint/70 transition focus:border-terracotta focus:outline-none focus:ring-2 focus:ring-terracotta/20";
 
 export function Input({ className, ...props }: InputHTMLAttributes<HTMLInputElement>) {
   return <input className={cn(fieldBase, className)} {...props} />;
@@ -192,7 +192,7 @@ export function StatCard({
     <Card>
       <CardBody className="p-5">
         <div className="flex items-center gap-2">
-          <span className={cn("h-2 w-2 rounded-full", accentDot[accent])} />
+          <span className={cn("h-2 w-2 rounded-sm", accentDot[accent])} />
           <p className="text-sm font-medium text-ink-faint">{label}</p>
         </div>
         <p className="mt-2 font-serif text-3xl font-semibold text-ink">{value}</p>
@@ -214,7 +214,7 @@ export function EmptyState({
   icon?: ReactNode;
 }) {
   return (
-    <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-ink/15 bg-paper-shade/40 px-6 py-14 text-center">
+    <div className="flex flex-col items-center justify-center rounded border border-dashed border-ink/15 bg-paper-shade/40 px-6 py-14 text-center">
       {icon && <div className="mb-3 text-terracotta">{icon}</div>}
       <h3 className="text-lg font-semibold text-ink">{title}</h3>
       {description && <p className="mt-1 max-w-md text-sm text-ink-faint">{description}</p>}
@@ -227,7 +227,7 @@ export function Spinner({ className }: { className?: string }) {
   return (
     <span
       className={cn(
-        "inline-block h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent",
+        "inline-block h-4 w-4 animate-spin rounded-sm border-2 border-current border-t-transparent",
         className,
       )}
       aria-hidden

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -70,9 +70,6 @@ const config: Config = {
         serif: ["var(--font-serif)", "ui-serif", "Georgia", "serif"],
         mono: ["var(--font-dm-mono)", "ui-monospace", "SFMono-Regular", "Menlo", "monospace"],
       },
-      borderRadius: {
-        "4xl": "2rem",
-      },
       boxShadow: {
         card: "0 1px 2px rgba(26,25,23,0.04), 0 6px 20px rgba(26,25,23,0.05)",
         lift: "0 2px 4px rgba(26,25,23,0.05), 0 16px 40px rgba(26,25,23,0.09)",


### PR DESCRIPTION
Sweeps the entire app so no corner radius exceeds 4px: `rounded-2xl/xl/lg/md` become `rounded` (4px), while dots, progress bars, pills/badges, toggle knobs, spinners, checkboxes and inline code drop to `rounded-sm` (2px). Icon housings (the colored square behind an icon) now obey the rule, but SVG glyph interiors and Recharts donut geometry keep their curves. Also removes the unused `4xl` radius token from the Tailwind config and caps the Recharts tooltip and bar-corner radii at 4px. Verified with a full grep (no remaining large-radius classes), a clean typecheck, and screenshots of the public pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)