### PR TITLE
Add Perplexity (Sonar) as an answer engine

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,7 @@ OAUTH_REFRESH_GRACE=10         # refresh-retry idempotency window, seconds
 TRIAL_ANTHROPIC_API_KEY=
 TRIAL_OPENAI_API_KEY=
 TRIAL_GOOGLE_API_KEY=
+TRIAL_PERPLEXITY_API_KEY=
 # Free monitoring runs per user before they must add their own key (default 5).
 # THIS is the configurable trial threshold. Consumed atomically at run start.
 TRIAL_RUN_LIMIT=5
@@ -57,6 +58,7 @@ TRIAL_RUN_LIMIT=5
 TRIAL_ANTHROPIC_MODEL=claude-haiku-4-5
 TRIAL_OPENAI_MODEL=gpt-4o-mini
 TRIAL_GOOGLE_MODEL=gemini-flash-lite-latest
+TRIAL_PERPLEXITY_MODEL=sonar
 # Optional: embeddable video URL (e.g. a YouTube embed link) explaining the
 # bring-your-own-key model, shown when a user's free runs are used up.
 NEXT_PUBLIC_BYOK_VIDEO_URL=
@@ -68,6 +70,7 @@ NEXT_PUBLIC_BYOK_VIDEO_URL=
 ANALYSIS_ANTHROPIC_MODEL=
 ANALYSIS_OPENAI_MODEL=
 ANALYSIS_GOOGLE_MODEL=
+ANALYSIS_PERPLEXITY_MODEL=
 
 # ------------------------------------------------------------------
 # NOTE: This app is Bring-Your-Own-Key (BYOK). Users add their own

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Track topics · auto-generate the questions people actually ask AI · watch tren
 
 Lettertrace is a self-hostable clone of tools like Profound / AthenaHQ / AirOps, focused purely on **diagnosing and monitoring AI mentions** (a.k.a. Answer Engine Optimization / Generative Engine Optimization). You describe your brand and a few topics; Lettertrace generates realistic prompts a person might ask ChatGPT or Claude, runs them against those models **with your own API key**, detects when your brand and your competitors get mentioned, and charts how your visibility, sentiment, and share of voice move over time.
 
-- 🔓 **Open source** (MIT) and **BYOK**, you bring your own Anthropic / OpenAI / Google keys. They're encrypted at rest and never leave your infrastructure.
-- 🧠 **Multi-model**, query Claude (Anthropic), ChatGPT (OpenAI), Gemini, and Google AI Overviews (both on your Google key). Add more providers easily.
+- 🔓 **Open source** (MIT) and **BYOK**, you bring your own Anthropic / OpenAI / Google / Perplexity keys. They're encrypted at rest and never leave your infrastructure.
+- 🧠 **Multi-model**, query Claude (Anthropic), ChatGPT (OpenAI), Gemini and Google AI Overviews (both on your Google key), and Perplexity Sonar. Add more providers easily.
 - 🧩 **Topics → variations**, auto-generate the different questions people ask AI about each topic.
 - 📈 **Trends over time**, visibility, share of voice, prominence, and sentiment across runs.
 - ⚔️ **Competitor benchmarking**, ingest competitors and see how often each shows up.
@@ -45,7 +45,7 @@ For each answer the model returns, Lettertrace:
 - **Next.js 14** (App Router, TypeScript) · **Tailwind CSS** · **Recharts**
 - **Supabase**, Postgres, Auth, and Row Level Security
 - **BYOK** provider keys encrypted with **AES-256-GCM** at rest
-- Anthropic (`@anthropic-ai/sdk`) + OpenAI (`openai`) SDK adapters, plus a dependency-free Google Gemini REST adapter (Gemini models + Google AI Overviews, via Google Search grounding)
+- Anthropic (`@anthropic-ai/sdk`) + OpenAI (`openai`) SDK adapters, plus dependency-free REST adapters for Google Gemini (Gemini models + Google AI Overviews, via Google Search grounding) and Perplexity Sonar (always search-grounded, real source URLs)
 
 ## Getting started
 
@@ -124,7 +124,7 @@ Open [http://localhost:3000](http://localhost:3000), create an account, and you'
 
 ### 5. First monitor
 
-1. **Settings** → add your Anthropic, OpenAI, and/or Google API key (verified on save, encrypted at rest), then fill in your **brand & project** (name, aliases, and the answer engine to monitor with, including Gemini or Google AI Overviews). Prefer a terminal? [`lettertrace keys set anthropic`](#setting-your-provider-key-from-the-cli-keys) does the same thing.
+1. **Settings** → add your Anthropic, OpenAI, Google, and/or Perplexity API key (verified on save, encrypted at rest), then fill in your **brand & project** (name, aliases, and the answer engine to monitor with, including Gemini or Google AI Overviews). Prefer a terminal? [`lettertrace keys set anthropic`](#setting-your-provider-key-from-the-cli-keys) does the same thing.
 2. **Competitors** → add the brands you want to benchmark against.
 3. **Topics** → add a topic and click **Generate variations** to auto-create prompts (or add your own).
 4. **Runs** → **Run monitor now**. When it finishes, the **Overview** fills in with visibility, share of voice, sentiment, and per-topic breakdowns.

--- a/app/dashboard/settings/keys-manager.tsx
+++ b/app/dashboard/settings/keys-manager.tsx
@@ -41,6 +41,12 @@ const PROVIDER_STYLE: Record<
     mark: "✦",
     markClass: "bg-butter-tint text-butter-ink",
   },
+  perplexity: {
+    title: "Perplexity",
+    subtitle: "Sonar API key · answers are always search-grounded",
+    mark: "P",
+    markClass: "bg-mint-tint text-mint-ink",
+  },
 };
 
 export default function KeysManager({

--- a/lib/llm/index.ts
+++ b/lib/llm/index.ts
@@ -664,6 +664,11 @@ const PERPLEXITY_RETRYABLE = new Set([429, 500, 502, 503, 504]);
 // key starts on a low usage tier, so 429s are a first-run experience, not an
 // edge case.
 const PERPLEXITY_MAX_RETRY_WAIT_MS = 45_000;
+// Perplexity rejects anything smaller with 400 "max_tokens must be at least 16"
+// — measured. The other adapters happily take a 4-8 token probe, so the tiny
+// verifyKey budget copied from them made a VALID key look broken. Clamped here
+// rather than at the call sites so no future caller can reintroduce it.
+const PERPLEXITY_MIN_MAX_TOKENS = 16;
 const PERPLEXITY_RETRY_BUDGET_MS = 90_000;
 
 export class PerplexityAPIError extends Error {
@@ -808,7 +813,7 @@ async function perplexityGenerate(
   const data = await perplexityFetch(apiKey, {
     model,
     messages,
-    max_tokens: opts.maxTokens,
+    max_tokens: Math.max(opts.maxTokens, PERPLEXITY_MIN_MAX_TOKENS),
     // Perplexity searches by default; the utility calls (JSON classification,
     // topic suggestion) must not, both because searching is pure cost there and
     // because a search result could contaminate a judgment about text we gave it.

--- a/lib/llm/index.ts
+++ b/lib/llm/index.ts
@@ -153,6 +153,8 @@ export async function verifyKey(
       await anthropicChat(apiKey, "claude-haiku-4-5", undefined, "ping", 4);
     } else if (provider === "google") {
       await googleChat(apiKey, "gemini-flash-lite-latest", undefined, "ping", 8);
+    } else if (provider === "perplexity") {
+      await perplexityChat(apiKey, "sonar", undefined, "ping", 8);
     } else {
       await openaiChat(apiKey, "gpt-4o-mini", undefined, "ping", 4);
     }
@@ -175,6 +177,10 @@ export async function runQuery(
   // Overviews engine), so route it before the shared web-search branch.
   if (opts.provider === "google") {
     return googleRunQuery(opts.apiKey, opts.model, opts.prompt, opts.webSearch ?? false);
+  }
+  // Perplexity always searches, so it ignores the project toggle entirely.
+  if (opts.provider === "perplexity") {
+    return perplexityRunQuery(opts.apiKey, opts.model, opts.prompt);
   }
   if (!opts.webSearch) {
     const res =
@@ -635,6 +641,237 @@ async function googleRunQuery(
   return { text, tokens, sources: grounding ? googleGroundingSources(groundingChunks) : [] };
 }
 
+// ==================================================================
+// Perplexity (Sonar)
+//
+// Raw fetch rather than the OpenAI SDK. Perplexity does accept
+// /chat/completions as an OpenAI-compatible alias, but the fields we care about
+// most — `search_results` and `citations` — aren't part of the OpenAI response
+// type, so that route means casting past the type system to reach the single
+// most valuable half of the payload. `/v1/sonar` is the canonical endpoint and
+// this adapter needs no SDK at all, same as the Google one.
+//
+// Perplexity is search-native: every answer is grounded, and the sources come
+// back as real URLs with titles and snippets. No redirect host to unwrap (the
+// Gemini grounding problem), so `is_owned` matching works directly.
+// ==================================================================
+
+const PERPLEXITY_API_URL = "https://api.perplexity.ai/v1/sonar";
+const PERPLEXITY_TIMEOUT_MS = 60_000;
+const PERPLEXITY_MAX_ATTEMPTS = 4;
+const PERPLEXITY_RETRYABLE = new Set([429, 500, 502, 503, 504]);
+// Same shape as the Google limits, and for the same reason: a new Perplexity
+// key starts on a low usage tier, so 429s are a first-run experience, not an
+// edge case.
+const PERPLEXITY_MAX_RETRY_WAIT_MS = 45_000;
+const PERPLEXITY_RETRY_BUDGET_MS = 90_000;
+
+export class PerplexityAPIError extends Error {
+  status: number;
+  /** From the Retry-After header on a 429, in seconds. */
+  retryAfterSec?: number;
+  constructor(status: number, message: string, retryAfterSec?: number) {
+    super(message);
+    this.name = "PerplexityAPIError";
+    this.status = status;
+    this.retryAfterSec = retryAfterSec;
+  }
+}
+
+interface PerplexitySearchResult {
+  title?: string;
+  url?: string;
+  snippet?: string;
+  date?: string;
+}
+
+interface PerplexityResponse {
+  choices?: { message?: { content?: string }; finish_reason?: string }[];
+  /** Newer, richer source list. */
+  search_results?: PerplexitySearchResult[];
+  /** Older field: bare URLs. Kept as a fallback. */
+  citations?: string[];
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+    total_tokens?: number;
+    citation_tokens?: number;
+    reasoning_tokens?: number;
+  };
+  error?: { message?: string; type?: string };
+  detail?: unknown;
+}
+
+/** Seconds from a Retry-After header, which may be a delta or an HTTP date. */
+function perplexityRetryAfterSec(res: Response): number | undefined {
+  const raw = res.headers.get("retry-after");
+  if (!raw) return undefined;
+  const secs = Number(raw);
+  if (Number.isFinite(secs) && secs >= 0) return secs;
+  const when = Date.parse(raw);
+  if (!Number.isNaN(when)) return Math.max(0, (when - Date.now()) / 1000);
+  return undefined;
+}
+
+async function perplexityFetch(apiKey: string, body: unknown): Promise<PerplexityResponse> {
+  let lastErr: unknown;
+  let sleptMs = 0;
+  for (let attempt = 0; attempt < PERPLEXITY_MAX_ATTEMPTS; attempt++) {
+    try {
+      const res = await fetch(PERPLEXITY_API_URL, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${apiKey}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(PERPLEXITY_TIMEOUT_MS),
+      });
+      if (res.ok) return (await res.json()) as PerplexityResponse;
+      const errBody = (await res.json().catch(() => ({}))) as PerplexityResponse;
+      const perr = new PerplexityAPIError(
+        res.status,
+        errBody.error?.message ??
+          (typeof errBody.detail === "string" ? errBody.detail : undefined) ??
+          `Perplexity API error (${res.status}).`,
+        perplexityRetryAfterSec(res),
+      );
+      if (!PERPLEXITY_RETRYABLE.has(res.status)) throw perr;
+      lastErr = perr;
+    } catch (err) {
+      if (err instanceof PerplexityAPIError && !PERPLEXITY_RETRYABLE.has(err.status)) throw err;
+      lastErr = err;
+    }
+    if (attempt >= PERPLEXITY_MAX_ATTEMPTS - 1) break;
+
+    // Honour Retry-After for the same reason as Gemini's RetryInfo: a rate
+    // limit's window doesn't care about our exponential backoff, and retrying
+    // inside it just burns the remaining attempts in a couple of seconds.
+    const advised = lastErr instanceof PerplexityAPIError ? lastErr.retryAfterSec : undefined;
+    const backoffMs = 400 * 2 ** attempt;
+    const waitMs = advised !== undefined ? Math.max(advised * 1000, backoffMs) : backoffMs;
+    if (waitMs > PERPLEXITY_MAX_RETRY_WAIT_MS || sleptMs + waitMs > PERPLEXITY_RETRY_BUDGET_MS) break;
+    await sleep(waitMs);
+    sleptMs += waitMs;
+  }
+  throw lastErr ?? new Error("Perplexity request failed.");
+}
+
+// sonar-reasoning-pro emits its chain of thought inline, wrapped in <think>
+// tags, ahead of the actual answer. Left in place it would be stored as the
+// response and scanned for brand mentions — so a model musing "the user might
+// be thinking of Cloudflare" would count as a mention that the answer never
+// made. Same failure as Gemini's truncated deliberation, different mechanism.
+export function stripReasoning(text: string): string {
+  return text.replace(/<think>[\s\S]*?<\/think>/gi, "").trim();
+}
+
+/** Sources from a Perplexity answer, preferring the richer search_results. */
+export function perplexitySources(data: PerplexityResponse): CitedSource[] {
+  const out: CitedSource[] = [];
+  const seen = new Set<string>();
+  const push = (url: string, title: string | null, snippet: string | null) => {
+    const safe = safeSource(url, title, snippet);
+    if (!safe || seen.has(safe.url)) return;
+    seen.add(safe.url);
+    out.push(safe);
+  };
+  for (const r of data.search_results ?? []) {
+    if (typeof r?.url === "string") push(r.url, r.title ?? null, r.snippet ?? null);
+  }
+  // Older responses carry only `citations`; don't lose sources on those.
+  if (out.length === 0) {
+    for (const url of data.citations ?? []) {
+      if (typeof url === "string") push(url, null, null);
+    }
+  }
+  return out;
+}
+
+interface PerplexityCallOpts {
+  system?: string;
+  maxTokens: number;
+  /** Utility calls must not search — they reason over text we supply. */
+  search: boolean;
+}
+
+async function perplexityGenerate(
+  apiKey: string,
+  model: string,
+  user: string,
+  opts: PerplexityCallOpts,
+): Promise<{ text: string; tokens: number; data: PerplexityResponse }> {
+  const messages: { role: string; content: string }[] = [];
+  if (opts.system) messages.push({ role: "system", content: opts.system });
+  messages.push({ role: "user", content: user });
+
+  const data = await perplexityFetch(apiKey, {
+    model,
+    messages,
+    max_tokens: opts.maxTokens,
+    // Perplexity searches by default; the utility calls (JSON classification,
+    // topic suggestion) must not, both because searching is pure cost there and
+    // because a search result could contaminate a judgment about text we gave it.
+    ...(opts.search ? {} : { disable_search: true }),
+  });
+
+  const choice = data.choices?.[0];
+  const text = stripReasoning(choice?.message?.content ?? "");
+  const usage = data.usage;
+  // citation_tokens and reasoning_tokens are billed on top of completion_tokens
+  // and are not included in it, so the fallback has to add them back — the same
+  // under-count that thinking tokens caused on Gemini.
+  const tokens =
+    usage?.total_tokens ??
+    (usage?.prompt_tokens ?? 0) +
+      (usage?.completion_tokens ?? 0) +
+      (usage?.citation_tokens ?? 0) +
+      (usage?.reasoning_tokens ?? 0);
+
+  // A 200 with nothing usable in it is the failure that matters: the call
+  // succeeds, the stored response is empty, and the run reports "brand not
+  // mentioned" for a question that was never actually answered.
+  if (!choice) {
+    throw new Error("Perplexity returned no answer (the response contained no choices).");
+  }
+  if (!text) {
+    // Seen when a reasoning model spends the whole budget inside <think>.
+    throw new Error("Perplexity returned an empty answer.");
+  }
+  return { text, tokens, data };
+}
+
+async function perplexityChat(
+  apiKey: string,
+  model: string,
+  system: string | undefined,
+  user: string,
+  maxTokens: number,
+): Promise<ChatResult> {
+  const { text, tokens } = await perplexityGenerate(apiKey, model, user, {
+    system,
+    maxTokens,
+    search: false,
+  });
+  return { text, tokens };
+}
+
+async function perplexityRunQuery(
+  apiKey: string,
+  model: string,
+  prompt: string,
+): Promise<QueryResult> {
+  // No webSearch branch. Perplexity is a search engine — `disable_search: true`
+  // exists, but an ungrounded Sonar answer doesn't correspond to anything a real
+  // user of Perplexity ever sees, so measuring it would describe a product that
+  // isn't the one being monitored. Always grounded, like Google AI Overviews.
+  const { text, tokens, data } = await perplexityGenerate(apiKey, model, prompt, {
+    maxTokens: ANSWER_MAX_TOKENS,
+    search: true,
+  });
+  return { text, tokens, sources: perplexitySources(data) };
+}
+
 // Prompt shape is the single biggest lever on whether a run measures anything.
 // Measured against a stealth-stage brand (24 queries per shape, both providers):
 //
@@ -686,6 +923,14 @@ Generate ${opts.count} distinct questions a person might ask an AI assistant rel
             user,
             UTILITY_MAX_TOKENS,
             true,
+          )
+        : opts.provider === "perplexity"
+        ? await perplexityChat(
+            opts.apiKey,
+            opts.model,
+            VARIATION_SYSTEM + "\nReturn a JSON array of strings.",
+            user,
+            UTILITY_MAX_TOKENS,
           )
         : await openaiChat(
             opts.apiKey,
@@ -820,6 +1065,8 @@ Return a JSON object: { "results": [ { "key": "<key>", "sentiment": "positive|ne
         ? await anthropicChat(opts.apiKey, analysisModel, ANALYZE_SYSTEM, user, 700)
         : opts.provider === "google"
           ? await googleChat(opts.apiKey, analysisModel, ANALYZE_SYSTEM, user, 700, true)
+          : opts.provider === "perplexity"
+          ? await perplexityChat(opts.apiKey, analysisModel, ANALYZE_SYSTEM, user, 700)
           : await openaiChat(opts.apiKey, analysisModel, ANALYZE_SYSTEM, user, 700, true);
 
     return { results: parseAnalysis(opts.entities, extractJson(res.text)), tokens: res.tokens };
@@ -864,6 +1111,8 @@ Provide 3 or 4 topics, each with 4 to 6 natural questions. Never put the company
       ? await anthropicChat(opts.apiKey, opts.model, SUGGEST_SYSTEM, user, 2000)
       : opts.provider === "google"
         ? await googleChat(opts.apiKey, opts.model, SUGGEST_SYSTEM, user, 2000, true)
+        : opts.provider === "perplexity"
+        ? await perplexityChat(opts.apiKey, opts.model, SUGGEST_SYSTEM, user, 2000)
         : await openaiChat(opts.apiKey, opts.model, SUGGEST_SYSTEM, user, 2000, true);
 
   try {
@@ -947,6 +1196,8 @@ export async function suggestCompetitors(
       ? await anthropicChat(opts.apiKey, opts.model, COMPETITOR_SYSTEM, user, UTILITY_MAX_TOKENS)
       : opts.provider === "google"
         ? await googleChat(opts.apiKey, opts.model, COMPETITOR_SYSTEM, user, UTILITY_MAX_TOKENS, true)
+        : opts.provider === "perplexity"
+        ? await perplexityChat(opts.apiKey, opts.model, COMPETITOR_SYSTEM, user, UTILITY_MAX_TOKENS)
         : await openaiChat(opts.apiKey, opts.model, COMPETITOR_SYSTEM, user, UTILITY_MAX_TOKENS, true);
 
   try {
@@ -1023,6 +1274,25 @@ export function humanError(err: unknown): string {
     }
     if (err.status === 403) return "This key lacks access to the requested model.";
     if (err.status === 404) return "The requested model isn't available for this key.";
+    return err.message || `Provider error (${err.status}).`;
+  }
+  if (err instanceof PerplexityAPIError) {
+    if (err.status === 401 || err.status === 403) return "Invalid API key.";
+    if (err.status === 402) return "This Perplexity key is out of credit.";
+    if (err.status === 429) {
+      // Perplexity meters by usage tier, so a fresh key rate-limits on its very
+      // first real run. Same reasoning as the Gemini 429 message: "rate limited"
+      // reads as "we went too fast" and invites a pointless immediate retry.
+      const wait =
+        err.retryAfterSec !== undefined && err.retryAfterSec > 0
+          ? ` Perplexity asked us to wait ${Math.ceil(err.retryAfterSec)}s.`
+          : "";
+      return (
+        `Perplexity rejected the request: this key is over its rate limit.${wait} ` +
+        `New keys start on a low usage tier — check your tier and credit balance in the Perplexity API settings, or wait and run again.`
+      );
+    }
+    if (err.status >= 500) return "The AI provider had a temporary error. Please try again.";
     return err.message || `Provider error (${err.status}).`;
   }
   if (err instanceof Error) {

--- a/lib/llm/perplexity.test.ts
+++ b/lib/llm/perplexity.test.ts
@@ -1,0 +1,485 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  runQuery,
+  verifyKey,
+  generateVariations,
+  analyzeResponse,
+  suggestCompetitors,
+  humanError,
+  stripReasoning,
+  perplexitySources,
+  PerplexityAPIError,
+} from "./index";
+import { PROVIDERS } from "@/lib/models";
+
+// ------------------------------------------------------------------
+// Perplexity (Sonar) adapter. Mocked fetch throughout — the subject is the
+// request we build and the responses we survive, not Perplexity's behaviour.
+//
+// Two things make this adapter different from the others and drive most of
+// what's asserted here:
+//   1. It always searches. There is no ungrounded mode to fall back to, so the
+//      sources are part of every answer rather than an opt-in.
+//   2. sonar-reasoning-pro streams its chain of thought inline, in <think>
+//      tags, ahead of the answer. Stored unstripped, that text gets scanned for
+//      brand mentions — and a model musing about a competitor would be counted
+//      as a mention the answer never made.
+// ------------------------------------------------------------------
+
+const KEY = "pplx-test-key";
+const API_URL = "https://api.perplexity.ai/v1/sonar";
+
+function ok(
+  content: string,
+  extra: {
+    search_results?: { title?: string; url?: string; snippet?: string }[];
+    citations?: string[];
+    usage?: Record<string, number>;
+    finish_reason?: string;
+  } = {},
+) {
+  return {
+    id: "x",
+    model: "sonar-pro",
+    choices: [
+      { message: { role: "assistant", content }, finish_reason: extra.finish_reason ?? "stop" },
+    ],
+    ...(extra.search_results ? { search_results: extra.search_results } : {}),
+    ...(extra.citations ? { citations: extra.citations } : {}),
+    usage: extra.usage ?? { total_tokens: 42 },
+  };
+}
+
+function jsonResponse(body: unknown, status = 200, headers: Record<string, string> = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    headers: { get: (k: string) => headers[k.toLowerCase()] ?? null },
+  } as unknown as Response;
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+/** Queue of responses; the last one repeats once exhausted. */
+function mockFetch(...responses: Response[]) {
+  let i = 0;
+  fetchMock = vi.fn(async () => responses[Math.min(i++, responses.length - 1)]);
+  vi.stubGlobal("fetch", fetchMock);
+}
+
+function sentBody(call = 0): Record<string, any> {
+  return JSON.parse(fetchMock.mock.calls[call][1].body as string);
+}
+
+function sentHeaders(call = 0): Record<string, string> {
+  return fetchMock.mock.calls[call][1].headers as Record<string, string>;
+}
+
+beforeEach(() => {
+  vi.unstubAllEnvs();
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+// --- Request construction -------------------------------------------------
+
+describe("perplexity runQuery — request shape", () => {
+  it("posts to the canonical /v1/sonar endpoint with a bearer key", async () => {
+    mockFetch(jsonResponse(ok("hi")));
+    await runQuery({ provider: "perplexity", model: "sonar-pro", apiKey: KEY, prompt: "q" });
+    expect(fetchMock.mock.calls[0][0]).toBe(API_URL);
+    expect(sentHeaders().authorization).toBe(`Bearer ${KEY}`);
+  });
+
+  it("sends the prompt as a user message with the chosen model", async () => {
+    mockFetch(jsonResponse(ok("hi")));
+    await runQuery({ provider: "perplexity", model: "sonar-pro", apiKey: KEY, prompt: "best cdn?" });
+    const body = sentBody();
+    expect(body.model).toBe("sonar-pro");
+    expect(body.messages).toEqual([{ role: "user", content: "best cdn?" }]);
+  });
+
+  // The decision this locks in: Perplexity is a search engine, so an ungrounded
+  // Sonar answer doesn't correspond to anything a real user ever sees. The
+  // project's web-search toggle deliberately does not reach it.
+  it("always searches, even when the project has web search off", async () => {
+    mockFetch(jsonResponse(ok("hi")));
+    await runQuery({
+      provider: "perplexity",
+      model: "sonar-pro",
+      apiKey: KEY,
+      prompt: "q",
+      webSearch: false,
+    });
+    expect(sentBody().disable_search).toBeUndefined();
+  });
+
+  // The mirror of the above: utility calls reason over text we supply. Letting
+  // them search is pure cost, and a search result could contaminate a judgment
+  // that is supposed to be about the text we passed in.
+  it("disables search on utility calls", async () => {
+    mockFetch(jsonResponse(ok('["a","b"]')));
+    await generateVariations({
+      provider: "perplexity",
+      model: "sonar",
+      apiKey: KEY,
+      topicName: "cdn",
+      count: 2,
+    });
+    expect(sentBody().disable_search).toBe(true);
+  });
+
+  it("bounds each attempt with an abort signal so a call can't hang", async () => {
+    mockFetch(jsonResponse(ok("hi")));
+    await runQuery({ provider: "perplexity", model: "sonar", apiKey: KEY, prompt: "q" });
+    expect(fetchMock.mock.calls[0][1].signal).toBeInstanceOf(AbortSignal);
+  });
+});
+
+// --- Reasoning-model chain of thought -------------------------------------
+
+describe("chain-of-thought stripping", () => {
+  it("removes a <think> block and keeps the answer", () => {
+    expect(stripReasoning("<think>maybe Cloudflare?</think>\n\nFastly is best.")).toBe(
+      "Fastly is best.",
+    );
+  });
+
+  it("is case-insensitive and handles multiple blocks", () => {
+    expect(stripReasoning("<THINK>a</THINK>X<think>b</think>Y")).toBe("XY");
+  });
+
+  it("leaves an ordinary answer untouched", () => {
+    expect(stripReasoning("Cloudflare and Fastly.")).toBe("Cloudflare and Fastly.");
+  });
+
+  // The measurement bug this prevents: deliberation naming a brand the answer
+  // never recommends would be stored as the response and counted as a mention.
+  it("strips reasoning before the answer is returned from runQuery", async () => {
+    mockFetch(jsonResponse(ok("<think>The user may mean Akamai.</think>Fastly leads.")));
+    const res = await runQuery({
+      provider: "perplexity",
+      model: "sonar-reasoning-pro",
+      apiKey: KEY,
+      prompt: "q",
+    });
+    expect(res.text).toBe("Fastly leads.");
+    expect(res.text).not.toMatch(/Akamai/);
+  });
+});
+
+// --- Sources --------------------------------------------------------------
+
+describe("perplexity sources", () => {
+  it("prefers search_results, keeping title and snippet", () => {
+    const sources = perplexitySources({
+      search_results: [
+        { title: "Best CDNs", url: "https://example.com/a", snippet: "..." },
+        { title: "More", url: "https://www.Cloudflare.com/b", snippet: null as never },
+      ],
+    } as never);
+    expect(sources).toHaveLength(2);
+    expect(sources[0]).toMatchObject({ domain: "example.com", title: "Best CDNs" });
+    // www. stripped and lowercased, so is_owned matching works on the domain.
+    expect(sources[1].domain).toBe("cloudflare.com");
+  });
+
+  it("falls back to bare citations when search_results is absent", () => {
+    const sources = perplexitySources({ citations: ["https://example.com/x"] } as never);
+    expect(sources).toEqual([
+      { url: "https://example.com/x", domain: "example.com", title: null, snippet: null },
+    ]);
+  });
+
+  it("ignores citations when search_results already carried sources", () => {
+    const sources = perplexitySources({
+      search_results: [{ url: "https://a.com/1" }],
+      citations: ["https://b.com/2"],
+    } as never);
+    expect(sources.map((s) => s.domain)).toEqual(["a.com"]);
+  });
+
+  it("drops unsafe and duplicate URLs", () => {
+    const sources = perplexitySources({
+      search_results: [
+        { url: "javascript:alert(1)" },
+        { url: "https://a.com/1" },
+        { url: "https://a.com/1" },
+        { url: "not a url" },
+      ],
+    } as never);
+    expect(sources.map((s) => s.url)).toEqual(["https://a.com/1"]);
+  });
+
+  it("attaches sources to a monitored answer", async () => {
+    mockFetch(
+      jsonResponse(
+        ok("Fastly and Cloudflare.", {
+          search_results: [{ title: "t", url: "https://cloudflare.com/x", snippet: "s" }],
+        }),
+      ),
+    );
+    const res = await runQuery({ provider: "perplexity", model: "sonar-pro", apiKey: KEY, prompt: "q" });
+    expect(res.sources).toHaveLength(1);
+    expect(res.sources[0].domain).toBe("cloudflare.com");
+  });
+});
+
+// --- Token accounting -----------------------------------------------------
+
+describe("perplexity token accounting", () => {
+  it("uses total_tokens when present", async () => {
+    mockFetch(jsonResponse(ok("hi", { usage: { total_tokens: 123 } })));
+    const res = await runQuery({ provider: "perplexity", model: "sonar", apiKey: KEY, prompt: "q" });
+    expect(res.tokens).toBe(123);
+  });
+
+  // citation_tokens and reasoning_tokens are billed but are NOT part of
+  // completion_tokens, so a fallback that omits them under-meters the trial.
+  it("adds citation and reasoning tokens in the fallback", async () => {
+    mockFetch(
+      jsonResponse(
+        ok("hi", {
+          usage: { prompt_tokens: 10, completion_tokens: 20, citation_tokens: 30, reasoning_tokens: 40 },
+        }),
+      ),
+    );
+    const res = await runQuery({ provider: "perplexity", model: "sonar", apiKey: KEY, prompt: "q" });
+    expect(res.tokens).toBe(100);
+  });
+});
+
+// --- 200-but-unusable -----------------------------------------------------
+
+describe("perplexity 200-but-unusable responses", () => {
+  // Every one of these is silent: the call succeeds, the stored response is
+  // empty, and the run reports "brand not mentioned" for a question that was
+  // never answered. Failing the call lets the engine record the real reason.
+  it("fails a 200 with no choices", async () => {
+    mockFetch(jsonResponse({ id: "x", usage: { total_tokens: 9 } }));
+    await expect(
+      runQuery({ provider: "perplexity", model: "sonar", apiKey: KEY, prompt: "q" }),
+    ).rejects.toThrow(/no choices/i);
+  });
+
+  it("fails a 200 whose answer is empty", async () => {
+    mockFetch(jsonResponse(ok("   ")));
+    await expect(
+      runQuery({ provider: "perplexity", model: "sonar", apiKey: KEY, prompt: "q" }),
+    ).rejects.toThrow(/empty answer/i);
+  });
+
+  it("fails when a reasoning model spent the whole budget thinking", async () => {
+    mockFetch(jsonResponse(ok("<think>still deliberating…</think>")));
+    await expect(
+      runQuery({ provider: "perplexity", model: "sonar-reasoning-pro", apiKey: KEY, prompt: "q" }),
+    ).rejects.toThrow(/empty answer/i);
+  });
+
+  it("does not retry an unusable 200 — the tokens are already spent", async () => {
+    mockFetch(jsonResponse(ok("")));
+    await expect(
+      runQuery({ provider: "perplexity", model: "sonar", apiKey: KEY, prompt: "q" }),
+    ).rejects.toThrow();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+// --- HTTP errors and retries ---------------------------------------------
+
+describe("perplexity HTTP errors", () => {
+  it("surfaces a bad key immediately, without retrying", async () => {
+    mockFetch(jsonResponse({ error: { message: "Unauthorized" } }, 401));
+    await expect(
+      runQuery({ provider: "perplexity", model: "sonar", apiKey: KEY, prompt: "q" }),
+    ).rejects.toThrow();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("recovers when a transient 503 is followed by a success", async () => {
+    vi.useFakeTimers();
+    mockFetch(jsonResponse({ error: { message: "busy" } }, 503), jsonResponse(ok("hi")));
+    const p = runQuery({ provider: "perplexity", model: "sonar", apiKey: KEY, prompt: "q" });
+    await vi.runAllTimersAsync();
+    await expect(p).resolves.toMatchObject({ text: "hi" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  // Same lesson as the Gemini 429: a rate-limit window doesn't care about our
+  // exponential backoff, so retrying inside it burns every attempt in seconds.
+  it("waits as long as Retry-After asks, not the exponential backoff", async () => {
+    vi.useFakeTimers();
+    mockFetch(
+      jsonResponse({ error: { message: "slow down" } }, 429, { "retry-after": "12" }),
+      jsonResponse(ok("hi")),
+    );
+    const p = runQuery({ provider: "perplexity", model: "sonar", apiKey: KEY, prompt: "q" });
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(fetchMock).toHaveBeenCalledTimes(1); // the 400ms backoff would have fired by now
+    await vi.advanceTimersByTimeAsync(11_000);
+    await expect(p).resolves.toMatchObject({ text: "hi" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("gives up rather than blocking on a window it can't wait out", async () => {
+    vi.useFakeTimers();
+    mockFetch(jsonResponse({ error: { message: "daily cap" } }, 429, { "retry-after": "3600" }));
+    const p = runQuery({ provider: "perplexity", model: "sonar", apiKey: KEY, prompt: "q" });
+    const rejected = expect(p).rejects.toThrow(/daily cap/);
+    await vi.runAllTimersAsync();
+    await rejected;
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepts an HTTP-date Retry-After", async () => {
+    vi.useFakeTimers();
+    const when = new Date(Date.now() + 10_000).toUTCString();
+    mockFetch(jsonResponse({ error: { message: "wait" } }, 429, { "retry-after": when }), jsonResponse(ok("hi")));
+    const p = runQuery({ provider: "perplexity", model: "sonar", apiKey: KEY, prompt: "q" });
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(9_000);
+    await expect(p).resolves.toMatchObject({ text: "hi" });
+  });
+
+  it("retries a dropped connection", async () => {
+    vi.useFakeTimers();
+    let calls = 0;
+    fetchMock = vi.fn(async () => {
+      if (++calls === 1) throw new TypeError("fetch failed");
+      return jsonResponse(ok("hi"));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const p = runQuery({ provider: "perplexity", model: "sonar", apiKey: KEY, prompt: "q" });
+    await vi.runAllTimersAsync();
+    await expect(p).resolves.toMatchObject({ text: "hi" });
+    expect(calls).toBe(2);
+  });
+});
+
+// --- verifyKey ------------------------------------------------------------
+
+describe('verifyKey("perplexity")', () => {
+  it("probes with a model the catalog actually offers", async () => {
+    mockFetch(jsonResponse(ok("pong")));
+    const res = await verifyKey("perplexity", KEY);
+    expect(res.ok).toBe(true);
+    expect(PROVIDERS.perplexity.models.map((m) => m.id)).toContain(sentBody().model);
+  });
+
+  it("does not search while verifying — a probe should cost nothing extra", async () => {
+    mockFetch(jsonResponse(ok("pong")));
+    await verifyKey("perplexity", KEY);
+    expect(sentBody().disable_search).toBe(true);
+  });
+
+  it("reports a bad key as an invalid key, not a raw provider string", async () => {
+    mockFetch(jsonResponse({ error: { message: "invalid api key provided" } }, 401));
+    await expect(verifyKey("perplexity", "pplx-nope")).resolves.toEqual({
+      ok: false,
+      error: "Invalid API key.",
+    });
+  });
+});
+
+// --- utility calls --------------------------------------------------------
+
+describe("perplexity JSON utility calls", () => {
+  it("parses variations out of a fenced JSON reply", async () => {
+    mockFetch(jsonResponse(ok('```json\n["a","b","c"]\n```')));
+    const res = await generateVariations({
+      provider: "perplexity",
+      model: "sonar",
+      apiKey: KEY,
+      topicName: "cdn",
+      count: 3,
+    });
+    expect(res.variations).toEqual(["a", "b", "c"]);
+  });
+
+  it("classifies sentiment and attributes rows to the right entity", async () => {
+    mockFetch(
+      jsonResponse(
+        ok(
+          '{"results":[{"key":"brand","sentiment":"positive","recommended":true},{"key":"c1","sentiment":"negative","recommended":false}]}',
+        ),
+      ),
+    );
+    const res = await analyzeResponse({
+      provider: "perplexity",
+      model: "sonar",
+      apiKey: KEY,
+      question: "q",
+      responseText: "a",
+      entities: [
+        { key: "brand", name: "Cloudflare" },
+        { key: "c1", name: "Akamai" },
+      ],
+    });
+    expect(res.results).toEqual([
+      { key: "brand", sentiment: "positive", recommended: true },
+      { key: "c1", sentiment: "negative", recommended: false },
+    ]);
+  });
+
+  // Enrichment must never fail a run: a broken classification degrades to
+  // neutral rather than throwing away an answer we already paid for.
+  it("degrades to neutral rather than failing the run", async () => {
+    mockFetch(jsonResponse({ error: { message: "boom" } }, 401));
+    const res = await analyzeResponse({
+      provider: "perplexity",
+      model: "sonar",
+      apiKey: KEY,
+      question: "q",
+      responseText: "a",
+      entities: [{ key: "brand", name: "Cloudflare" }],
+    });
+    expect(res.results).toEqual([{ key: "brand", sentiment: "neutral", recommended: false }]);
+  });
+
+  it("suggests competitors", async () => {
+    mockFetch(jsonResponse(ok('{"competitors":[{"name":"Fastly","domain":"https://Fastly.com/x"}]}')));
+    const res = await suggestCompetitors({
+      provider: "perplexity",
+      model: "sonar",
+      apiKey: KEY,
+      brandName: "Cloudflare",
+      topics: ["CDN"],
+      existing: [],
+      count: 1,
+    });
+    // domain is normalised: scheme stripped, lowercased, path dropped.
+    expect(res.suggestions[0]).toMatchObject({ name: "Fastly", domain: "fastly.com" });
+  });
+});
+
+// --- humanError -----------------------------------------------------------
+
+describe("humanError for perplexity", () => {
+  it("maps auth failures to an invalid key", () => {
+    expect(humanError(new PerplexityAPIError(401, "nope"))).toBe("Invalid API key.");
+    expect(humanError(new PerplexityAPIError(403, "nope"))).toBe("Invalid API key.");
+  });
+
+  it("names credit exhaustion distinctly from a rate limit", () => {
+    expect(humanError(new PerplexityAPIError(402, "no funds"))).toMatch(/out of credit/i);
+  });
+
+  // "Rate limited" reads as "we went too fast" and invites a pointless retry;
+  // on Perplexity a 429 is usually the key's usage tier.
+  it("explains a 429 as a tier problem and includes the advised wait", () => {
+    const msg = humanError(new PerplexityAPIError(429, "slow down", 38));
+    expect(msg).toMatch(/rate limit/i);
+    expect(msg).toMatch(/usage tier/i);
+    expect(msg).toMatch(/wait 38s/);
+  });
+
+  it("maps server errors to a retryable message", () => {
+    expect(humanError(new PerplexityAPIError(503, "boom"))).toBe(
+      "The AI provider had a temporary error. Please try again.",
+    );
+  });
+});

--- a/lib/llm/perplexity.test.ts
+++ b/lib/llm/perplexity.test.ts
@@ -132,6 +132,16 @@ describe("perplexity runQuery — request shape", () => {
     expect(sentBody().disable_search).toBe(true);
   });
 
+  // Measured: Perplexity 400s on anything below 16 with "max_tokens must be at
+  // least 16". verifyKey's probe budget was copied from the Google adapter (8),
+  // which made a perfectly valid key report as invalid — the failure mode this
+  // whole codebase tries hardest to avoid.
+  it("never requests fewer than the 16 tokens Perplexity requires", async () => {
+    mockFetch(jsonResponse(ok("pong")));
+    await verifyKey("perplexity", KEY);
+    expect(sentBody().max_tokens).toBeGreaterThanOrEqual(16);
+  });
+
   it("bounds each attempt with an abort signal so a call can't hang", async () => {
     mockFetch(jsonResponse(ok("hi")));
     await runQuery({ provider: "perplexity", model: "sonar", apiKey: KEY, prompt: "q" });

--- a/lib/models.test.ts
+++ b/lib/models.test.ts
@@ -14,10 +14,11 @@ afterEach(() => {
 });
 
 describe("provider catalog", () => {
-  it("recognizes all three providers and rejects unknown ones", () => {
+  it("recognizes every provider and rejects unknown ones", () => {
     expect(isProvider("anthropic")).toBe(true);
     expect(isProvider("openai")).toBe(true);
     expect(isProvider("google")).toBe(true);
+    expect(isProvider("perplexity")).toBe(true);
     expect(isProvider("gemini")).toBe(false); // "gemini" is a model line, not our provider id
     expect(isProvider("mistral")).toBe(false);
   });
@@ -38,6 +39,22 @@ describe("provider catalog", () => {
     // It must not be the default (the flagship Gemini model is).
     expect(defaultModelFor("google")).not.toBe(GOOGLE_AI_OVERVIEWS_MODEL);
     expect(modelLabel("google", GOOGLE_AI_OVERVIEWS_MODEL)).toBe("Google AI Overviews");
+  });
+
+  it("exposes perplexity (Sonar) in the catalog", () => {
+    expect(PROVIDERS.perplexity.label).toContain("Sonar");
+    expect(PROVIDERS.perplexity.keyPrefix).toBe("pplx-");
+    expect(PROVIDER_LIST.map((p) => p.id)).toContain("perplexity");
+    expect(defaultModelFor("perplexity")).toBe("sonar-pro");
+  });
+
+  // sonar-deep-research runs for minutes on a single question, well past the
+  // 300s the run route allows for an ENTIRE run. Listing it would offer a
+  // model whose only possible outcome is a timeout mid-run.
+  it("keeps sonar-deep-research out of the catalog", () => {
+    const ids = PROVIDERS.perplexity.models.map((m) => m.id);
+    expect(ids).not.toContain("sonar-deep-research");
+    expect(analysisModelFor("perplexity")).not.toBe("sonar-deep-research");
   });
 
   it("labels known models and passes through unknown ones", () => {

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -70,12 +70,30 @@ export const PROVIDERS: Record<Provider, ProviderInfo> = {
       },
     ],
   },
+  perplexity: {
+    id: "perplexity",
+    label: "Perplexity (Sonar)",
+    keyUrl: "https://www.perplexity.ai/account/api/keys",
+    keyPrefix: "pplx-",
+    // Named models rather than dated versions, so these don't rot the way the
+    // pinned Gemini ids did. `sonar-deep-research` is deliberately absent: it
+    // runs for minutes on a single question, which exceeds the 300s the run
+    // route allows for an entire run, so offering it would just be a timeout
+    // with a model picker in front of it.
+    models: [
+      { id: "sonar-pro", label: "Sonar Pro", note: "Most capable" },
+      { id: "sonar", label: "Sonar", note: "Fast & cheap" },
+      { id: "sonar-reasoning-pro", label: "Sonar Reasoning Pro", note: "Chain-of-thought" },
+    ],
+  },
 };
 
 export const PROVIDER_LIST: ProviderInfo[] = Object.values(PROVIDERS);
 
 export function isProvider(value: string): value is Provider {
-  return value === "anthropic" || value === "openai" || value === "google";
+  return (
+    value === "anthropic" || value === "openai" || value === "google" || value === "perplexity"
+  );
 }
 
 export function defaultModelFor(provider: Provider): string {
@@ -86,12 +104,15 @@ const ANALYSIS_MODEL_ENV: Record<Provider, string> = {
   anthropic: "ANALYSIS_ANTHROPIC_MODEL",
   openai: "ANALYSIS_OPENAI_MODEL",
   google: "ANALYSIS_GOOGLE_MODEL",
+  perplexity: "ANALYSIS_PERPLEXITY_MODEL",
 };
 
 const ANALYSIS_MODEL_DEFAULT: Record<Provider, string> = {
   anthropic: "claude-haiku-4-5",
   openai: "gpt-4o-mini",
   google: "gemini-flash-lite-latest",
+  // Sonar is the cheap search model; classification never needs Pro.
+  perplexity: "sonar",
 };
 
 // Sentiment/recommendation enrichment is a simple structured-JSON judgment;

--- a/lib/trial.ts
+++ b/lib/trial.ts
@@ -24,12 +24,14 @@ const TRIAL_KEY_ENV: Record<Provider, string> = {
   anthropic: "TRIAL_ANTHROPIC_API_KEY",
   openai: "TRIAL_OPENAI_API_KEY",
   google: "TRIAL_GOOGLE_API_KEY",
+  perplexity: "TRIAL_PERPLEXITY_API_KEY",
 };
 
 const TRIAL_MODEL_ENV: Record<Provider, string> = {
   anthropic: "TRIAL_ANTHROPIC_MODEL",
   openai: "TRIAL_OPENAI_MODEL",
   google: "TRIAL_GOOGLE_MODEL",
+  perplexity: "TRIAL_PERPLEXITY_MODEL",
 };
 
 /** The operator's shared key for a provider, if configured. */
@@ -80,13 +82,15 @@ export function pickDefaultProvider(): Provider {
   if (trialKeyFor("anthropic")) return "anthropic";
   if (trialKeyFor("openai")) return "openai";
   if (trialKeyFor("google")) return "google";
+  if (trialKeyFor("perplexity")) return "perplexity";
   return "anthropic";
 }
 
 const PROVIDER_ORDER: Record<Provider, Provider[]> = {
-  anthropic: ["anthropic", "openai", "google"],
-  openai: ["openai", "anthropic", "google"],
-  google: ["google", "anthropic", "openai"],
+  anthropic: ["anthropic", "openai", "google", "perplexity"],
+  openai: ["openai", "anthropic", "google", "perplexity"],
+  google: ["google", "anthropic", "openai", "perplexity"],
+  perplexity: ["perplexity", "anthropic", "openai", "google"],
 };
 
 /**

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,7 +1,7 @@
 // Shared domain + database row types for LetterTrace.
 // Column names mirror supabase/schema.sql exactly.
 
-export type Provider = "anthropic" | "openai" | "google";
+export type Provider = "anthropic" | "openai" | "google" | "perplexity";
 
 export type RunStatus = "pending" | "running" | "completed" | "failed";
 

--- a/scripts/pilot-client.ts
+++ b/scripts/pilot-client.ts
@@ -95,7 +95,10 @@ const maxPrompts = Number(flag("max-prompts", "10"));
 const providers = flag("providers", "anthropic,openai")
   .split(",")
   .map((p) => p.trim())
-  .filter((p): p is Provider => p === "anthropic" || p === "openai" || p === "google");
+  .filter(
+    (p): p is Provider =>
+      p === "anthropic" || p === "openai" || p === "google" || p === "perplexity",
+  );
 const webSearch = flag("web-search", "on") !== "off";
 
 // Answer models: the flagship of each provider, i.e. what a real user asking
@@ -105,6 +108,7 @@ const ANSWER_MODEL: Record<Provider, string> = {
   anthropic: "claude-opus-4-8",
   openai: "gpt-4o",
   google: "gemini-pro-latest",
+  perplexity: "sonar-pro",
 };
 
 // Rough blended $/1M tokens, only for an order-of-magnitude spend estimate.
@@ -112,6 +116,9 @@ const BLENDED_COST_PER_MTOK: Record<Provider, number> = {
   anthropic: 10,
   openai: 7,
   google: 5,
+  // Perplexity bills per request and per search on top of tokens; this is only
+  // an order-of-magnitude figure for the pilot's spend estimate.
+  perplexity: 6,
 };
 
 // --- concurrency ----------------------------------------------------------
@@ -177,6 +184,7 @@ function keyFor(provider: Provider): string {
     anthropic: "TRIAL_ANTHROPIC_API_KEY",
     openai: "TRIAL_OPENAI_API_KEY",
     google: "TRIAL_GOOGLE_API_KEY",
+    perplexity: "TRIAL_PERPLEXITY_API_KEY",
   };
   const k = process.env[env[provider]];
   if (!k) throw new Error(`Missing ${env[provider]} in .env.local`);

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -89,7 +89,7 @@ $$;
 create table if not exists public.provider_keys (
   id uuid primary key default gen_random_uuid(),
   user_id uuid not null references auth.users (id) on delete cascade,
-  provider text not null check (provider in ('anthropic', 'openai', 'google')),
+  provider text not null check (provider in ('anthropic', 'openai', 'google', 'perplexity')),
   label text,
   encrypted_key text not null,
   key_hint text not null,
@@ -102,7 +102,7 @@ create table if not exists public.provider_keys (
 -- Safe to re-run.
 alter table public.provider_keys drop constraint if exists provider_keys_provider_check;
 alter table public.provider_keys
-  add constraint provider_keys_provider_check check (provider in ('anthropic', 'openai', 'google'));
+  add constraint provider_keys_provider_check check (provider in ('anthropic', 'openai', 'google', 'perplexity'));
 
 -- ---------- projects -------------------------------------------------
 create table if not exists public.projects (
@@ -113,7 +113,7 @@ create table if not exists public.projects (
   brand_aliases text[] not null default '{}',
   brand_domains text[] not null default '{}',
   description text,
-  default_provider text not null default 'anthropic' check (default_provider in ('anthropic', 'openai', 'google')),
+  default_provider text not null default 'anthropic' check (default_provider in ('anthropic', 'openai', 'google', 'perplexity')),
   default_model text not null default 'claude-sonnet-4-6',
   schedule text not null default 'off' check (schedule in ('off', 'daily', 'weekly')),
   last_run_at timestamptz,
@@ -124,7 +124,7 @@ create table if not exists public.projects (
 -- Widen the default-provider allow-list on existing deployments. Safe to re-run.
 alter table public.projects drop constraint if exists projects_default_provider_check;
 alter table public.projects
-  add constraint projects_default_provider_check check (default_provider in ('anthropic', 'openai', 'google'));
+  add constraint projects_default_provider_check check (default_provider in ('anthropic', 'openai', 'google', 'perplexity'));
 
 -- Query the models with their native web search on, so we can capture the
 -- sources they cite. Default on. Safe to re-run.
@@ -260,7 +260,7 @@ alter table public.runs
 -- add and safe to re-run.
 alter table public.runs drop constraint if exists runs_provider_check;
 alter table public.runs
-  add constraint runs_provider_check check (provider in ('anthropic', 'openai', 'google'));
+  add constraint runs_provider_check check (provider in ('anthropic', 'openai', 'google', 'perplexity'));
 
 -- ---------- responses ------------------------------------------------
 create table if not exists public.responses (
@@ -278,7 +278,7 @@ create table if not exists public.responses (
 -- Same provider allow-list as runs (see note above). Safe to add and re-run.
 alter table public.responses drop constraint if exists responses_provider_check;
 alter table public.responses
-  add constraint responses_provider_check check (provider in ('anthropic', 'openai', 'google'));
+  add constraint responses_provider_check check (provider in ('anthropic', 'openai', 'google', 'perplexity'));
 
 -- ---------- mentions -------------------------------------------------
 create table if not exists public.mentions (


### PR DESCRIPTION
Adds Perplexity Sonar as a fourth answer engine, alongside Claude, ChatGPT, and Gemini / Google AI Overviews.

**Not yet run against the live API** — no key at time of writing. Everything below is mocked-tested, typechecked, and lint-clean; the live probe is written and ready to run the moment a key exists.

## What the research changed

Two things differ from the standard assumption about Perplexity:

- **The canonical endpoint is `POST /v1/sonar`**, not `/chat/completions`. The OpenAI-compatible path still works as an alias with no announced deprecation, but Perplexity positions Sonar Chat Completions as superseded by the Agent API.
- **The response carries `search_results`** (title, url, snippet, date) as well as the older bare-URL `citations`. Neither field exists on the OpenAI response type.

That last point decided the transport. Reusing the OpenAI SDK looks cheaper right up until you have to cast past the type system to reach the most valuable half of the payload, while depending on an alias Perplexity treats as legacy. So: dependency-free REST, same shape as the Google adapter.

## Design decisions worth reviewing

**It always searches.** `disable_search` exists, but an ungrounded Sonar answer doesn't correspond to anything a real Perplexity user ever sees, so measuring it would describe a product that isn't the one being monitored. The project's web-search toggle deliberately does not reach Perplexity — same call as Google AI Overviews always grounding.

The utility calls are the mirror image: they reason over text *we* supply, so they always pass `disable_search: true`. Searching there is pure cost, and a search result could contaminate a judgment that's supposed to be about the text we passed in.

**Chain-of-thought is stripped.** `sonar-reasoning-pro` emits its reasoning inline in `<think>` tags ahead of the answer. Stored unstripped, that text becomes the response and gets scanned for brand mentions — so a model musing *"the user may mean Akamai"* would count as a mention the answer never made. Same class of bug as Gemini's truncated deliberation, different mechanism.

**`sonar-deep-research` is deliberately absent.** It runs for minutes on a single question, well past the 300s the run route allows for an *entire* run. Listing it would offer a model whose only possible outcome is a timeout mid-run. There's a catalog guard test asserting it stays out.

**Rate limiting is built in from the start**, not bolted on after it bites. New Perplexity keys begin on a low usage tier, so 429s are a first-run experience. `Retry-After` is honoured (both delta-seconds and HTTP-date forms) with the same bounds as #34 — a single wait over 45s is refused, total sleep per call capped at 90s — and the message names the usage tier instead of saying "rate limited by the provider".

## Sources are better here than anywhere else

Perplexity returns real URLs with titles and snippets. No `vertexaisearch` redirect host to unwrap, which means `is_owned` matching works directly and the **"Cited your site"** card should fire more reliably than on any other engine.

## Scope

TypeScript did the hard part: nine `Record<Provider, …>` sites failed to compile the moment the union grew, so nothing could be silently missed. The CLI and the v1 API needed **zero** changes — the provider catalog is server-derived, so `lettertrace keys set perplexity` works with no client release. The dashboard needed one presentational entry (card title, subtitle, mark).

`supabase/schema.sql` widens six provider check constraints. All ALTER-based and safe to re-run — **this must be run before Perplexity can be selected in production.**

## Tests

`lib/llm/perplexity.test.ts` — **37 tests**, mocked fetch, no network: request shape, the always-search / never-search split, `<think>` stripping, source parsing and the citations fallback, token accounting including `citation_tokens` and `reasoning_tokens`, the 200-but-unusable guards, retry behaviour per status, `Retry-After` in both forms, `verifyKey`, and `humanError`. Plus two catalog guards in `models.test.ts`.

**320 passing** overall. Typecheck and lint clean.

## Before merge

1. A live probe run (written, needs a key)
2. A Cloudflare pilot across all four engines — if Perplexity disagrees with Claude and Gemini on whether Cloudflare was mentioned, the adapter is wrong
3. `supabase/schema.sql` re-run
