### PR TITLE
Set BYOK provider keys from the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Open [http://localhost:3000](http://localhost:3000), create an account, and you'
 
 ### 5. First monitor
 
-1. **Settings** → add your Anthropic and/or OpenAI API key (verified on save, encrypted at rest), then fill in your **brand & project** (name, aliases, default model).
+1. **Settings** → add your Anthropic and/or OpenAI API key (verified on save, encrypted at rest), then fill in your **brand & project** (name, aliases, default model). Prefer a terminal? [`lettertrace keys set anthropic`](#setting-your-provider-key-from-the-cli-keys) does the same thing.
 2. **Competitors** → add the brands you want to benchmark against.
 3. **Topics** → add a topic and click **Generate variations** to auto-create prompts (or add your own).
 4. **Runs** → **Run monitor now**. When it finishes, the **Overview** fills in with visibility, share of voice, sentiment, and per-topic breakdowns.
@@ -178,6 +178,19 @@ curl https://your-app.com/api/v1/projects/<project-id>/prompts \
 curl -X POST https://your-app.com/api/v1/projects/<project-id>/prompts \
   -H "Authorization: Bearer lt_live_..." -H "Content-Type: application/json" \
   -d '{"prompts": [{"text": "best crm for startups", "topic": "CRM"}]}'
+
+# BYOK provider keys: list (masked hints + the supported-provider catalog),
+# set/rotate, remove. Verified against the provider and encrypted before storage.
+# Read the key from a file rather than inlining it — a key typed into a shell
+# command is in your history and in `ps` forever after.
+curl https://your-app.com/api/v1/keys \
+  -H "Authorization: Bearer lt_live_..."
+jq -n --arg k "$(cat ./anthropic.key)" '{api_key: $k}' | \
+  curl -X PUT https://your-app.com/api/v1/keys/anthropic \
+    -H "Authorization: Bearer lt_live_..." -H "Content-Type: application/json" \
+    --data-binary @-
+curl -X DELETE https://your-app.com/api/v1/keys/openai \
+  -H "Authorization: Bearer lt_live_..."
 
 # Toggle a prompt on or off
 curl -X PATCH https://your-app.com/api/v1/prompts/<prompt-id> \
@@ -246,6 +259,10 @@ npm run cli -- help                 # or: node cli/lettertrace.mjs help
 npm run cli -- login --url https://your-app.com   # browser sign-in / create account
 npm run cli -- whoami --json        # machine-readable auth status (no browser)
 
+# Bring your own key without opening the dashboard (see below):
+npm run cli -- keys                                  # what's stored, masked
+npm run cli -- keys set anthropic                    # hidden prompt, key verified on save
+
 # Set up an account over the API — the agent-drivable part:
 npm run cli -- projects create --name "Acme" --brand "Acme" --domains acme.io
 npm run cli -- prompts add <projectId> --text "best crm for startups" --topic CRM
@@ -262,6 +279,62 @@ resolves the deployment from `--url`, then `$LETTERTRACE_URL`, then the URL save
 at login. Tokens live in `~/.lettertrace/config.json` (one per audience). The
 data commands use REST v1; the `mcp` commands speak the Model Context Protocol
 directly. The mechanism underneath is:
+
+#### Setting your provider key from the CLI (`keys`)
+
+Adding a BYOK key no longer requires the dashboard. `keys set` verifies the key
+against the provider, encrypts it with AES-256-GCM, and stores it exactly as
+Settings does — the same code path, so nothing about the stored key differs by
+where you added it. Only the masked hint (`sk-ant-…4a9c`) ever comes back.
+
+```bash
+npm run cli -- keys                        # every supported provider, and which have a key
+npm run cli -- keys set anthropic          # prompts, input hidden and not echoed
+npm run cli -- keys set anthropic --label "team account"
+npm run cli -- keys remove openai          # forget the stored key
+```
+
+**The key is never a command-line argument.** Anything in `argv` lands in your
+shell history and is readable by every process on the machine, and there's no
+taking that back — so `--key` is rejected outright rather than quietly accepted.
+The key is read from the first of these that's available:
+
+| Source | Use it for |
+|---|---|
+| `--key-file <path>` (`-` = stdin) | a secret manager writing to a file or a pipe |
+| `$LETTERTRACE_PROVIDER_KEY` | CI, where a pipe is awkward |
+| piped stdin (`… \| lettertrace keys set anthropic`) | scripts |
+| hidden interactive prompt | a human at a terminal |
+
+```bash
+# CI
+LETTERTRACE_PROVIDER_KEY="$ANTHROPIC_KEY" npm run cli -- keys set anthropic --json
+
+# From a secret manager, without ever touching disk
+op read "op://vault/anthropic/key" | npm run cli -- keys set anthropic --key-file -
+```
+
+The provider list comes from the **server**, not the CLI, so a provider added to
+`lib/models.ts` shows up in `lettertrace keys` with no CLI change. Under the hood
+these commands call `GET /api/v1/keys`, `PUT /api/v1/keys/<provider>`
+(body `{"api_key": "…", "label": "…"}`), and `DELETE /api/v1/keys/<provider>`,
+which carry the `keys:read` / `keys:write` scopes below. Saving shows up in the
+activity feed as `provider_key.saved` on the **`cli`** channel, so a key added by
+an agent is distinguishable from one you added in the browser.
+
+Two failures are deliberately kept apart, because the fix is different:
+
+- **400** — the provider rejected the key. Yours to fix; get a new one.
+- **503** — the key is valid, but the deployment's `ENCRYPTION_KEY` is missing or
+  malformed, so nothing was stored. The operator's to fix (see
+  `openssl rand -base64 32` in [Configure environment](#3-configure-environment)).
+  You are never told to rotate a key that was fine.
+
+> Upgrading a CLI you'd already logged into? `keys:read`/`keys:write` are new
+> scopes, and a token minted before they existed can't hold them. The CLI detects
+> the resulting `insufficient_scope` challenge, discards the stale token, and
+> relaunches the browser consent by itself — you just approve once more. Re-run
+> `supabase/schema.sql` first so the `lt_cli` client is allowed to request them.
 
 ### OAuth: delegated access for CLIs and external systems
 
@@ -288,9 +361,12 @@ delivered), and the CLI exchanges the code at `/api/oauth/token` for an access
 token (+ a refresh token when `offline_access` is requested).
 
 - **Scopes** — `projects:read`, `projects:write`, `runs:read`, `runs:trigger`,
-  and `offline_access` (asks for a refresh token). Enforced on **every** REST
-  route and MCP tool, reads included; a classic `lt_live_` key implicitly holds
-  all of them, so nothing about existing keys changes.
+  `keys:read`, `keys:write`, and `offline_access` (asks for a refresh token).
+  Enforced on **every** REST route and MCP tool, reads included; a classic
+  `lt_live_` key implicitly holds all of them, so nothing about existing keys
+  changes. The `keys:*` pair is deliberately separate from `projects:write`:
+  swapping the provider key every run is billed to is a different decision from
+  adding a prompt, and the consent screen is where a user gets to make it.
 - **Audience** — pass `resource=v1` (default) or `resource=mcp`. A token is
   bound to one surface: an MCP token can't call the REST API, and vice versa.
 - **Discovery** — MCP/OAuth clients can auto-configure from
@@ -315,12 +391,12 @@ values
 
 Notes:
 
-- API-triggered runs are **BYOK-only** — the account must have its own provider key; free-trial runs stay dashboard-only.
+- API-triggered runs are **BYOK-only** — the account must have its own provider key; free-trial runs stay dashboard-only. That key can be set over the API too (`PUT /api/v1/keys/<provider>`, or `lettertrace keys set`), so an agent never has to hand the user back to the browser mid-setup.
 - Projects created via the API start with `schedule: "off"` — trigger runs explicitly (or flip the schedule in the dashboard).
 - API keys grant access to all of the account's organizations. Revoke them anytime from Settings.
 - Requires `SUPABASE_SERVICE_ROLE_KEY` (the same variable scheduled runs use), since API-key requests carry no browser session.
 - OAuth tokens are scoped and audience-bound; a classic `lt_live_` API key stays full-access across all of the account's organizations. Revoke either anytime (API keys from Settings; OAuth grants via `/api/oauth/revoke`).
-- Upgrading an existing deployment? Re-run `supabase/schema.sql` — it adds the `api_keys` table and the OAuth tables (`oauth_clients`, `oauth_access_tokens`, …) plus the seeded `lt_cli` client (all safe to re-run).
+- Upgrading an existing deployment? Re-run `supabase/schema.sql` — it adds the `api_keys` table and the OAuth tables (`oauth_clients`, `oauth_access_tokens`, …) plus the seeded `lt_cli` client, and widens that client's `allowed_scopes` to include `keys:read` / `keys:write` (all safe to re-run). Without the re-run, `lettertrace keys` fails at consent with `invalid_scope`.
 
 ## Deployment
 
@@ -328,7 +404,7 @@ Deploy anywhere that runs Next.js. On **Vercel**: import the repo, set the env v
 
 ## Security notes
 
-- Provider API keys are **encrypted with AES-256-GCM** using `ENCRYPTION_KEY` and are never returned to the browser (only a masked hint like `sk-ant-…4a9c`).
+- Provider API keys are **encrypted with AES-256-GCM** using `ENCRYPTION_KEY` and are never returned to any client — browser, REST, or CLI (only a masked hint like `sk-ant-…4a9c`). Whichever surface stores one, it goes through the same verify → encrypt → store path in `lib/provider-keys.ts`, and the CLI refuses to take a key as a command-line argument so it can't leak through shell history or `ps`.
 - All data is isolated per user by **Postgres Row Level Security**. The service-role key is used only by the cron endpoint and the API-key-authenticated surface (`/api/v1`, `/api/mcp`), where every query is scoped to the key's owner.
 - Lettertrace API keys are stored as **SHA-256 hashes** (never recoverable); the plaintext is shown once at creation.
 - Nothing is sent to any third party except the AI providers **you** configure, using **your** keys.
@@ -354,6 +430,7 @@ lib/
   mentions.ts            Deterministic mention detection
   metrics.ts             Visibility / share-of-voice / sentiment aggregation
   crypto.ts              AES-256-GCM for BYOK keys
+  provider-keys.ts       Verify → encrypt → store, shared by the dashboard + CLI
   data.ts, types.ts, models.ts, utils.ts
 supabase/schema.sql      Postgres schema + RLS
 ```

--- a/README.md
+++ b/README.md
@@ -398,6 +398,35 @@ Notes:
 - OAuth tokens are scoped and audience-bound; a classic `lt_live_` API key stays full-access across all of the account's organizations. Revoke either anytime (API keys from Settings; OAuth grants via `/api/oauth/revoke`).
 - Upgrading an existing deployment? Re-run `supabase/schema.sql` — it adds the `api_keys` table and the OAuth tables (`oauth_clients`, `oauth_access_tokens`, …) plus the seeded `lt_cli` client, and widens that client's `allowed_scopes` to include `keys:read` / `keys:write` (all safe to re-run). Without the re-run, `lettertrace keys` fails at consent with `invalid_scope`.
 
+## Tests
+
+```bash
+npm test          # unit + route tests, all mocked, no network, no keys spent
+npm run typecheck
+```
+
+Two harnesses go further than `npm test` and are deliberately excluded from it,
+because they need a live server and spend real provider tokens:
+
+```bash
+# End-to-end BYOK key management: drives the real cli/lettertrace.mjs binary
+# against a running deployment and asserts on what lands in Postgres.
+npx next dev -p 3200 &
+npx tsx scripts/harness-provider-keys.ts --url http://localhost:3200
+
+# Measurement pilot: runs a real brand through scrape → topics → prompts →
+# query → mention detection, without writing to the database.
+npx tsx scripts/pilot-client.ts cloudflare --providers google,anthropic
+```
+
+The key harness needs `SUPABASE_SERVICE_ROLE_KEY`, `ENCRYPTION_KEY`, and
+`TRIAL_ANTHROPIC_API_KEY` in `.env.local`. It creates one throwaway user and
+deletes it in a `finally`, so a failed assertion still cleans up. What it covers
+that mocks can't: that a key entered at the CLI decrypts back byte-for-byte at
+run time, that `keys:read` can't write, that a plaintext key reaches neither
+stdout nor the activity log, and that the deployment advertises the origin it
+was actually reached on.
+
 ## Deployment
 
 Deploy anywhere that runs Next.js. On **Vercel**: import the repo, set the env vars from `.env.example`, and deploy. Runs execute synchronously inside the API route, so for large prompt sets prefer a Node server or bump the function's `maxDuration`.

--- a/app/api/keys/route.ts
+++ b/app/api/keys/route.ts
@@ -1,10 +1,11 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
-import { isProvider } from "@/lib/models";
-import { verifyKey, humanError } from "@/lib/llm";
-import { ConfigurationError, encryptSecret, keyHint } from "@/lib/crypto";
+import { setProviderKey } from "@/lib/provider-keys";
 import { logDashboard } from "@/lib/activity";
 
+// Dashboard (cookie-session) path for saving a BYOK provider key. The verify →
+// encrypt → store sequence lives in lib/provider-keys so this route and the
+// CLI-facing /api/v1/keys route cannot drift apart on the part that matters.
 export async function POST(request: Request) {
   const supabase = createClient();
   const {
@@ -27,72 +28,24 @@ export async function POST(request: Request) {
     label?: unknown;
   };
 
-  if (typeof provider !== "string" || !isProvider(provider)) {
-    return NextResponse.json({ error: "Unknown provider" }, { status: 400 });
+  const outcome = await setProviderKey(supabase, user.id, { provider, apiKey, label });
+  if (!outcome.ok) {
+    // `misconfigured` is the deployment's fault, not the user's, so it must not
+    // land on the key field as validation feedback — 503, and the message says
+    // the key itself was fine.
+    const status =
+      outcome.code === "misconfigured" ? 503 : outcome.code === "failed" ? 500 : 400;
+    return NextResponse.json({ error: outcome.message }, { status });
   }
-  if (typeof apiKey !== "string" || apiKey.trim().length === 0) {
-    return NextResponse.json({ error: "An API key is required" }, { status: 400 });
-  }
 
-  const key = apiKey.trim();
-  const cleanLabel =
-    typeof label === "string" && label.trim().length > 0 ? label.trim() : null;
+  await logDashboard(user, request, {
+    category: "provider_key",
+    action: "provider_key.saved",
+    summary: `Saved a ${outcome.key.provider} provider key (${outcome.key.key_hint})`,
+    targetType: "provider_key",
+    targetId: outcome.key.id,
+    metadata: { provider: outcome.key.provider, key_hint: outcome.key.key_hint },
+  });
 
-  try {
-    const v = await verifyKey(provider, key);
-    if (!v.ok) {
-      return NextResponse.json(
-        { error: v.error || "Key verification failed" },
-        { status: 400 },
-      );
-    }
-
-    const encrypted_key = encryptSecret(key);
-    const key_hint = keyHint(key);
-
-    const { data, error } = await supabase
-      .from("provider_keys")
-      .upsert(
-        {
-          user_id: user.id,
-          provider,
-          label: cleanLabel,
-          encrypted_key,
-          key_hint,
-        },
-        { onConflict: "user_id,provider" },
-      )
-      .select("id, provider, label, key_hint, created_at")
-      .single();
-
-    if (error) {
-      return NextResponse.json({ error: humanError(error) }, { status: 500 });
-    }
-
-    await logDashboard(user, request, {
-      category: "provider_key",
-      action: "provider_key.saved",
-      summary: `Saved a ${provider} provider key (${key_hint})`,
-      targetType: "provider_key",
-      targetId: (data as { id: string }).id,
-      metadata: { provider, key_hint },
-    });
-
-    return NextResponse.json(data);
-  } catch (e) {
-    // The key was already verified against the provider above, so a failure
-    // here is ours, not theirs. Say so plainly instead of rendering a server
-    // misconfiguration as validation feedback on the field they just filled in.
-    if (e instanceof ConfigurationError) {
-      console.error("[keys] deployment misconfigured:", e.message);
-      return NextResponse.json(
-        {
-          error:
-            "Your key is valid, but this deployment can't store it yet: the server is missing a working ENCRYPTION_KEY. Nothing was saved. Contact whoever operates this instance.",
-        },
-        { status: 503 },
-      );
-    }
-    return NextResponse.json({ error: humanError(e) }, { status: 500 });
-  }
+  return NextResponse.json(outcome.key);
 }

--- a/app/api/v1/keys-routes.test.ts
+++ b/app/api/v1/keys-routes.test.ts
@@ -1,0 +1,232 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { authenticateApiKey } from "@/lib/api-auth";
+import {
+  ENCRYPTION_UNAVAILABLE_MESSAGE,
+  listProviderKeys,
+  removeProviderKey,
+  setProviderKey,
+} from "@/lib/provider-keys";
+import { GET as getKeysRoute } from "@/app/api/v1/keys/route";
+import {
+  DELETE as deleteKeyRoute,
+  PUT as putKeyRoute,
+} from "@/app/api/v1/keys/[provider]/route";
+
+vi.mock("@/lib/api-auth", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/api-auth")>()),
+  authenticateApiKey: vi.fn(),
+}));
+vi.mock("@/lib/provider-keys", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/provider-keys")>()),
+  listProviderKeys: vi.fn(),
+  setProviderKey: vi.fn(),
+  removeProviderKey: vi.fn(),
+}));
+
+const AUTH_CTX = {
+  supabase: {} as never,
+  userId: "user-1",
+  keyId: "key-1",
+  tokenType: "api_key" as const,
+  scopes: ["projects:read", "projects:write", "runs:read", "runs:trigger", "keys:read", "keys:write"],
+  clientId: null,
+  expiresAt: null,
+  aud: null,
+};
+
+const STORED = {
+  id: "pk-1",
+  provider: "anthropic" as const,
+  label: null,
+  key_hint: "sk-ant-…4a9c",
+  created_at: "2026-07-20T00:00:00Z",
+};
+
+const PLAINTEXT = "sk-ant-api03-definitely-not-a-real-key-4a9c";
+
+function req(path: string, init?: RequestInit) {
+  return new Request(`http://localhost${path}`, {
+    headers: { authorization: "Bearer lt_live_test" },
+    ...init,
+  });
+}
+
+beforeEach(() => {
+  vi.mocked(authenticateApiKey).mockReset().mockResolvedValue(AUTH_CTX);
+  vi.mocked(listProviderKeys).mockReset();
+  vi.mocked(setProviderKey).mockReset();
+  vi.mocked(removeProviderKey).mockReset();
+});
+
+describe("GET /api/v1/keys", () => {
+  it("401s without a valid credential", async () => {
+    vi.mocked(authenticateApiKey).mockResolvedValue(null);
+    const res = await getKeysRoute(new Request("http://localhost/api/v1/keys"));
+    expect(res.status).toBe(401);
+    expect(listProviderKeys).not.toHaveBeenCalled();
+  });
+
+  it("403s a token granted before keys:read existed", async () => {
+    vi.mocked(authenticateApiKey).mockResolvedValue({
+      ...AUTH_CTX,
+      tokenType: "oauth",
+      clientId: "lt_cli",
+      aud: "v1",
+      scopes: ["projects:read", "runs:read"],
+    });
+    const res = await getKeysRoute(req("/api/v1/keys"));
+    expect(res.status).toBe(403);
+    // The machine-readable challenge is what lets the CLI tell "re-consent"
+    // apart from "you're not allowed" and relaunch login by itself.
+    expect(res.headers.get("WWW-Authenticate")).toContain("insufficient_scope");
+    expect(res.headers.get("WWW-Authenticate")).toContain("keys:read");
+  });
+
+  it("returns stored hints plus the provider catalog", async () => {
+    vi.mocked(listProviderKeys).mockResolvedValue([STORED]);
+    const res = await getKeysRoute(req("/api/v1/keys"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.keys).toEqual([STORED]);
+    // Shipped so clients never hardcode a provider list of their own.
+    expect(body.providers.map((p: { id: string }) => p.id)).toContain("anthropic");
+    expect(listProviderKeys).toHaveBeenCalledWith(AUTH_CTX.supabase, "user-1");
+  });
+});
+
+describe("PUT /api/v1/keys/:provider", () => {
+  const put = (provider: string, body?: unknown) =>
+    putKeyRoute(
+      req(`/api/v1/keys/${provider}`, {
+        method: "PUT",
+        body: body === undefined ? undefined : JSON.stringify(body),
+      }),
+      { params: { provider } },
+    );
+
+  it("403s a token without keys:write, even one that may write projects", async () => {
+    vi.mocked(authenticateApiKey).mockResolvedValue({
+      ...AUTH_CTX,
+      tokenType: "oauth",
+      clientId: "lt_cli",
+      aud: "v1",
+      scopes: ["projects:write", "runs:trigger"],
+    });
+    const res = await put("anthropic", { api_key: PLAINTEXT });
+    expect(res.status).toBe(403);
+    expect(setProviderKey).not.toHaveBeenCalled();
+  });
+
+  it("400s without a JSON body", async () => {
+    const res = await put("anthropic");
+    expect(res.status).toBe(400);
+    expect(setProviderKey).not.toHaveBeenCalled();
+  });
+
+  it("400s on an unknown provider, naming the ones that work", async () => {
+    vi.mocked(setProviderKey).mockResolvedValue({
+      ok: false,
+      code: "invalid",
+      message: "Unknown provider. Supported: anthropic, openai.",
+    });
+    const res = await put("gemini", { api_key: PLAINTEXT });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toContain("anthropic");
+  });
+
+  it("400s when the provider rejects the key", async () => {
+    vi.mocked(setProviderKey).mockResolvedValue({
+      ok: false,
+      code: "unverified",
+      message: "Invalid API key.",
+    });
+    const res = await put("anthropic", { api_key: PLAINTEXT });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("Invalid API key.");
+  });
+
+  // A broken deployment is a 503 an operator can act on — not a 400 that tells
+  // the caller to go rotate a key the provider just accepted.
+  it("503s on a misconfigured ENCRYPTION_KEY, not 400", async () => {
+    vi.mocked(setProviderKey).mockResolvedValue({
+      ok: false,
+      code: "misconfigured",
+      message: ENCRYPTION_UNAVAILABLE_MESSAGE,
+    });
+    const res = await put("anthropic", { api_key: PLAINTEXT });
+    expect(res.status).toBe(503);
+    const error = (await res.json()).error;
+    expect(error).toContain("ENCRYPTION_KEY");
+    expect(error).not.toMatch(/invalid api key/i);
+  });
+
+  it("500s when storage fails", async () => {
+    vi.mocked(setProviderKey).mockResolvedValue({
+      ok: false,
+      code: "failed",
+      message: "connection reset",
+    });
+    const res = await put("anthropic", { api_key: PLAINTEXT });
+    expect(res.status).toBe(500);
+  });
+
+  it("stores the key and echoes back only the masked hint", async () => {
+    vi.mocked(setProviderKey).mockResolvedValue({ ok: true, key: STORED });
+    const res = await put("anthropic", { api_key: PLAINTEXT, label: "work" });
+    expect(res.status).toBe(200);
+
+    const raw = JSON.stringify(await res.json());
+    expect(raw).toContain("sk-ant-…4a9c");
+    // The response is the one place a key could trivially leak back out.
+    expect(raw).not.toContain(PLAINTEXT);
+
+    // The provider comes from the path; the secret only ever from the body.
+    expect(setProviderKey).toHaveBeenCalledWith(AUTH_CTX.supabase, "user-1", {
+      provider: "anthropic",
+      apiKey: PLAINTEXT,
+      label: "work",
+    });
+  });
+});
+
+describe("DELETE /api/v1/keys/:provider", () => {
+  const del = (provider: string) =>
+    deleteKeyRoute(req(`/api/v1/keys/${provider}`, { method: "DELETE" }), {
+      params: { provider },
+    });
+
+  it("403s a token without keys:write", async () => {
+    vi.mocked(authenticateApiKey).mockResolvedValue({
+      ...AUTH_CTX,
+      tokenType: "oauth",
+      clientId: "lt_cli",
+      aud: "v1",
+      scopes: ["keys:read"],
+    });
+    const res = await del("anthropic");
+    expect(res.status).toBe(403);
+    expect(removeProviderKey).not.toHaveBeenCalled();
+  });
+
+  it("400s an unknown provider before touching the database", async () => {
+    const res = await del("gemini");
+    expect(res.status).toBe(400);
+    expect(removeProviderKey).not.toHaveBeenCalled();
+  });
+
+  it("404s when nothing was stored, so a no-op can't read as a revocation", async () => {
+    vi.mocked(removeProviderKey).mockResolvedValue(null);
+    const res = await del("openai");
+    expect(res.status).toBe(404);
+  });
+
+  it("removes the key and reports which one went", async () => {
+    vi.mocked(removeProviderKey).mockResolvedValue(STORED);
+    const res = await del("anthropic");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.key.key_hint).toBe("sk-ant-…4a9c");
+    expect(removeProviderKey).toHaveBeenCalledWith(AUTH_CTX.supabase, "user-1", "anthropic");
+  });
+});

--- a/app/api/v1/keys/[provider]/route.ts
+++ b/app/api/v1/keys/[provider]/route.ts
@@ -1,0 +1,113 @@
+import { NextResponse } from "next/server";
+import { requireApiAuth } from "@/lib/api-guards";
+import {
+  parseProvider,
+  removeProviderKey,
+  setProviderKey,
+  unknownProviderMessage,
+} from "@/lib/provider-keys";
+import { logApiRequest } from "@/lib/activity";
+import { humanError } from "@/lib/llm";
+
+export const dynamic = "force-dynamic";
+
+// The account holds at most one key per provider, so the provider IS the
+// resource id here — no lookup round-trip before a write, and PUT is honestly
+// idempotent: setting and rotating a key are the same request.
+
+// PUT /api/v1/keys/:provider — verify, encrypt, and store a BYOK key.
+// Body: { api_key: string, label?: string }
+// Auth: Bearer token with the "keys:write" scope.
+//
+// The key travels in the JSON body and nowhere else: never a query parameter
+// (proxy and server access logs record those verbatim) and never a path
+// segment. It is also never echoed back — the response carries only the masked
+// hint, which is all any client needs to confirm the right key landed.
+export async function PUT(
+  request: Request,
+  { params }: { params: { provider: string } },
+) {
+  const auth = await requireApiAuth(request, "keys:write", "v1");
+  if (auth instanceof Response) return auth;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  const { api_key, label } = (body ?? {}) as { api_key?: unknown; label?: unknown };
+
+  const outcome = await setProviderKey(auth.supabase, auth.userId, {
+    provider: params.provider,
+    apiKey: api_key,
+    label,
+  });
+
+  if (!outcome.ok) {
+    // A misconfigured ENCRYPTION_KEY is the operator's problem, not the
+    // caller's: 503 (retriable once someone fixes the deployment), never the
+    // 400 that would tell a user their perfectly good key was rejected.
+    const status =
+      outcome.code === "misconfigured" ? 503 : outcome.code === "failed" ? 500 : 400;
+    await logApiRequest(auth, request, "v1", {
+      category: "provider_key",
+      action: "api.set_provider_key",
+      status: "failure",
+      statusCode: status,
+      summary: `Provider key not saved via the API: ${outcome.message}`,
+      metadata: { provider: params.provider, reason: outcome.code },
+    });
+    return NextResponse.json({ error: outcome.message }, { status });
+  }
+
+  await logApiRequest(auth, request, "v1", {
+    category: "provider_key",
+    action: "provider_key.saved",
+    statusCode: 200,
+    targetType: "provider_key",
+    targetId: outcome.key.id,
+    summary: `Saved a ${outcome.key.provider} provider key (${outcome.key.key_hint})`,
+    metadata: { provider: outcome.key.provider, key_hint: outcome.key.key_hint },
+  });
+  return NextResponse.json({ key: outcome.key });
+}
+
+// DELETE /api/v1/keys/:provider — forget the stored key for one provider.
+// Auth: Bearer token with the "keys:write" scope.
+export async function DELETE(
+  request: Request,
+  { params }: { params: { provider: string } },
+) {
+  const auth = await requireApiAuth(request, "keys:write", "v1");
+  if (auth instanceof Response) return auth;
+
+  const provider = parseProvider(params.provider);
+  if (!provider) {
+    return NextResponse.json({ error: unknownProviderMessage() }, { status: 400 });
+  }
+
+  try {
+    const removed = await removeProviderKey(auth.supabase, auth.userId, provider);
+    if (!removed) {
+      // Nothing stored. Reported as 404 rather than a cheerful 200 so a script
+      // that thinks it just revoked a key isn't quietly wrong.
+      return NextResponse.json(
+        { error: `No ${provider} key is stored for this account.` },
+        { status: 404 },
+      );
+    }
+    await logApiRequest(auth, request, "v1", {
+      category: "provider_key",
+      action: "provider_key.removed",
+      statusCode: 200,
+      targetType: "provider_key",
+      targetId: removed.id,
+      summary: `Removed the ${provider} provider key (${removed.key_hint}) via the API`,
+      metadata: { provider, key_hint: removed.key_hint },
+    });
+    return NextResponse.json({ ok: true, key: removed });
+  } catch (e) {
+    return NextResponse.json({ error: humanError(e) }, { status: 500 });
+  }
+}

--- a/app/api/v1/keys/route.ts
+++ b/app/api/v1/keys/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { requireApiAuth } from "@/lib/api-guards";
+import { listProviderKeys, supportedProviders } from "@/lib/provider-keys";
+import { logApiRequest } from "@/lib/activity";
+import { humanError } from "@/lib/llm";
+
+export const dynamic = "force-dynamic";
+
+// GET /api/v1/keys — which BYOK provider keys the account has stored, masked.
+//
+// The response also carries the provider catalog. That is what keeps clients
+// from hardcoding a provider list: the CLI renders whatever this returns, so a
+// provider added to lib/models.ts appears in `lettertrace keys` with no client
+// release. Auth: Bearer token with the "keys:read" scope.
+export async function GET(request: Request) {
+  const auth = await requireApiAuth(request, "keys:read", "v1");
+  if (auth instanceof Response) return auth;
+
+  try {
+    const keys = await listProviderKeys(auth.supabase, auth.userId);
+    await logApiRequest(auth, request, "v1", {
+      category: "provider_key",
+      action: "api.list_provider_keys",
+      summary: `Listed ${keys.length} provider key${keys.length === 1 ? "" : "s"} via the API`,
+      statusCode: 200,
+      metadata: { count: keys.length },
+    });
+    return NextResponse.json({ keys, providers: supportedProviders() });
+  } catch (e) {
+    return NextResponse.json({ error: humanError(e) }, { status: 500 });
+  }
+}

--- a/cli/http.mjs
+++ b/cli/http.mjs
@@ -1,4 +1,4 @@
-import { getAccessToken } from "./oauth.mjs";
+import { forget, getAccessToken, NeedsLogin } from "./oauth.mjs";
 
 // Thin REST client for the Lettertrace v1 API. Every call carries an OAuth
 // access token bound to the "v1" audience, transparently refreshed when it has
@@ -45,6 +45,22 @@ export async function rest(base, method, pathname, { query, body } = {}) {
     // The token was rejected despite passing our local expiry check. Force a
     // rotation (or NeedsLogin) and try exactly once more.
     res = await send(await getAccessToken(base, "v1", { force: true }));
+  }
+
+  // A token minted before the deployment started requiring a scope is a
+  // permanent 403 no amount of refreshing fixes — the scope set is baked into
+  // the grant the user approved. Discard it and surface NeedsLogin so the
+  // caller re-runs consent, which is the only place the wider scope can be
+  // granted. Detected from the RFC 6750 challenge, not the prose message.
+  if (res.status === 403) {
+    const challenge = res.headers.get("www-authenticate") ?? "";
+    if (challenge.includes("insufficient_scope")) {
+      forget("v1");
+      throw new NeedsLogin(
+        "v1",
+        "Your saved sign-in predates a permission this command needs.",
+      );
+    }
   }
 
   const text = await res.text();

--- a/cli/lettertrace.mjs
+++ b/cli/lettertrace.mjs
@@ -16,6 +16,7 @@ import { resolveBase, loadConfig } from "./config.mjs";
 import { login, logout, getAccessToken, revoke, NeedsLogin } from "./oauth.mjs";
 import { rest, ApiError } from "./http.mjs";
 import { listTools, callTool, renderToolResult } from "./mcp.mjs";
+import { readSecret, SecretInputError, SECRET_ENV } from "./secret.mjs";
 import { c, printJson, table, kv, ok, info, fail } from "./output.mjs";
 
 // --- arg parsing ----------------------------------------------------
@@ -91,7 +92,7 @@ async function withAutoLogin(fn) {
     return await fn();
   } catch (e) {
     if (e instanceof NeedsLogin) {
-      info(c.yellow(`Not authenticated for "${e.resource}". Launching login...`));
+      info(c.yellow(`${e.detail ?? `Not authenticated for "${e.resource}".`} Launching login...`));
       await login(base, e.resource, { ipv6: IPV6 });
       return await fn();
     }
@@ -149,6 +150,86 @@ const commands = {
       { key: "expires_at", label: "ACCESS EXPIRES", map: (v) => rel(v) },
       { key: "refresh_token", label: "REFRESH", map: (v) => (v ? "yes" : "no") },
     ]);
+  },
+
+  // BYOK provider keys. The secret itself never travels through argv (see
+  // cli/secret.mjs); this command only ever handles the masked hint the server
+  // returns. The provider list comes from the server too, so a provider added
+  // to the deployment's catalog works here with no new CLI release.
+  async keys() {
+    const sub = rest_[0] ?? "list";
+
+    // A key passed as a flag is already burned — it is in the shell history and
+    // was visible in `ps` the moment the process started. Refuse loudly rather
+    // than ignoring the flag and letting the user believe it went nowhere.
+    for (const banned of ["key", "api-key", "apikey", "secret"]) {
+      if (flags[banned] !== undefined) {
+        throw new UsageError(
+          `--${banned} is not accepted: a key on the command line leaks into shell history and process lists. ` +
+            `Pipe it in, set $${SECRET_ENV}, or use --key-file <path>. Rotate that key.`,
+        );
+      }
+    }
+
+    if (sub === "set") {
+      const provider = need(rest_[1], "keys set needs a <provider> (see `lettertrace keys`)");
+      // Authenticate and fetch the catalog BEFORE asking for the secret. That
+      // gets any browser consent out of the way while the terminal is still
+      // free, and it rejects a mistyped provider before the user has pasted a
+      // key we would only throw away.
+      const current = await withAutoLogin(() => rest(base, "GET", "/keys"));
+      const supported = current.providers ?? [];
+      const match = supported.find((p) => p.id === provider);
+      if (!match) {
+        throw new UsageError(
+          `Unknown provider "${provider}". This deployment supports: ${supported.map((p) => p.id).join(", ") || "(none)"}.`,
+        );
+      }
+
+      const apiKey = await readSecret({
+        file: typeof flags["key-file"] === "string" ? flags["key-file"] : undefined,
+        label: `${match.label} key (input hidden): `,
+      });
+      const body = { api_key: apiKey };
+      if (typeof flags.label === "string") body.label = flags.label;
+
+      info(c.dim(`Verifying the key against ${match.label}...`));
+      const out = await withAutoLogin(() => rest(base, "PUT", `/keys/${provider}`, { body }));
+      if (JSON_OUT) return printJson(out);
+      ok(`Verified and stored your ${match.label} key (${out.key.key_hint}).`);
+      return;
+    }
+
+    if (sub === "remove" || sub === "rm") {
+      const provider = need(rest_[1], "keys remove needs a <provider>");
+      const out = await withAutoLogin(() => rest(base, "DELETE", `/keys/${provider}`));
+      if (JSON_OUT) return printJson(out);
+      ok(`Removed the ${provider} key (${out.key.key_hint}).`);
+      return;
+    }
+
+    // list: one row per supported provider, set or not, so this doubles as the
+    // answer to "what can I configure here?".
+    const out = await withAutoLogin(() => rest(base, "GET", "/keys"));
+    if (JSON_OUT) return printJson(out);
+    const stored = new Map((out.keys ?? []).map((k) => [k.provider, k]));
+    table(
+      (out.providers ?? []).map((p) => ({
+        provider: p.id,
+        name: p.label,
+        key: stored.get(p.id)?.key_hint ?? c.dim("not set"),
+        added: stored.get(p.id)?.created_at ?? "",
+        where: p.key_url,
+      })),
+      [
+        { key: "provider", label: "PROVIDER" },
+        { key: "name", label: "NAME" },
+        { key: "key", label: "STORED KEY" },
+        { key: "added", label: "ADDED" },
+        { key: "where", label: "GET A KEY" },
+      ],
+    );
+    info(c.dim("\nSet one with: lettertrace keys set <provider>  (the key is never typed as an argument)"));
   },
 
   async projects() {
@@ -397,6 +478,14 @@ function printHelp() {
     "  logout                                 Forget and revoke stored tokens",
     "  whoami                                 Show stored credentials",
     "",
+    c.bold("PROVIDER KEYS (BYOK)"),
+    "  keys                                   Which AI provider keys are stored (masked)",
+    "  keys set <provider> [--key-file <p>] [--label <l>]",
+    "                                         Verify + store a key. The key is read from",
+    `                                         --key-file (- = stdin), $${SECRET_ENV},`,
+    "                                         piped stdin, or a hidden prompt — never a flag.",
+    "  keys remove <provider>                 Forget the stored key for a provider",
+    "",
     c.bold("DATA (REST v1)"),
     "  projects                               List organizations",
     "  projects create --name <n> --brand <b> [--domains a,b] [--description <d>]",
@@ -438,7 +527,7 @@ async function main() {
 }
 
 main().catch((e) => {
-  if (e instanceof UsageError) {
+  if (e instanceof UsageError || e instanceof SecretInputError) {
     fail(e.message);
   } else if (e instanceof ApiError) {
     fail(`API error ${e.status}: ${e.message}`);

--- a/cli/oauth.mjs
+++ b/cli/oauth.mjs
@@ -9,17 +9,21 @@ import { loadConfig, saveConfig } from "./config.mjs";
 
 const CLIENT_ID = "lt_cli";
 export const DEFAULT_SCOPE =
-  "projects:read projects:write runs:read runs:trigger offline_access";
+  "projects:read projects:write runs:read runs:trigger keys:read keys:write offline_access";
 
 const b64url = (buf) => buf.toString("base64url");
 
 /** Thrown when a resource has no usable credential; the caller may prompt a
- *  login for exactly that audience. */
+ *  login for exactly that audience. `detail` explains why when the reason is
+ *  something other than "you never logged in" — e.g. a stored token that
+ *  predates a scope the deployment has since started requiring. */
 export class NeedsLogin extends Error {
-  constructor(resource) {
-    super(`Not authenticated for "${resource}". Run: lettertrace login${resource === "mcp" ? " --mcp" : ""}`);
+  constructor(resource, detail) {
+    const how = `Run: lettertrace login${resource === "mcp" ? " --mcp" : ""}`;
+    super(detail ? `${detail} ${how}` : `Not authenticated for "${resource}". ${how}`);
     this.name = "NeedsLogin";
     this.resource = resource;
+    this.detail = detail ?? null;
   }
 }
 
@@ -213,6 +217,15 @@ export async function getAccessToken(base, resource, { force = false } = {}) {
     throw new NeedsLogin(resource);
   }
   return storeCredential(base, resource, tokens).access_token;
+}
+
+/** Drop the stored credential for one audience without touching the others, so
+ *  the next command re-runs the browser flow and re-consents from scratch. */
+export function forget(resource) {
+  const cfg = loadConfig();
+  if (!cfg.credentials[resource]) return;
+  delete cfg.credentials[resource];
+  saveConfig(cfg);
 }
 
 export function logout() {

--- a/cli/secret.mjs
+++ b/cli/secret.mjs
@@ -1,0 +1,133 @@
+import fs from "node:fs";
+
+// Reading a secret without leaking it.
+//
+// The one thing this module exists to prevent is a provider key ever appearing
+// in argv. A `--key sk-ant-…` flag lands in shell history, in `ps` output for
+// every user on the box, and in any process supervisor's logs — and unlike a
+// file or a pipe there is no way to un-leak it afterwards. So the CLI accepts a
+// key from exactly three places, none of which is the command line:
+//
+//   1. --key-file <path>  (or `-` for stdin), so a secret manager can feed it
+//   2. $LETTERTRACE_PROVIDER_KEY, for CI where a pipe is awkward
+//   3. an interactive prompt with the terminal echo turned off
+//
+// Nothing here writes the value anywhere: not to stdout, not to a temp file,
+// not into an error message. Errors describe the source, never the contents.
+
+export const SECRET_ENV = "LETTERTRACE_PROVIDER_KEY";
+
+/** A secret could not be obtained; the message is safe to print. */
+export class SecretInputError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "SecretInputError";
+  }
+}
+
+function readAllStdin() {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => {
+      data += chunk;
+    });
+    process.stdin.on("end", () => resolve(data));
+    process.stdin.on("error", reject);
+    process.stdin.resume();
+  });
+}
+
+/**
+ * Prompt on a TTY with echo disabled. Nothing is rendered as the user types —
+ * not even asterisks, which would put the key's length on screen and in a
+ * screen-share recording for no benefit. Raw mode is always restored, including
+ * on Ctrl-C, so an aborted prompt can't leave the terminal unusable.
+ */
+function promptHidden(label) {
+  return new Promise((resolve, reject) => {
+    const input = process.stdin;
+    const wasRaw = Boolean(input.isRaw);
+    let buffer = "";
+
+    const cleanup = () => {
+      input.removeListener("data", onData);
+      if (input.isTTY) input.setRawMode(wasRaw);
+      input.pause();
+    };
+
+    const onData = (chunk) => {
+      for (const ch of chunk) {
+        const code = ch.charCodeAt(0);
+        if (ch === "\r" || ch === "\n") {
+          cleanup();
+          process.stderr.write("\n");
+          resolve(buffer);
+          return;
+        }
+        if (code === 3) {
+          // Ctrl-C: the prompt owns raw mode, so the default SIGINT handling
+          // never fires and we have to quit deliberately.
+          cleanup();
+          process.stderr.write("\n");
+          reject(new SecretInputError("Aborted."));
+          return;
+        }
+        if (code === 127 || ch === "\b") {
+          buffer = buffer.slice(0, -1);
+          continue;
+        }
+        if (code < 32) continue; // drop arrow keys and other control sequences
+        buffer += ch;
+      }
+    };
+
+    process.stderr.write(label);
+    input.setEncoding("utf8");
+    input.setRawMode(true);
+    input.resume();
+    input.on("data", onData);
+  });
+}
+
+/**
+ * Obtain a secret. Precedence: an explicitly named --key-file, then the
+ * environment variable, then piped stdin, then an interactive prompt. The
+ * explicit flag wins over the environment so a stale exported variable can
+ * never silently override what the user just asked for.
+ */
+export async function readSecret({ file, label } = {}) {
+  if (typeof file === "string" && file.length > 0) {
+    if (file === "-") {
+      const piped = (await readAllStdin()).trim();
+      if (!piped) throw new SecretInputError("No key arrived on stdin.");
+      return piped;
+    }
+    let contents;
+    try {
+      contents = fs.readFileSync(file, "utf8");
+    } catch (e) {
+      throw new SecretInputError(`Could not read ${file}: ${e.code ?? e.message}`);
+    }
+    const trimmed = contents.trim();
+    if (!trimmed) throw new SecretInputError(`${file} is empty.`);
+    return trimmed;
+  }
+
+  const fromEnv = process.env[SECRET_ENV];
+  if (typeof fromEnv === "string" && fromEnv.trim()) return fromEnv.trim();
+
+  if (!process.stdin.isTTY) {
+    const piped = (await readAllStdin()).trim();
+    if (!piped) {
+      throw new SecretInputError(
+        `No key provided. Pipe it in, set $${SECRET_ENV}, or use --key-file <path>.`,
+      );
+    }
+    return piped;
+  }
+
+  const typed = (await promptHidden(label ?? "Key (input hidden): ")).trim();
+  if (!typed) throw new SecretInputError("No key entered.");
+  return typed;
+}

--- a/lib/api-auth.ts
+++ b/lib/api-auth.ts
@@ -22,6 +22,8 @@ export const FULL_SCOPES = [
   "projects:write",
   "runs:read",
   "runs:trigger",
+  "keys:read",
+  "keys:write",
 ] as const;
 
 export type Scope = (typeof FULL_SCOPES)[number];

--- a/lib/oauth.ts
+++ b/lib/oauth.ts
@@ -44,6 +44,12 @@ export const DATA_SCOPES = [
   "projects:write",
   "runs:read",
   "runs:trigger",
+  // BYOK provider keys get their own pair rather than riding on projects:write.
+  // Handing someone the ability to swap the key that every run is billed to is
+  // a different decision from letting them add a prompt, and the consent screen
+  // is the only place a user ever gets to make it.
+  "keys:read",
+  "keys:write",
 ] as const;
 export const OFFLINE_ACCESS = "offline_access";
 export const KNOWN_SCOPES = [...DATA_SCOPES, OFFLINE_ACCESS] as const;
@@ -54,6 +60,8 @@ export const SCOPE_DESCRIPTIONS: Record<string, string> = {
   "projects:write": "Create organizations and add or edit prompts",
   "runs:read": "Read your monitoring runs and share-of-voice reports",
   "runs:trigger": "Start new monitoring runs (spends your provider key)",
+  "keys:read": "See which AI provider keys you've stored (masked, never the key itself)",
+  "keys:write": "Replace or remove the AI provider keys your runs are billed to",
   [OFFLINE_ACCESS]: "Stay connected without you signing in again",
 };
 

--- a/lib/provider-keys.test.ts
+++ b/lib/provider-keys.test.ts
@@ -240,4 +240,21 @@ describe("listProviderKeys / removeProviderKey", () => {
     const db = stubClient({ data: null });
     await expect(removeProviderKey(db.supabase, "user-1", "openai")).resolves.toBeNull();
   });
+
+  // Both of these used to swallow the error and collapse into the same value
+  // the "nothing there" case returns, which made a failed query indistinguishable
+  // from a true answer about the account.
+  it("throws on a failed read instead of claiming the account has no keys", async () => {
+    const db = stubClient({ data: null, error: new Error("connection reset") });
+    await expect(listProviderKeys(db.supabase, "user-1")).rejects.toThrow("connection reset");
+  });
+
+  // The dangerous direction: a delete that failed must never be reported as
+  // "no key is stored", which reads as "already revoked" for a live credential.
+  it("throws on a failed delete rather than reporting nothing was stored", async () => {
+    const db = stubClient({ data: null, error: new Error("connection reset") });
+    await expect(removeProviderKey(db.supabase, "user-1", "anthropic")).rejects.toThrow(
+      "connection reset",
+    );
+  });
 });

--- a/lib/provider-keys.test.ts
+++ b/lib/provider-keys.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import crypto from "node:crypto";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { verifyKey } from "@/lib/llm";
+import { decryptSecret } from "@/lib/crypto";
+import {
+  ENCRYPTION_UNAVAILABLE_MESSAGE,
+  listProviderKeys,
+  parseProvider,
+  removeProviderKey,
+  setProviderKey,
+  supportedProviders,
+  unknownProviderMessage,
+} from "@/lib/provider-keys";
+
+vi.mock("@/lib/llm", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/llm")>()),
+  verifyKey: vi.fn(),
+}));
+
+const PLAINTEXT = "sk-ant-api03-definitely-not-a-real-key-0000";
+const VALID_ENCRYPTION_KEY = crypto.randomBytes(32).toString("base64");
+const originalEncryptionKey = process.env.ENCRYPTION_KEY;
+
+const STORED_ROW = {
+  id: "key-1",
+  provider: "anthropic",
+  label: null,
+  key_hint: "sk-ant-…0000",
+  created_at: "2026-07-20T00:00:00Z",
+};
+
+/**
+ * Minimal stand-in for the PostgREST query builder: every call is recorded and
+ * returns the same chain, and the terminal methods resolve to a fixed result.
+ * The point of the recording is that these tests can assert on the row that
+ * WOULD have been written — which is the only way to prove the plaintext key
+ * never reaches the database.
+ */
+function stubClient(result: { data: unknown; error?: unknown }) {
+  const calls: { method: string; args: unknown[] }[] = [];
+  const settled = Promise.resolve({ data: result.data, error: result.error ?? null });
+  const record = (method: string, args: unknown[]) => calls.push({ method, args });
+
+  const chain: Record<string, (...args: unknown[]) => unknown> = {};
+  for (const method of ["upsert", "delete", "select", "eq"]) {
+    chain[method] = (...args: unknown[]) => {
+      record(method, args);
+      return chain;
+    };
+  }
+  for (const method of ["order", "single", "maybeSingle"]) {
+    chain[method] = (...args: unknown[]) => {
+      record(method, args);
+      return settled;
+    };
+  }
+
+  const supabase = {
+    from: (table: string) => {
+      record("from", [table]);
+      return chain;
+    },
+  } as unknown as SupabaseClient;
+
+  const argsOf = (method: string) => calls.find((c) => c.method === method)?.args;
+  return { supabase, calls, argsOf };
+}
+
+beforeEach(() => {
+  process.env.ENCRYPTION_KEY = VALID_ENCRYPTION_KEY;
+  vi.mocked(verifyKey).mockReset().mockResolvedValue({ ok: true });
+});
+
+afterEach(() => {
+  if (originalEncryptionKey === undefined) delete process.env.ENCRYPTION_KEY;
+  else process.env.ENCRYPTION_KEY = originalEncryptionKey;
+});
+
+describe("the provider catalog is the server's, not the client's", () => {
+  it("derives the supported providers from the model catalog", () => {
+    const ids = supportedProviders().map((p) => p.id);
+    expect(ids).toContain("anthropic");
+    expect(ids).toContain("openai");
+    // Each entry carries enough for a client to render a picker unaided.
+    expect(supportedProviders()[0]).toMatchObject({
+      label: expect.any(String),
+      key_url: expect.any(String),
+    });
+  });
+
+  it("names the working providers when one is rejected", () => {
+    expect(parseProvider("gemini")).toBeNull();
+    expect(parseProvider("anthropic")).toBe("anthropic");
+    expect(unknownProviderMessage()).toContain("anthropic");
+    expect(unknownProviderMessage()).toContain("openai");
+  });
+});
+
+describe("setProviderKey", () => {
+  it("rejects an unknown provider without calling the provider or the database", async () => {
+    const db = stubClient({ data: null });
+    const outcome = await setProviderKey(db.supabase, "user-1", {
+      provider: "gemini",
+      apiKey: PLAINTEXT,
+    });
+    expect(outcome).toMatchObject({ ok: false, code: "invalid" });
+    expect(verifyKey).not.toHaveBeenCalled();
+    expect(db.calls).toHaveLength(0);
+  });
+
+  it("rejects an empty key", async () => {
+    const db = stubClient({ data: null });
+    const outcome = await setProviderKey(db.supabase, "user-1", {
+      provider: "anthropic",
+      apiKey: "   ",
+    });
+    expect(outcome).toMatchObject({ ok: false, code: "invalid" });
+    expect(verifyKey).not.toHaveBeenCalled();
+  });
+
+  // The ordering guarantee: a key the provider refuses must never be persisted,
+  // not even encrypted. Verification is what makes the stored key trustworthy.
+  it("never writes a key the provider rejected", async () => {
+    vi.mocked(verifyKey).mockResolvedValue({ ok: false, error: "Invalid API key." });
+    const db = stubClient({ data: null });
+    const outcome = await setProviderKey(db.supabase, "user-1", {
+      provider: "anthropic",
+      apiKey: PLAINTEXT,
+    });
+    expect(outcome).toMatchObject({ ok: false, code: "unverified", message: "Invalid API key." });
+    expect(db.calls).toHaveLength(0);
+  });
+
+  it("stores ciphertext plus a hint, and never the plaintext", async () => {
+    const db = stubClient({ data: STORED_ROW });
+    const outcome = await setProviderKey(db.supabase, "user-1", {
+      provider: "anthropic",
+      apiKey: `  ${PLAINTEXT}  `,
+      label: "  work  ",
+    });
+
+    expect(outcome).toEqual({ ok: true, key: STORED_ROW });
+    expect(verifyKey).toHaveBeenCalledWith("anthropic", PLAINTEXT);
+
+    const row = db.argsOf("upsert")?.[0] as Record<string, string>;
+    expect(row.user_id).toBe("user-1");
+    expect(row.label).toBe("work");
+    // The row is inspected as a whole: no field anywhere may equal the key.
+    expect(JSON.stringify(row)).not.toContain(PLAINTEXT);
+    expect(decryptSecret(row.encrypted_key)).toBe(PLAINTEXT);
+    expect(row.key_hint).toBe("sk-ant-…0000");
+
+    // Upsert on (user_id, provider): setting a key replaces, never duplicates.
+    expect(db.argsOf("upsert")?.[1]).toEqual({ onConflict: "user_id,provider" });
+  });
+
+  it("blanks an empty label rather than storing an empty string", async () => {
+    const db = stubClient({ data: STORED_ROW });
+    await setProviderKey(db.supabase, "user-1", {
+      provider: "anthropic",
+      apiKey: PLAINTEXT,
+      label: "   ",
+    });
+    expect((db.argsOf("upsert")?.[0] as Record<string, unknown>).label).toBeNull();
+  });
+
+  // The distinction the whole ConfigurationError machinery exists for: the user
+  // pasted a good key and the DEPLOYMENT is broken. Reporting this as a bad key
+  // sends them off to rotate a credential that was never the problem.
+  it("reports a missing ENCRYPTION_KEY as the operator's problem, not a bad key", async () => {
+    delete process.env.ENCRYPTION_KEY;
+    const db = stubClient({ data: STORED_ROW });
+    const outcome = await setProviderKey(db.supabase, "user-1", {
+      provider: "anthropic",
+      apiKey: PLAINTEXT,
+    });
+    expect(outcome).toEqual({
+      ok: false,
+      code: "misconfigured",
+      message: ENCRYPTION_UNAVAILABLE_MESSAGE,
+    });
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.message).toMatch(/ENCRYPTION_KEY/);
+      expect(outcome.message).not.toMatch(/invalid api key/i);
+    }
+    // Verified first, stored never: nothing reached the database.
+    expect(verifyKey).toHaveBeenCalled();
+    expect(db.calls).toHaveLength(0);
+  });
+
+  it("reports a hex ENCRYPTION_KEY the same way, not as a 500", async () => {
+    process.env.ENCRYPTION_KEY = crypto.randomBytes(32).toString("hex");
+    const db = stubClient({ data: STORED_ROW });
+    const outcome = await setProviderKey(db.supabase, "user-1", {
+      provider: "anthropic",
+      apiKey: PLAINTEXT,
+    });
+    expect(outcome).toMatchObject({ ok: false, code: "misconfigured" });
+  });
+
+  it("surfaces a storage failure as `failed`, distinct from a bad key", async () => {
+    const db = stubClient({ data: null, error: new Error("connection reset") });
+    const outcome = await setProviderKey(db.supabase, "user-1", {
+      provider: "anthropic",
+      apiKey: PLAINTEXT,
+    });
+    expect(outcome).toMatchObject({ ok: false, code: "failed" });
+  });
+});
+
+describe("listProviderKeys / removeProviderKey", () => {
+  it("scopes the listing to the caller and returns hints only", async () => {
+    const db = stubClient({ data: [STORED_ROW] });
+    const keys = await listProviderKeys(db.supabase, "user-1");
+    expect(keys).toEqual([STORED_ROW]);
+    expect(db.argsOf("eq")).toEqual(["user_id", "user-1"]);
+    // encrypted_key is decryptable by the server; it is never selected.
+    expect(db.argsOf("select")?.[0]).not.toContain("encrypted_key");
+  });
+
+  it("returns an empty list rather than throwing when the query yields nothing", async () => {
+    const db = stubClient({ data: null });
+    await expect(listProviderKeys(db.supabase, "user-1")).resolves.toEqual([]);
+  });
+
+  it("returns the removed row so the caller can confirm which key went", async () => {
+    const db = stubClient({ data: STORED_ROW });
+    await expect(removeProviderKey(db.supabase, "user-1", "anthropic")).resolves.toEqual(
+      STORED_ROW,
+    );
+    expect(db.calls.filter((c) => c.method === "eq").map((c) => c.args)).toEqual([
+      ["user_id", "user-1"],
+      ["provider", "anthropic"],
+    ]);
+  });
+
+  it("returns null when nothing was stored, so a no-op can't read as success", async () => {
+    const db = stubClient({ data: null });
+    await expect(removeProviderKey(db.supabase, "user-1", "openai")).resolves.toBeNull();
+  });
+});

--- a/lib/provider-keys.ts
+++ b/lib/provider-keys.ts
@@ -1,0 +1,190 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { ConfigurationError, encryptSecret, keyHint } from "@/lib/crypto";
+import { humanError, verifyKey } from "@/lib/llm";
+import { isProvider, PROVIDER_LIST } from "@/lib/models";
+import type { Provider } from "@/lib/types";
+
+// ==================================================================
+// The single write path for BYOK provider keys.
+//
+// Two surfaces store keys — the dashboard (app/api/keys, cookie/RLS client) and
+// the REST v1 API used by the CLI (app/api/v1/keys, service-role client) — and
+// the sequence they must follow is identical and security-critical: verify the
+// key against the provider FIRST, encrypt it SECOND, and only ever persist the
+// ciphertext plus a non-reversible hint. Duplicating that in two routes is how
+// one of them eventually drifts into storing a plaintext key or skipping
+// verification, so both call in here instead.
+//
+// Every function takes userId explicitly rather than leaning on RLS, because
+// the API surface passes the service-role client, where RLS is bypassed.
+//
+// Nothing in this module ever returns, logs, or echoes the plaintext key. The
+// only representation that leaves is keyHint() — e.g. "sk-ant-…4a9c".
+// ==================================================================
+
+/** A provider_keys row trimmed to what any surface may show. No ciphertext:
+ *  the encrypted key is decryptable by the server and has no business being in
+ *  a JSON response, even to the key's owner. */
+export interface ProviderKeySummary {
+  id: string;
+  provider: Provider;
+  label: string | null;
+  key_hint: string;
+  created_at: string;
+}
+
+/**
+ * What an operator (not the end user) has to fix. Kept as one constant so the
+ * dashboard and the CLI say the same thing, and phrased to make the ordering
+ * explicit: the key was already accepted by the provider, so the failure is the
+ * deployment's. Rendering this as field-level "invalid API key" feedback would
+ * send the user off to regenerate a key that was never the problem.
+ */
+export const ENCRYPTION_UNAVAILABLE_MESSAGE =
+  "Your key is valid, but this deployment can't store it yet: the server is missing a working ENCRYPTION_KEY. Nothing was saved. Contact whoever operates this instance.";
+
+export type SetProviderKeyOutcome =
+  | { ok: true; key: ProviderKeySummary }
+  // `invalid` = malformed request, `unverified` = the provider rejected the
+  // key, `misconfigured` = ours to fix (503), `failed` = storage blew up.
+  // Callers map the code to a status; they never re-derive it from the message.
+  | {
+      ok: false;
+      code: "invalid" | "unverified" | "misconfigured" | "failed";
+      message: string;
+    };
+
+/** The providers this deployment can hold a key for, derived from the model
+ *  catalog. Exposed over the API so clients (the CLI) can enumerate providers
+ *  without shipping their own copy of the list — adding a provider to
+ *  lib/models.ts is then the only change needed. */
+export function supportedProviders(): {
+  id: Provider;
+  label: string;
+  key_url: string;
+  key_prefix: string;
+}[] {
+  return PROVIDER_LIST.map((p) => ({
+    id: p.id,
+    label: p.label,
+    key_url: p.keyUrl,
+    key_prefix: p.keyPrefix,
+  }));
+}
+
+/** Narrow an untrusted provider value, or null. */
+export function parseProvider(value: unknown): Provider | null {
+  return typeof value === "string" && isProvider(value) ? value : null;
+}
+
+/** The 400 message for an unrecognized provider, naming the ones that do work
+ *  so a caller never has to guess (and so a newly added provider self-documents). */
+export function unknownProviderMessage(): string {
+  return `Unknown provider. Supported: ${PROVIDER_LIST.map((p) => p.id).join(", ")}.`;
+}
+
+const SUMMARY_COLUMNS = "id, provider, label, key_hint, created_at";
+
+/** The caller's stored keys, hints only. */
+export async function listProviderKeys(
+  supabase: SupabaseClient,
+  userId: string,
+): Promise<ProviderKeySummary[]> {
+  const { data } = await supabase
+    .from("provider_keys")
+    .select(SUMMARY_COLUMNS)
+    .eq("user_id", userId)
+    .order("provider");
+  return (data as ProviderKeySummary[] | null) ?? [];
+}
+
+/**
+ * Verify a provider key, encrypt it, and store it as the account's key for that
+ * provider (one per provider — an existing key is replaced, which is what both
+ * "set" and "rotate" mean here).
+ *
+ * The order matters and is the reason this function exists: a key that the
+ * provider rejects must never reach the database, and an encryption failure
+ * must be distinguishable from a rejected key.
+ */
+export async function setProviderKey(
+  supabase: SupabaseClient,
+  userId: string,
+  input: { provider: unknown; apiKey: unknown; label?: unknown },
+): Promise<SetProviderKeyOutcome> {
+  const provider = parseProvider(input.provider);
+  if (!provider) {
+    return { ok: false, code: "invalid", message: unknownProviderMessage() };
+  }
+  if (typeof input.apiKey !== "string" || input.apiKey.trim().length === 0) {
+    return { ok: false, code: "invalid", message: "An API key is required" };
+  }
+
+  const key = input.apiKey.trim();
+  const label =
+    typeof input.label === "string" && input.label.trim().length > 0
+      ? input.label.trim()
+      : null;
+
+  const verified = await verifyKey(provider, key);
+  if (!verified.ok) {
+    return {
+      ok: false,
+      code: "unverified",
+      message: verified.error || "Key verification failed",
+    };
+  }
+
+  let encrypted_key: string;
+  const key_hint = keyHint(key);
+  try {
+    encrypted_key = encryptSecret(key);
+  } catch (e) {
+    if (e instanceof ConfigurationError) {
+      // Operator-facing, and only ever reachable AFTER the provider accepted
+      // the key — so it is safe to state plainly that the key itself is fine.
+      console.error("[provider-keys] deployment misconfigured:", e.message);
+      return {
+        ok: false,
+        code: "misconfigured",
+        message: ENCRYPTION_UNAVAILABLE_MESSAGE,
+      };
+    }
+    return { ok: false, code: "failed", message: humanError(e) };
+  }
+
+  const { data, error } = await supabase
+    .from("provider_keys")
+    .upsert(
+      { user_id: userId, provider, label, encrypted_key, key_hint },
+      { onConflict: "user_id,provider" },
+    )
+    .select(SUMMARY_COLUMNS)
+    .single();
+
+  if (error || !data) {
+    return { ok: false, code: "failed", message: humanError(error) };
+  }
+  return { ok: true, key: data as ProviderKeySummary };
+}
+
+/**
+ * Delete the account's key for one provider. Returns the removed row's summary,
+ * or null when there was nothing stored — the caller can then answer 404 rather
+ * than reporting a no-op as a successful removal, which would let a typo'd
+ * provider read as "removed".
+ */
+export async function removeProviderKey(
+  supabase: SupabaseClient,
+  userId: string,
+  provider: Provider,
+): Promise<ProviderKeySummary | null> {
+  const { data } = await supabase
+    .from("provider_keys")
+    .delete()
+    .eq("user_id", userId)
+    .eq("provider", provider)
+    .select(SUMMARY_COLUMNS)
+    .maybeSingle();
+  return (data as ProviderKeySummary | null) ?? null;
+}

--- a/lib/provider-keys.ts
+++ b/lib/provider-keys.ts
@@ -85,16 +85,23 @@ export function unknownProviderMessage(): string {
 
 const SUMMARY_COLUMNS = "id, provider, label, key_hint, created_at";
 
-/** The caller's stored keys, hints only. */
+/** The caller's stored keys, hints only.
+ *
+ *  Throws rather than returning [] on a query error. An empty list is a
+ *  meaningful answer here — "you have no keys stored" — so quietly returning it
+ *  for a failed read tells the user something false about their own account,
+ *  and the caller has no way to tell the two apart. Both routes turn a throw
+ *  into a 500. */
 export async function listProviderKeys(
   supabase: SupabaseClient,
   userId: string,
 ): Promise<ProviderKeySummary[]> {
-  const { data } = await supabase
+  const { data, error } = await supabase
     .from("provider_keys")
     .select(SUMMARY_COLUMNS)
     .eq("user_id", userId)
     .order("provider");
+  if (error) throw error;
   return (data as ProviderKeySummary[] | null) ?? [];
 }
 
@@ -173,18 +180,25 @@ export async function setProviderKey(
  * or null when there was nothing stored — the caller can then answer 404 rather
  * than reporting a no-op as a successful removal, which would let a typo'd
  * provider read as "removed".
+ *
+ * A query error throws instead of collapsing into that same null. This is a
+ * revocation path: telling someone "no key is stored" when the delete actually
+ * failed leaves them believing a live credential is gone. Of the two ways to be
+ * wrong about a secret, that is the dangerous one, so a failure has to surface
+ * as a 500 the caller can retry.
  */
 export async function removeProviderKey(
   supabase: SupabaseClient,
   userId: string,
   provider: Provider,
 ): Promise<ProviderKeySummary | null> {
-  const { data } = await supabase
+  const { data, error } = await supabase
     .from("provider_keys")
     .delete()
     .eq("user_id", userId)
     .eq("provider", provider)
     .select(SUMMARY_COLUMNS)
     .maybeSingle();
+  if (error) throw error;
   return (data as ProviderKeySummary | null) ?? null;
 }

--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -15,9 +15,23 @@ describe("resolveRedirectBase", () => {
     expect(resolveRedirectBase("http://localhost", PROD)).toBe(PROD);
   });
 
-  it("still honours a loopback site URL for a genuinely local request", () => {
+  it("keeps a loopback site URL when it already agrees with the request", () => {
     expect(resolveRedirectBase(LOCAL, LOCAL)).toBe(LOCAL);
-    expect(resolveRedirectBase(LOCAL, "http://127.0.0.1:3000")).toBe(LOCAL);
+  });
+
+  // The second outage: the port is part of the origin, so a dev server on any
+  // port other than the configured one stamped the wrong `iss` on its OAuth
+  // callback and every CLI login died on "Issuer mismatch" (RFC 9207 requires
+  // the client to reject that). A loopback config value can never be the
+  // deployment's public identity, so it must never override the real origin.
+  it("defers to the actual origin for a loopback request on another port", () => {
+    expect(resolveRedirectBase(LOCAL, "http://localhost:3100")).toBe("http://localhost:3100");
+    expect(resolveRedirectBase(LOCAL, "http://localhost:3200")).toBe("http://localhost:3200");
+    expect(resolveRedirectBase(LOCAL, "http://127.0.0.1:3000")).toBe("http://127.0.0.1:3000");
+  });
+
+  it("keeps the configured value when the request origin is unusable", () => {
+    expect(resolveRedirectBase(LOCAL, "")).toBe(LOCAL);
   });
 
   it("prefers the configured URL over the request origin behind a proxy", () => {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -34,21 +34,29 @@ function isLoopback(url: string): boolean {
 }
 
 /**
- * The absolute base to build post-auth redirects on.
+ * The absolute base to build post-auth redirects and OAuth `iss` stamps on.
  *
  * Prefers the configured site URL, because behind a proxy the origin parsed off
  * the request can be the internal deployment host rather than the public
- * domain. Two cases fall back to the request origin instead:
+ * domain. It falls back to the request origin when the configured value is
+ * unset or unparseable — and, more importantly, whenever it points at loopback.
  *
- *   - the configured value is unset or unparseable
- *   - it points at loopback while the request didn't
+ * A loopback value can never be the deployment's public identity, so it tells
+ * us nothing the request origin doesn't already say. When the two disagree it
+ * does active harm, in two ways we have both actually shipped:
  *
- * That second case is a real outage we shipped: NEXT_PUBLIC_SITE_URL was left
- * at http://localhost:3000 in production, so every OAuth sign-in exchanged its
- * code correctly, set cookies on the real domain, and then redirected the user
- * to their own machine — where those cookies don't exist. It presents as
- * "signing in silently dumps me back on the login page" with no error anywhere,
- * and a deploy should simply not be able to do it.
+ *   - NEXT_PUBLIC_SITE_URL left at http://localhost:3000 in production. Every
+ *     OAuth sign-in exchanged its code, set cookies on the real domain, and
+ *     then redirected the user to their own machine, where those cookies don't
+ *     exist. It presents as "signing in silently dumps me back on the login
+ *     page", with no error anywhere.
+ *   - The same value against a dev server on any other port. The port is part
+ *     of the origin, so a server on :3100 stamped `iss: http://localhost:3000`
+ *     and every CLI login died on "Issuer mismatch" (RFC 9207 requires the
+ *     client to reject exactly that).
+ *
+ * Hence: loopback never overrides the origin. A deploy, or a second dev server,
+ * should simply not be able to do either of those.
  */
 export function resolveRedirectBase(
   configured: string | null | undefined,
@@ -61,7 +69,9 @@ export function resolveRedirectBase(
   } catch {
     return origin; // malformed env var shouldn't break sign-in
   }
-  if (isLoopback(value) && !isLoopback(origin)) return origin;
+  // `origin` is empty only when the request URL itself was unparseable; in that
+  // case even a loopback configured value beats returning nothing.
+  if (isLoopback(value) && origin) return origin;
   return value;
 }
 

--- a/scripts/harness-provider-keys.ts
+++ b/scripts/harness-provider-keys.ts
@@ -1,0 +1,754 @@
+/**
+ * Integration harness for BYOK provider keys (CLI + `/api/v1/keys`).
+ *
+ * The unit tests mock the network and the database. This does neither: it
+ * drives the real `cli/lettertrace.mjs` binary as a child process against a
+ * real running deployment backed by real Supabase, and asserts on what actually
+ * lands in the database. It is the only thing that can prove the pieces fit
+ * together — that a key typed at the CLI is the same key `lib/crypto` decrypts
+ * back out at run time.
+ *
+ *   npx tsx scripts/harness-provider-keys.ts --url http://localhost:3200
+ *
+ * Requires in .env.local: NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY,
+ * ENCRYPTION_KEY, TRIAL_ANTHROPIC_API_KEY. TRIAL_GOOGLE_API_KEY is optional and
+ * only enables the "catalog is server-derived" check.
+ *
+ * NOT part of `npm test`: it needs a live server, spends a few provider tokens
+ * on key verification, and writes to the database.
+ *
+ * Everything it creates is namespaced to one throwaway user which is deleted in
+ * a `finally` — including when an assertion fails. The user id is printed at
+ * the start so a crashed run can be cleaned up by hand.
+ *
+ * On secrets: the harness holds real provider keys in memory and passes them to
+ * the CLI through files and pipes. It never prints one, and `no output ever
+ * contained the secret` below is an explicit assertion over every byte of
+ * captured stdout/stderr, not an assumption.
+ */
+
+import { spawn } from "node:child_process";
+import { readFileSync, writeFileSync, mkdirSync, rmSync, existsSync } from "node:fs";
+import { dirname, resolve, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { tmpdir } from "node:os";
+import crypto from "node:crypto";
+
+import { createClient } from "@supabase/supabase-js";
+import { decryptSecret, sha256Hex } from "../lib/crypto";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "..");
+
+// --- env ------------------------------------------------------------------
+
+function loadEnvLocal(): void {
+  const raw = readFileSync(resolve(repoRoot, ".env.local"), "utf8");
+  for (const line of raw.split("\n")) {
+    const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*)$/);
+    if (!m) continue;
+    const value = m[2].trim().replace(/^["']|["']$/g, "");
+    if (value && !process.env[m[1]]) process.env[m[1]] = value;
+  }
+}
+loadEnvLocal();
+
+const argv = process.argv.slice(2);
+const flag = (name: string, fallback: string): string => {
+  const i = argv.indexOf(`--${name}`);
+  return i >= 0 && argv[i + 1] ? argv[i + 1] : fallback;
+};
+const BASE = flag("url", "http://localhost:3200").replace(/\/+$/, "");
+
+function requireEnv(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`Missing ${name} in .env.local`);
+  return v;
+}
+
+const SUPABASE_URL = requireEnv("NEXT_PUBLIC_SUPABASE_URL");
+const SERVICE_ROLE = requireEnv("SUPABASE_SERVICE_ROLE_KEY");
+const REAL_ANTHROPIC_KEY = requireEnv("TRIAL_ANTHROPIC_API_KEY");
+const REAL_GOOGLE_KEY = process.env.TRIAL_GOOGLE_API_KEY ?? null;
+requireEnv("ENCRYPTION_KEY"); // used by decryptSecret below
+
+const admin = createClient(SUPABASE_URL, SERVICE_ROLE, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+// --- assertions -----------------------------------------------------------
+
+interface Result {
+  name: string;
+  ok: boolean;
+  detail: string;
+}
+const results: Result[] = [];
+/** Every byte the CLI ever wrote, kept for the leak assertion at the end. */
+const allOutput: string[] = [];
+
+function check(name: string, ok: boolean, detail = ""): void {
+  results.push({ name, ok, detail });
+  const mark = ok ? "\x1b[32mPASS\x1b[0m" : "\x1b[31mFAIL\x1b[0m";
+  console.log(`  ${mark}  ${name}${detail && !ok ? `\n          ${detail}` : ""}`);
+}
+
+function section(title: string): void {
+  console.log(`\n\x1b[1m${title}\x1b[0m`);
+}
+
+// --- running the CLI ------------------------------------------------------
+
+// An isolated HOME so the harness reads and writes its own ~/.lettertrace and
+// can never touch (or be influenced by) the developer's real login.
+const HOME = join(tmpdir(), `lt-harness-${process.pid}`);
+const CONFIG_FILE = join(HOME, ".lettertrace", "config.json");
+
+// The CLI opens a browser by spawning `open`/`xdg-open` off PATH whenever a
+// command needs consent. A test run must never take over the developer's
+// browser — and if it does reach a login, a machine that happens to be signed
+// in will silently complete it and hand the retry a fresh full-scope token,
+// which makes a permission test pass for entirely the wrong reason. So PATH is
+// shimmed with a no-op `open` for every child the harness spawns.
+const SHIM_BIN = join(HOME, "bin");
+function installBrowserShim(): void {
+  mkdirSync(SHIM_BIN, { recursive: true });
+  for (const name of ["open", "xdg-open"]) {
+    writeFileSync(join(SHIM_BIN, name), "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+  }
+}
+const childPath = () => `${SHIM_BIN}:${process.env.PATH ?? ""}`;
+
+interface CliResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+  all: string;
+  json: unknown;
+}
+
+function runCli(
+  args: string[],
+  opts: { stdin?: string; env?: Record<string, string> } = {},
+): Promise<CliResult> {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(process.execPath, [join(repoRoot, "cli", "lettertrace.mjs"), ...args], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        HOME,
+        PATH: childPath(),
+        LETTERTRACE_URL: BASE,
+        // Strip any inherited value so each test controls this explicitly.
+        LETTERTRACE_PROVIDER_KEY: "",
+        NO_COLOR: "1",
+        ...opts.env,
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (d) => (stdout += d));
+    child.stderr.on("data", (d) => (stderr += d));
+    child.on("error", reject);
+    child.on("close", (code) => {
+      const all = stdout + stderr;
+      allOutput.push(all);
+      let json: unknown = null;
+      try {
+        json = JSON.parse(stdout);
+      } catch {
+        /* not every command is --json */
+      }
+      resolvePromise({ code: code ?? -1, stdout, stderr, all, json });
+    });
+
+    if (opts.stdin !== undefined) child.stdin.write(opts.stdin);
+    child.stdin.end();
+  });
+}
+
+/**
+ * Run an inline ES module with the harness's isolated HOME. Used to exercise
+ * the CLI's internals directly when going through a command would drag in the
+ * interactive login flow.
+ */
+function runNode(source: string): Promise<CliResult> {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(process.execPath, ["--input-type=module", "-e", source], {
+      cwd: repoRoot,
+      env: { ...process.env, HOME, PATH: childPath(), LETTERTRACE_URL: BASE, NO_COLOR: "1" },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (d) => (stdout += d));
+    child.stderr.on("data", (d) => (stderr += d));
+    child.on("error", reject);
+    child.on("close", (code) => {
+      const all = stdout + stderr;
+      allOutput.push(all);
+      resolvePromise({ code: code ?? -1, stdout, stderr, all, json: null });
+    });
+  });
+}
+
+// --- direct HTTP, for scope enforcement -----------------------------------
+
+async function api(
+  method: string,
+  path: string,
+  token: string,
+  body?: unknown,
+): Promise<{ status: number; body: Record<string, unknown>; challenge: string }> {
+  const res = await fetch(`${BASE}/api/v1${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...(body ? { "Content-Type": "application/json" } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const text = await res.text();
+  let parsed: Record<string, unknown> = {};
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    parsed = { raw: text.slice(0, 200) };
+  }
+  return {
+    status: res.status,
+    body: parsed,
+    challenge: res.headers.get("www-authenticate") ?? "",
+  };
+}
+
+// --- fixtures -------------------------------------------------------------
+
+/**
+ * Mint an OAuth access token straight into the database with an exact scope
+ * set. The browser consent flow is what normally produces these and it can't be
+ * driven headlessly; going around it is the point here — the harness needs to
+ * present tokens holding scope combinations a user would never be offered
+ * (`keys:read` without `keys:write`) to prove the routes check the right one.
+ */
+async function mintToken(userId: string, scopes: string[]): Promise<string> {
+  const plain = `lt_oauth_${crypto.randomBytes(24).toString("base64url")}`;
+  const { error } = await admin.from("oauth_access_tokens").insert({
+    user_id: userId,
+    client_id: "lt_cli",
+    authorization_id: null,
+    family_id: crypto.randomUUID(),
+    token_hash: sha256Hex(plain),
+    token_hint: `${plain.slice(0, 12)}…${plain.slice(-4)}`,
+    scopes,
+    resource: "v1",
+    expires_at: new Date(Date.now() + 3600_000).toISOString(),
+  });
+  if (error) throw new Error(`Could not mint a token: ${error.message}`);
+  return plain;
+}
+
+function seedCliCredential(token: string, scopes: string[]): void {
+  mkdirSync(dirname(CONFIG_FILE), { recursive: true });
+  writeFileSync(
+    CONFIG_FILE,
+    JSON.stringify(
+      {
+        base: BASE,
+        credentials: {
+          v1: {
+            resource: "v1",
+            access_token: token,
+            refresh_token: null,
+            scope: scopes.join(" "),
+            expires_at: Date.now() + 3600_000,
+          },
+        },
+      },
+      null,
+      2,
+    ),
+    { mode: 0o600 },
+  );
+}
+
+function readCliConfig(): { credentials: Record<string, unknown> } {
+  try {
+    return JSON.parse(readFileSync(CONFIG_FILE, "utf8"));
+  } catch {
+    return { credentials: {} };
+  }
+}
+
+async function storedKeyRow(userId: string, provider: string) {
+  const { data } = await admin
+    .from("provider_keys")
+    .select("provider, encrypted_key, key_hint, label")
+    .eq("user_id", userId)
+    .eq("provider", provider)
+    .maybeSingle();
+  return data;
+}
+
+// --- the harness ----------------------------------------------------------
+
+const ALL_SCOPES = [
+  "projects:read",
+  "projects:write",
+  "runs:read",
+  "runs:trigger",
+  "keys:read",
+  "keys:write",
+];
+
+async function main(): Promise<void> {
+  console.log(`harness → ${BASE}`);
+
+  // Fail fast and legibly if the server isn't up, rather than 30 confusing
+  // assertion failures.
+  try {
+    const ping = await fetch(`${BASE}/api/v1/keys`, { method: "GET" });
+    if (ping.status !== 401) {
+      throw new Error(`expected 401 from an unauthenticated GET, got ${ping.status}`);
+    }
+  } catch (e) {
+    console.error(`\nCannot reach ${BASE}: ${(e as Error).message}`);
+    console.error(`Start one with:  npx next dev -p ${new URL(BASE).port}`);
+    process.exit(2);
+  }
+
+  const email = `lt-harness-${Date.now()}@example.com`;
+  const { data: created, error: userErr } = await admin.auth.admin.createUser({
+    email,
+    password: crypto.randomBytes(18).toString("base64url"),
+    email_confirm: true,
+  });
+  if (userErr || !created.user) throw new Error(`Could not create a test user: ${userErr?.message}`);
+  const userId = created.user.id;
+  console.log(`test user ${email}  (${userId})\n`);
+  installBrowserShim();
+
+  try {
+    // ------------------------------------------------------------------
+    section("Unauthenticated");
+    // ------------------------------------------------------------------
+    {
+      const r = await api("GET", "/keys", "lt_oauth_not-a-real-token");
+      check("a bogus token is rejected", r.status === 401, `got ${r.status}`);
+      const r2 = await fetch(`${BASE}/api/v1/keys`);
+      check("no token at all is rejected", r2.status === 401, `got ${r2.status}`);
+    }
+
+    // ------------------------------------------------------------------
+    section("Issuer identity");
+    // ------------------------------------------------------------------
+    {
+      // Every CLI login ends by comparing the `iss` on the callback against the
+      // base it dialled (RFC 9207 mix-up defense) and aborting with "Issuer
+      // mismatch" if they differ. A deployment that advertises a different
+      // origin than the one you reached it on cannot be logged into at all —
+      // which is what a stale NEXT_PUBLIC_SITE_URL did to every dev server not
+      // running on the configured port.
+      const meta = await fetch(`${BASE}/.well-known/oauth-authorization-server`).then((r) =>
+        r.json(),
+      );
+      check(
+        "the server advertises the origin it was actually reached on",
+        meta.issuer === BASE,
+        `advertised ${meta.issuer}, reached on ${BASE}`,
+      );
+      check(
+        "…and its endpoints point at the same origin",
+        typeof meta.authorization_endpoint === "string" &&
+          meta.authorization_endpoint.startsWith(BASE),
+        `authorization_endpoint is ${meta.authorization_endpoint}`,
+      );
+      check(
+        "…and advertises the keys scopes",
+        Array.isArray(meta.scopes_supported) &&
+          meta.scopes_supported.includes("keys:read") &&
+          meta.scopes_supported.includes("keys:write"),
+        `scopes_supported: ${JSON.stringify(meta.scopes_supported)}`,
+      );
+    }
+
+    // ------------------------------------------------------------------
+    section("Scope enforcement");
+    // ------------------------------------------------------------------
+    {
+      const noKeys = await mintToken(userId, ["projects:read", "projects:write", "runs:read"]);
+      const readOnly = await mintToken(userId, ["keys:read"]);
+      const full = await mintToken(userId, ALL_SCOPES);
+
+      const g = await api("GET", "/keys", noKeys);
+      check("GET /keys without keys:read → 403", g.status === 403, `got ${g.status}`);
+      check(
+        "…and says insufficient_scope in WWW-Authenticate",
+        g.challenge.includes("insufficient_scope"),
+        `challenge was ${JSON.stringify(g.challenge)}`,
+      );
+
+      const p = await api("PUT", "/keys/anthropic", noKeys, { api_key: "x" });
+      check("PUT /keys/:provider without keys:write → 403", p.status === 403, `got ${p.status}`);
+
+      const d = await api("DELETE", "/keys/anthropic", noKeys);
+      check("DELETE /keys/:provider without keys:write → 403", d.status === 403, `got ${d.status}`);
+
+      // The whole reason the scopes are a pair rather than one: a token that can
+      // see which keys exist must not be able to swap the one runs are billed to.
+      const pr = await api("PUT", "/keys/anthropic", readOnly, { api_key: "x" });
+      check("keys:read alone cannot write", pr.status === 403, `got ${pr.status}`);
+
+      const gr = await api("GET", "/keys", readOnly);
+      check("keys:read alone can read", gr.status === 200, `got ${gr.status}`);
+
+      const gf = await api("GET", "/keys", full);
+      check("a full-scope token can read", gf.status === 200, `got ${gf.status}`);
+    }
+
+    // ------------------------------------------------------------------
+    section("Stale token → discard + re-consent (no silent 403)");
+    // ------------------------------------------------------------------
+    {
+      // A CLI that logged in before keys:* existed holds a token that can never
+      // gain them by refreshing. It must drop the credential rather than loop.
+      //
+      // Driven through cli/http.mjs directly rather than the `keys` command,
+      // because the command wraps every call in withAutoLogin — which on
+      // NeedsLogin opens a real browser and blocks on consent. Under a harness
+      // that either hangs or, on a machine already signed in, quietly completes
+      // a login and hands the retry a brand-new full-scope token, which looks
+      // exactly like the discard never happened. This asserts the transport
+      // behaviour that withAutoLogin is reacting to.
+      const stale = await mintToken(userId, ["projects:read", "runs:read"]);
+      seedCliCredential(stale, ["projects:read", "runs:read"]);
+
+      const r = await runNode(`
+        import { rest } from ${JSON.stringify(join(repoRoot, "cli", "http.mjs"))};
+        try {
+          await rest(${JSON.stringify(BASE)}, "GET", "/keys");
+          console.log("UNEXPECTED_SUCCESS");
+        } catch (e) {
+          console.log(JSON.stringify({ name: e.name, message: e.message }));
+        }
+      `);
+      const thrown = JSON.parse(r.stdout.trim() || "{}") as { name?: string; message?: string };
+
+      const cfg = readCliConfig();
+      check(
+        "the stale credential is discarded from config.json",
+        cfg.credentials.v1 === undefined,
+        `config still holds: ${JSON.stringify(Object.keys(cfg.credentials))}`,
+      );
+      check(
+        "…and it surfaces as NeedsLogin, not a raw 403",
+        thrown.name === "NeedsLogin",
+        `threw ${thrown.name}: ${thrown.message}`,
+      );
+      check(
+        "…explaining that the saved sign-in predates the permission",
+        /predates a permission/i.test(thrown.message ?? "") &&
+          /lettertrace login/i.test(thrown.message ?? ""),
+        thrown.message ?? "(no message)",
+      );
+    }
+
+    // ------------------------------------------------------------------
+    section("Refusing a key on the command line");
+    // ------------------------------------------------------------------
+    {
+      const full = await mintToken(userId, ALL_SCOPES);
+      seedCliCredential(full, ALL_SCOPES);
+
+      for (const flagName of ["key", "api-key", "apikey", "secret"]) {
+        const r = await runCli(["keys", "set", "anthropic", `--${flagName}`, REAL_ANTHROPIC_KEY]);
+        check(
+          `--${flagName} is refused`,
+          r.code !== 0 && /not accepted/i.test(r.all),
+          `exit ${r.code}: ${r.all.slice(0, 160)}`,
+        );
+        check(
+          `--${flagName} refusal tells the user to rotate`,
+          /rotate/i.test(r.all),
+          r.all.slice(0, 160),
+        );
+        check(
+          `--${flagName} refusal does not echo the key`,
+          !r.all.includes(REAL_ANTHROPIC_KEY),
+          "the key appeared in output",
+        );
+      }
+      const stored = await storedKeyRow(userId, "anthropic");
+      check("nothing was stored by any refused attempt", stored === null, JSON.stringify(stored));
+    }
+
+    // ------------------------------------------------------------------
+    section("Reading the secret from every supported source");
+    // ------------------------------------------------------------------
+    const keyFile = join(HOME, "anthropic.key");
+    {
+      const full = await mintToken(userId, ALL_SCOPES);
+      seedCliCredential(full, ALL_SCOPES);
+
+      // 1. --key-file, with trailing newline (what `echo > file` produces).
+      writeFileSync(keyFile, `${REAL_ANTHROPIC_KEY}\n`, { mode: 0o600 });
+      let r = await runCli(["keys", "set", "anthropic", "--key-file", keyFile, "--json"]);
+      check("--key-file stores the key", r.code === 0, r.all.slice(0, 200));
+      let row = await storedKeyRow(userId, "anthropic");
+      check(
+        "…and the trailing newline was trimmed, not stored",
+        row !== null && decryptSecret(row.encrypted_key) === REAL_ANTHROPIC_KEY,
+        "decrypted value did not match the key exactly",
+      );
+
+      // THE assertion this whole harness exists for: what the CLI stored is
+      // byte-for-byte what a run will later decrypt and send to the provider.
+      check(
+        "the stored ciphertext decrypts back to the exact key",
+        row !== null && decryptSecret(row.encrypted_key) === REAL_ANTHROPIC_KEY,
+        "round-trip mismatch",
+      );
+      check(
+        "only a masked hint is returned to the client",
+        typeof (r.json as { key?: { key_hint?: string } })?.key?.key_hint === "string" &&
+          !JSON.stringify(r.json).includes(REAL_ANTHROPIC_KEY),
+        JSON.stringify(r.json).slice(0, 200),
+      );
+
+      await admin.from("provider_keys").delete().eq("user_id", userId);
+
+      // 2. The environment variable.
+      r = await runCli(["keys", "set", "anthropic", "--json"], {
+        env: { LETTERTRACE_PROVIDER_KEY: REAL_ANTHROPIC_KEY },
+      });
+      row = await storedKeyRow(userId, "anthropic");
+      check(
+        "$LETTERTRACE_PROVIDER_KEY stores the key",
+        r.code === 0 && row !== null && decryptSecret(row.encrypted_key) === REAL_ANTHROPIC_KEY,
+        r.all.slice(0, 200),
+      );
+      await admin.from("provider_keys").delete().eq("user_id", userId);
+
+      // 3. Piped stdin (non-TTY), the shape a script uses.
+      r = await runCli(["keys", "set", "anthropic", "--json"], { stdin: `${REAL_ANTHROPIC_KEY}\n` });
+      row = await storedKeyRow(userId, "anthropic");
+      check(
+        "piped stdin stores the key",
+        r.code === 0 && row !== null && decryptSecret(row.encrypted_key) === REAL_ANTHROPIC_KEY,
+        r.all.slice(0, 200),
+      );
+      await admin.from("provider_keys").delete().eq("user_id", userId);
+
+      // 4. --key-file - (explicit stdin), the secret-manager shape.
+      r = await runCli(["keys", "set", "anthropic", "--key-file", "-", "--json"], {
+        stdin: REAL_ANTHROPIC_KEY,
+      });
+      row = await storedKeyRow(userId, "anthropic");
+      check(
+        "--key-file - reads stdin",
+        r.code === 0 && row !== null && decryptSecret(row.encrypted_key) === REAL_ANTHROPIC_KEY,
+        r.all.slice(0, 200),
+      );
+      await admin.from("provider_keys").delete().eq("user_id", userId);
+
+      // 5. Precedence: an explicit --key-file must beat a stale exported var,
+      //    or a forgotten export silently overrides what the user just asked for.
+      writeFileSync(keyFile, REAL_ANTHROPIC_KEY, { mode: 0o600 });
+      r = await runCli(["keys", "set", "anthropic", "--key-file", keyFile, "--json"], {
+        env: { LETTERTRACE_PROVIDER_KEY: "sk-ant-this-should-lose" },
+      });
+      row = await storedKeyRow(userId, "anthropic");
+      check(
+        "--key-file wins over $LETTERTRACE_PROVIDER_KEY",
+        r.code === 0 && row !== null && decryptSecret(row.encrypted_key) === REAL_ANTHROPIC_KEY,
+        r.all.slice(0, 200),
+      );
+      await admin.from("provider_keys").delete().eq("user_id", userId);
+    }
+
+    // ------------------------------------------------------------------
+    section("Bad input is reported without leaking or storing");
+    // ------------------------------------------------------------------
+    {
+      const emptyFile = join(HOME, "empty.key");
+      writeFileSync(emptyFile, "   \n");
+      let r = await runCli(["keys", "set", "anthropic", "--key-file", emptyFile]);
+      check("an empty key file is rejected", r.code !== 0 && /empty/i.test(r.all), r.all.slice(0, 160));
+
+      const missing = join(HOME, "nope.key");
+      r = await runCli(["keys", "set", "anthropic", "--key-file", missing]);
+      check(
+        "a missing key file names the path, not the contents",
+        r.code !== 0 && r.all.includes("nope.key"),
+        r.all.slice(0, 160),
+      );
+
+      r = await runCli(["keys", "set", "not-a-provider", "--key-file", keyFile]);
+      check(
+        "an unknown provider is rejected before the secret is read",
+        r.code !== 0 && /unknown provider/i.test(r.all),
+        r.all.slice(0, 160),
+      );
+
+      // A syntactically plausible but invalid key: the provider must reject it,
+      // and the failure must be attributed to the key — not to the deployment.
+      r = await runCli(["keys", "set", "anthropic", "--json"], {
+        env: { LETTERTRACE_PROVIDER_KEY: "sk-ant-api03-definitely-not-valid-0000" },
+      });
+      const row = await storedKeyRow(userId, "anthropic");
+      check("an invalid key is refused by the provider", r.code !== 0, `exit ${r.code}`);
+      check("…and nothing is stored", row === null, JSON.stringify(row));
+      check(
+        "…and the message blames the key, not the encryption config",
+        /invalid|incorrect|api key/i.test(r.all) && !/encryption/i.test(r.all),
+        r.all.slice(0, 200),
+      );
+    }
+
+    // ------------------------------------------------------------------
+    section("List, rotate, remove");
+    // ------------------------------------------------------------------
+    {
+      let r = await runCli(["keys", "--json"]);
+      const listed = r.json as { keys?: unknown[]; providers?: { id: string }[] };
+      check("keys list returns the provider catalog", (listed.providers?.length ?? 0) > 0, r.all.slice(0, 200));
+      check(
+        "the catalog is server-derived, so Gemini appears without a CLI change",
+        (listed.providers ?? []).some((p) => p.id === "google"),
+        `saw: ${(listed.providers ?? []).map((p) => p.id).join(", ")}`,
+      );
+      check("nothing is stored yet", (listed.keys?.length ?? 0) === 0, JSON.stringify(listed.keys));
+
+      // Set, then set again — PUT is meant to be honestly idempotent, so
+      // rotating is the same request as setting and needs no delete first.
+      await runCli(["keys", "set", "anthropic", "--key-file", keyFile, "--label", "first", "--json"]);
+      r = await runCli(["keys", "set", "anthropic", "--key-file", keyFile, "--label", "second", "--json"]);
+      check("setting an existing key rotates it in place", r.code === 0, r.all.slice(0, 200));
+
+      const { count } = await admin
+        .from("provider_keys")
+        .select("*", { count: "exact", head: true })
+        .eq("user_id", userId)
+        .eq("provider", "anthropic");
+      check("…leaving exactly one row, not two", count === 1, `found ${count}`);
+
+      const row = await storedKeyRow(userId, "anthropic");
+      check("…and the label was updated", row?.label === "second", `label is ${row?.label}`);
+
+      r = await runCli(["keys", "--json"]);
+      const after = r.json as { keys?: { provider: string; key_hint: string }[] };
+      const anth = (after.keys ?? []).find((k) => k.provider === "anthropic");
+      check("the stored key is listed", Boolean(anth), JSON.stringify(after.keys));
+      check(
+        "…as a masked hint only",
+        Boolean(anth) && !anth!.key_hint.includes(REAL_ANTHROPIC_KEY.slice(10, 30)),
+        anth?.key_hint,
+      );
+
+      r = await runCli(["keys", "remove", "anthropic", "--json"]);
+      check("remove succeeds", r.code === 0, r.all.slice(0, 200));
+      check("…and the row is gone", (await storedKeyRow(userId, "anthropic")) === null);
+
+      r = await runCli(["keys", "remove", "anthropic", "--json"]);
+      check(
+        "removing again is an error, not a cheerful no-op",
+        r.code !== 0 && /no anthropic key|not.*stored/i.test(r.all),
+        r.all.slice(0, 200),
+      );
+    }
+
+    // ------------------------------------------------------------------
+    section("Gemini, end to end through the CLI");
+    // ------------------------------------------------------------------
+    if (REAL_GOOGLE_KEY) {
+      const r = await runCli(["keys", "set", "google", "--json"], {
+        env: { LETTERTRACE_PROVIDER_KEY: REAL_GOOGLE_KEY },
+      });
+      const row = await storedKeyRow(userId, "google");
+      check("a Google key verifies and stores", r.code === 0, r.all.slice(0, 200));
+      check(
+        "…and decrypts back to the exact key",
+        row !== null && decryptSecret(row.encrypted_key) === REAL_GOOGLE_KEY,
+        "round-trip mismatch",
+      );
+      await runCli(["keys", "remove", "google", "--json"]);
+    } else {
+      check("a Google key verifies and stores", true, "skipped: no TRIAL_GOOGLE_API_KEY");
+    }
+
+    // ------------------------------------------------------------------
+    section("Nothing leaked");
+    // ------------------------------------------------------------------
+    {
+      const combined = allOutput.join("\n");
+      check(
+        "no CLI output ever contained a plaintext key",
+        !combined.includes(REAL_ANTHROPIC_KEY) &&
+          (!REAL_GOOGLE_KEY || !combined.includes(REAL_GOOGLE_KEY)),
+        "a plaintext key appeared in CLI output",
+      );
+
+      // The activity feed records every write; a key must not ride along in it.
+      const { data: logs } = await admin
+        .from("activity_logs")
+        .select("category, action, channel, status, summary, metadata")
+        .eq("user_id", userId);
+      const serialized = JSON.stringify(logs ?? []);
+      check(
+        "no plaintext key reached the activity log",
+        !serialized.includes(REAL_ANTHROPIC_KEY) &&
+          (!REAL_GOOGLE_KEY || !serialized.includes(REAL_GOOGLE_KEY)),
+        "a plaintext key appeared in activity_logs",
+      );
+
+      const keyEvents = (logs ?? []).filter((l) => l.category === "provider_key");
+      check(
+        "…which still recorded the writes",
+        keyEvents.some((l) => l.action === "provider_key.saved") &&
+          keyEvents.some((l) => l.action === "provider_key.removed"),
+        `saw actions: ${[...new Set(keyEvents.map((l) => l.action))].join(", ") || "(none)"}`,
+      );
+      check(
+        "…attributed to the cli channel, so an agent's write is distinguishable",
+        keyEvents.length > 0 && keyEvents.every((l) => l.channel === "cli"),
+        `channels: ${[...new Set(keyEvents.map((l) => l.channel))].join(", ") || "(none)"}`,
+      );
+      check(
+        "…including the failures, recorded as failures",
+        keyEvents.some((l) => l.status === "failure"),
+        `statuses: ${[...new Set(keyEvents.map((l) => l.status))].join(", ")}`,
+      );
+
+      check(
+        "the CLI config file holds no provider key",
+        !readFileSync(CONFIG_FILE, "utf8").includes(REAL_ANTHROPIC_KEY),
+        "the key was persisted to config.json",
+      );
+    }
+  } finally {
+    // Unconditional: a failed assertion must not leave a user, tokens, or keys
+    // behind in a real database.
+    await admin.from("provider_keys").delete().eq("user_id", userId);
+    await admin.from("oauth_access_tokens").delete().eq("user_id", userId);
+    await admin.auth.admin.deleteUser(userId).catch(() => {});
+    if (existsSync(HOME)) rmSync(HOME, { recursive: true, force: true });
+    console.log(`\ncleaned up ${email}`);
+  }
+
+  const failed = results.filter((r) => !r.ok);
+  console.log(
+    `\n${results.length - failed.length}/${results.length} passed` +
+      (failed.length ? `, \x1b[31m${failed.length} failed\x1b[0m` : ""),
+  );
+  if (failed.length) {
+    for (const f of failed) console.log(`  \x1b[31m✗\x1b[0m ${f.name}`);
+    process.exit(1);
+  }
+}
+
+main().catch((e) => {
+  console.error(`\nharness aborted: ${(e as Error).message}`);
+  process.exit(2);
+});

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -558,7 +558,8 @@ insert into public.oauth_clients
 values
   ('lt_cli', true, 'Lettertrace CLI & MCP', 'public', 'none',
    array['http://127.0.0.1/callback', 'http://[::1]/callback'],
-   array['projects:read', 'projects:write', 'runs:read', 'runs:trigger', 'offline_access'])
+   array['projects:read', 'projects:write', 'runs:read', 'runs:trigger',
+         'keys:read', 'keys:write', 'offline_access'])
 on conflict (client_id) do update set
   is_first_party = excluded.is_first_party,
   client_name = excluded.client_name,


### PR DESCRIPTION
Adds BYOK provider-key management to the CLI and the v1 API, so an account can be
set up end to end from a terminal without ever opening the dashboard.

```bash
lettertrace keys                        # every supported provider, and which have a key
lettertrace keys set anthropic          # hidden prompt, verified on save, encrypted
lettertrace keys set anthropic --label "team account"
lettertrace keys remove openai
```

## The key is never a command-line argument

`--key`, `--api-key`, `--apikey`, and `--secret` are **rejected outright** with a
message telling you to rotate that key — by the time the CLI sees the flag, the
value is already in your shell history and was readable in `ps` by every process
on the box. There is no un-leaking it, so accepting it quietly would be the worse
behaviour.

The key is read from the first available of:

| Source | For |
|---|---|
| `--key-file <path>` (`-` = stdin) | a secret manager writing a file or a pipe |
| `$LETTERTRACE_PROVIDER_KEY` | CI, where a pipe is awkward |
| piped stdin | scripts |
| hidden interactive prompt | a human at a terminal |

The prompt renders nothing as you type — not even asterisks, which would put the
key's length on screen and into any screen recording. Raw mode is restored on
Ctrl-C so an aborted prompt can't leave the terminal wedged.

Nothing on the path logs, echoes, or persists a plaintext key. Only the masked
hint (`sk-ant-…4a9c`) is ever returned.

## API

Three new v1 routes, plus the shared module they and the dashboard now both use:

- `GET /api/v1/keys` — masked hints plus the supported-provider catalog (`keys:read`)
- `PUT /api/v1/keys/:provider` — verify → encrypt → store, idempotent, so setting
  and rotating are the same request (`keys:write`)
- `DELETE /api/v1/keys/:provider` — 404 rather than a cheerful 200 when nothing
  was stored, so a script that thinks it revoked a key isn't quietly wrong

The key travels in the JSON body only: never a query parameter (proxies log those
verbatim) and never a path segment.

**The provider catalog comes from the server**, so adding a provider to
`lib/models.ts` — Gemini, Perplexity — surfaces in `lettertrace keys` with no CLI
change.

## Two failures kept apart

Carried over from #20 and preserved through the refactor:

- **400** — the provider rejected the key. Yours to fix.
- **503** — the key is fine, but the deployment's `ENCRYPTION_KEY` is missing or
  malformed, so nothing was stored. The operator's to fix.

A user is never told to rotate a key that was perfectly good.

## New scopes — needs a schema re-run

`keys:read` and `keys:write` are deliberately **not** folded into `projects:write`.
Swapping the key that every run is billed to is a different decision from adding a
prompt, and the consent screen is the only place a user ever gets to make it.

The cost: `supabase/schema.sql` must be re-run so the `lt_cli` client is allowed to
request them, and a token minted before they existed can't hold them. The CLI
detects the resulting RFC 6750 `insufficient_scope` challenge (from the
`WWW-Authenticate` header, not the prose message), discards the stale token, and
relaunches browser consent by itself — one extra approval, no confusing 403.

## Scope note for review

`POST /api/keys` (the dashboard route) was refactored onto the same
`lib/provider-keys.ts` rather than duplicating verify → encrypt → store. That's
wider than "add a CLI command", and worth a look — but two copies of the code that
decides whether a key is valid would drift, and this is the half where being wrong
means either storing an unusable key or blaming a user for our misconfiguration.

## Tests

`lib/provider-keys.test.ts` (shared module: provider parsing, verification
outcomes, the `ConfigurationError` → 503 mapping) and `app/api/v1/keys-routes.test.ts`
(scope enforcement on every route, body handling, the 404-on-nothing-stored case).

**214 passing**, typecheck clean.

## To deploy

1. Re-run `supabase/schema.sql` — without it, `keys` commands 403.
2. Existing CLI users re-approve once, automatically prompted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
