### PR TITLE
Honour Gemini's retry window on a 429, and explain what a 429 means

### DIFF
--- a/lib/llm/google.test.ts
+++ b/lib/llm/google.test.ts
@@ -481,6 +481,67 @@ describe("google HTTP errors", () => {
     expect(fetchMock).toHaveBeenCalledTimes(4);
   });
 
+  // The failure Casey hit on the first real production run: a single-prompt run
+  // burned all four attempts in about three seconds because the backoff ignored
+  // the quota window Google had just told us about, then reported "rate
+  // limited" as though nothing could be done.
+  it("waits as long as a 429's RetryInfo asks, not the exponential backoff", async () => {
+    vi.useFakeTimers();
+    mockFetch(
+      jsonResponse(
+        {
+          error: {
+            code: 429,
+            message: "Quota exceeded",
+            status: "RESOURCE_EXHAUSTED",
+            details: [
+              { "@type": "type.googleapis.com/google.rpc.RetryInfo", retryDelay: "12s" },
+            ],
+          },
+        },
+        429,
+      ),
+      jsonResponse(ok("hi")),
+    );
+    const p = runQuery({ provider: "google", model: "gemini-pro-latest", apiKey: KEY, prompt: "q" });
+
+    // The old 400ms backoff would have fired the retry by now — and hit the
+    // same spent quota window, which is exactly the bug.
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(11_000);
+    await expect(p).resolves.toMatchObject({ text: "hi" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("gives up rather than blocking on a quota window it can't wait out", async () => {
+    vi.useFakeTimers();
+    mockFetch(
+      jsonResponse(
+        {
+          error: {
+            code: 429,
+            message: "Quota exceeded",
+            status: "RESOURCE_EXHAUSTED",
+            // A per-day quota. Waiting is not an option; failing fast with a
+            // message that says so is.
+            details: [
+              { "@type": "type.googleapis.com/google.rpc.RetryInfo", retryDelay: "3600s" },
+            ],
+          },
+        },
+        429,
+      ),
+    );
+    const p = runQuery({ provider: "google", model: "gemini-pro-latest", apiKey: KEY, prompt: "q" });
+    const rejected = expect(p).rejects.toThrow(/Quota exceeded/);
+    await vi.runAllTimersAsync();
+    await rejected;
+    // One attempt, no retry: the advised wait exceeded what we will block for.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("retries a dropped connection", async () => {
     vi.useFakeTimers();
     let calls = 0;
@@ -570,8 +631,23 @@ describe("humanError for google", () => {
     ).toBe("Invalid API key.");
   });
 
-  it("maps quota, access, retired models and server errors", () => {
-    expect(humanError(new GoogleAPIError(429, "Quota exceeded"))).toBe("Rate limited by the provider.");
+  // "Rate limited by the provider" reads as "we went too fast" and invites a
+  // pointless immediate retry. A Gemini 429 is a spent quota on the key.
+  it("explains a 429 as a quota problem, not a speed problem", () => {
+    const msg = humanError(new GoogleAPIError(429, "Quota exceeded", "RESOURCE_EXHAUSTED"));
+    expect(msg).toMatch(/quota/i);
+    expect(msg).toMatch(/Google AI Studio/);
+    expect(msg).not.toBe("Rate limited by the provider.");
+  });
+
+  it("includes the wait Google asked for when it gave one", () => {
+    const msg = humanError(
+      new GoogleAPIError(429, "Quota exceeded", "RESOURCE_EXHAUSTED", 38),
+    );
+    expect(msg).toMatch(/wait 38s/);
+  });
+
+  it("maps access, retired models and server errors", () => {
     expect(humanError(new GoogleAPIError(403, "no access"))).toBe(
       "This key lacks access to the requested model.",
     );

--- a/lib/llm/index.ts
+++ b/lib/llm/index.ts
@@ -326,6 +326,14 @@ const GOOGLE_TIMEOUT_MS = 60_000;
 const GOOGLE_MAX_ATTEMPTS = 4;
 // HTTP statuses worth retrying (transient); everything else fails fast.
 const GOOGLE_RETRYABLE = new Set([429, 500, 503, 504]);
+// The longest single wait we'll honour from a 429's RetryInfo. Past this the
+// quota window is long enough that blocking the request is worse than failing
+// with a message that says what to do about it.
+const GOOGLE_MAX_RETRY_WAIT_MS = 45_000;
+// Total time one call may spend asleep across all its retries. The run route
+// allows 300s for every prompt in the run, so a single prompt must not be able
+// to eat it and starve the rest.
+const GOOGLE_RETRY_BUDGET_MS = 90_000;
 // The real Gemini model the "Google AI Overviews" engine runs on. AI Overviews
 // are served by a fast Gemini model over Google Search, so we back them with
 // Flash and always ground the answer in Search.
@@ -349,12 +357,35 @@ const GOOGLE_THINKING_HEADROOM = 4096;
 export class GoogleAPIError extends Error {
   status: number;
   googleStatus?: string;
-  constructor(status: number, message: string, googleStatus?: string) {
+  /** Seconds Google itself asked us to wait, from google.rpc.RetryInfo. Only
+   *  ever present on 429s, and the only trustworthy source for how long a quota
+   *  window has left to run. */
+  retryAfterSec?: number;
+  constructor(status: number, message: string, googleStatus?: string, retryAfterSec?: number) {
     super(message);
     this.name = "GoogleAPIError";
     this.status = status;
     this.googleStatus = googleStatus;
+    this.retryAfterSec = retryAfterSec;
   }
+}
+
+/**
+ * Pull the advised wait out of a google.rpc.RetryInfo detail, in seconds.
+ *
+ * A Gemini 429 carries `details: [{ "@type": ".../google.rpc.RetryInfo",
+ * retryDelay: "38s" }]`. That number is the quota window, not a hint: backing
+ * off 400ms and retrying is guaranteed to fail again, which is how a run with a
+ * single prompt burned all four attempts in about three seconds and reported
+ * "Rate limited by the provider" as if nothing could be done.
+ */
+function googleRetryAfterSec(errBody: GoogleResponse): number | undefined {
+  for (const d of errBody.error?.details ?? []) {
+    if (typeof d?.retryDelay !== "string") continue;
+    const secs = Number.parseFloat(d.retryDelay);
+    if (Number.isFinite(secs) && secs >= 0) return secs;
+  }
+  return undefined;
 }
 
 interface GoogleGroundingChunk {
@@ -373,7 +404,13 @@ interface GoogleResponse {
     thoughtsTokenCount?: number;
     totalTokenCount?: number;
   };
-  error?: { code?: number; message?: string; status?: string };
+  error?: {
+    code?: number;
+    message?: string;
+    status?: string;
+    // google.rpc error details; RetryInfo is the one we act on.
+    details?: { "@type"?: string; retryDelay?: string }[];
+  };
 }
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
@@ -386,6 +423,7 @@ function resolveGoogleModel(model: string): string {
 
 async function googleFetch(realModel: string, apiKey: string, body: unknown): Promise<GoogleResponse> {
   let lastErr: unknown;
+  let sleptMs = 0;
   for (let attempt = 0; attempt < GOOGLE_MAX_ATTEMPTS; attempt++) {
     try {
       const res = await fetch(`${GOOGLE_API_BASE}/models/${realModel}:generateContent`, {
@@ -400,6 +438,7 @@ async function googleFetch(realModel: string, apiKey: string, body: unknown): Pr
         res.status,
         errBody.error?.message ?? `Google API error (${res.status}).`,
         errBody.error?.status,
+        googleRetryAfterSec(errBody),
       );
       // Retry transient statuses; surface auth/quota/bad-request immediately.
       if (!GOOGLE_RETRYABLE.has(res.status)) throw gerr;
@@ -410,7 +449,19 @@ async function googleFetch(realModel: string, apiKey: string, body: unknown): Pr
       if (err instanceof GoogleAPIError && !GOOGLE_RETRYABLE.has(err.status)) throw err;
       lastErr = err;
     }
-    if (attempt < GOOGLE_MAX_ATTEMPTS - 1) await sleep(400 * 2 ** attempt);
+    if (attempt >= GOOGLE_MAX_ATTEMPTS - 1) break;
+
+    // Honour Google's own RetryInfo when it gave one — a 429's quota window
+    // does not care about our exponential backoff. Two guards keep that from
+    // becoming a hang: a single wait longer than GOOGLE_MAX_RETRY_WAIT_MS is
+    // not worth blocking a request for, and the waits across one call are
+    // capped so the run route's 300s budget still covers the other prompts.
+    const advised = lastErr instanceof GoogleAPIError ? lastErr.retryAfterSec : undefined;
+    const backoffMs = 400 * 2 ** attempt;
+    const waitMs = advised !== undefined ? Math.max(advised * 1000, backoffMs) : backoffMs;
+    if (waitMs > GOOGLE_MAX_RETRY_WAIT_MS || sleptMs + waitMs > GOOGLE_RETRY_BUDGET_MS) break;
+    await sleep(waitMs);
+    sleptMs += waitMs;
   }
   throw lastErr ?? new Error("Google request failed.");
 }
@@ -953,7 +1004,19 @@ export function humanError(err: unknown): string {
   if (err instanceof GoogleAPIError) {
     // Google returns a bad key as 400 INVALID_ARGUMENT with an "API key not
     // valid" message (not 401), so match on the message as well as the status.
-    if (err.status === 429) return "Rate limited by the provider.";
+    if (err.status === 429) {
+      // "Rate limited" alone reads as "we went too fast, try again" — but a
+      // Gemini 429 is almost always a spent per-minute or per-day quota on the
+      // key, which retrying will not fix. Say which, and say what to do.
+      const wait =
+        err.retryAfterSec !== undefined && err.retryAfterSec > 0
+          ? ` Google asked us to wait ${Math.ceil(err.retryAfterSec)}s.`
+          : "";
+      return (
+        `Google rejected the request: this key's quota is used up.${wait} ` +
+        `Free-tier and trial keys allow only a few requests per minute — check the key's quota in Google AI Studio, or wait and run again.`
+      );
+    }
     if (err.status >= 500) return "The AI provider had a temporary error. Please try again.";
     if (err.status === 401 || /api[_ ]?key.*(not valid|invalid)|api_key_invalid/i.test(err.message)) {
       return "Invalid API key.";


### PR DESCRIPTION
Found by the first real production Gemini run, which failed in about three seconds:

> **failed** · Gemini Pro · 0 / 1 answers · Rate limited by the provider.

## What went wrong

A Gemini 429 carries `google.rpc.RetryInfo` in its error details telling us exactly how long the quota window has left — commonly ~38s:

```json
{"error":{"code":429,"status":"RESOURCE_EXHAUSTED",
  "details":[{"@type":"…/google.rpc.RetryInfo","retryDelay":"38s"}]}}
```

We ignored it and used a 400ms–1.6s exponential backoff, so all four attempts hit the *same* spent window within ~3s. On a one-prompt run that's the entire run failing about as fast as the button can be clicked.

The audit flagged this and deliberately left it, reasoning that a 38s wait can't fit a 60s route budget. That reasoning was right for `/api/topics/[id]/generate` and `/api/competitors/suggest` — but **the run routes are `maxDuration = 300`**, so waiting is entirely affordable there. The deferral was based on the wrong route's budget.

## The fix

Honour the advised delay, bounded two ways so it can never hang a request:

- a single wait over **45s** is refused outright — a per-day quota is not something to block a request on, and failing fast with a useful message beats a timeout
- total sleep per call is capped at **90s**, so one prompt can't eat the run's 300s and starve the others

## The message was its own bug

`"Rate limited by the provider."` reads as *"we went too fast, try again"* and invites an immediate pointless retry. A Gemini 429 is nearly always a **spent quota on the key** — which is exactly what a free-tier or trial key does on its first real run. It now names the quota, includes the wait Google asked for, and points at where to check it:

> Google rejected the request: this key's quota is used up. Google asked us to wait 38s. Free-tier and trial keys allow only a few requests per minute — check the key's quota in Google AI Studio, or wait and run again.

## Tests

Three new cases in `lib/llm/google.test.ts`, all mocked, no network:

- honours a 12s `RetryInfo` instead of the 400ms backoff — asserted behaviourally (no retry at 2s, success after 13s), so reverting to plain backoff fails it
- refuses to block on a 3600s per-day quota — one attempt, no retry
- the 429 message names the quota and includes the advised wait

Mutation-tested: reverting the wait calculation to plain `backoffMs` fails exactly these two. **249 passing**, typecheck clean.

## Note on what this does *not* fix

If a key's quota is genuinely exhausted, the run still fails — correctly. This makes the retry honest and the failure legible; it doesn't manufacture quota. The trial/express-mode keys (`AQ.…` prefix) have very little of it; a standard AI Studio key (`AIza…`) is the fix for that.
