### PR TITLE
Never answer a run with an engine other than the one selected (LET-172)

### DIFF
--- a/app/api/competitors/suggest/route.ts
+++ b/app/api/competitors/suggest/route.ts
@@ -3,7 +3,7 @@ import { createClient } from "@/lib/supabase/server";
 import { getProject } from "@/lib/data";
 import { suggestCompetitors, humanError } from "@/lib/llm";
 import { PROVIDERS } from "@/lib/models";
-import { resolveRunKey, recordTrialUsage } from "@/lib/trial";
+import { resolveKey, recordTrialUsage } from "@/lib/trial";
 import { logDashboard } from "@/lib/activity";
 import type { Competitor, Topic } from "@/lib/types";
 
@@ -33,7 +33,10 @@ export async function POST(request: Request) {
   const topics = ((topicRows ?? []) as Topic[]).map((t) => t.name);
 
   const providerLabel = PROVIDERS[project.default_provider].label;
-  const key = await resolveRunKey(supabase, user.id, project);
+  // Lenient resolution on purpose: suggesting competitor names is a helper the
+  // user edits before anything is saved, so any key they hold will do. Runs are
+  // the opposite — see resolveRunKey.
+  const key = await resolveKey(supabase, user.id, project.default_provider, project.default_model);
 
   if (key.source === "none") {
     return NextResponse.json(

--- a/app/api/onboarding/complete/route.ts
+++ b/app/api/onboarding/complete/route.ts
@@ -3,7 +3,13 @@ import { createClient } from "@/lib/supabase/server";
 import { getConfiguredProviders, getProjects, setActiveProject } from "@/lib/data";
 import { executeRun } from "@/lib/engine";
 import { humanError } from "@/lib/llm";
-import { resolveRunKey, consumeTrialRun, recordTrialUsage, pickDefaultProvider } from "@/lib/trial";
+import {
+  resolveRunKey,
+  consumeTrialRun,
+  recordTrialUsage,
+  pickDefaultProvider,
+  engineKeyMessage,
+} from "@/lib/trial";
 import { defaultModelFor } from "@/lib/models";
 import { logDashboard } from "@/lib/activity";
 import type { Project } from "@/lib/types";
@@ -111,7 +117,14 @@ export async function POST(request: Request) {
     );
   }
 
-  const provider = pickDefaultProvider();
+  // Start the project on an engine this user can actually run. Runs no longer
+  // substitute another provider's key, so defaulting purely on the operator's
+  // trial config would hand a BYOK user a project whose first monitor can't
+  // execute — with a perfectly good key sitting in Settings. Their own key wins
+  // over the trial; the env default applies only when they have none.
+  const envDefault = pickDefaultProvider();
+  const provider =
+    providers.length === 0 || providers.includes(envDefault) ? envDefault : providers[0];
   const model = defaultModelFor(provider);
 
   const { data: projRow, error: projErr } = await supabase
@@ -175,7 +188,10 @@ export async function POST(request: Request) {
     return NextResponse.json({
       projectId: project.id,
       ran: false,
-      needsKey: key.source === "exhausted" ? "exhausted" : "none",
+      // 'mismatch' = they have a key, just not for the engine this project was
+      // created with, so the message points at the engine rather than at signup.
+      needsKey: key.source === "own" || key.source === "trial" ? "none" : key.source,
+      keyMessage: engineKeyMessage(key),
     });
   }
 

--- a/app/api/runs/route.ts
+++ b/app/api/runs/route.ts
@@ -4,7 +4,7 @@ import { getProject } from "@/lib/data";
 import { executeRun } from "@/lib/engine";
 import { humanError } from "@/lib/llm";
 import { PROVIDERS } from "@/lib/models";
-import { resolveRunKey, consumeTrialRun, recordTrialUsage } from "@/lib/trial";
+import { resolveRunKey, consumeTrialRun, recordTrialUsage, engineKeyMessage } from "@/lib/trial";
 
 export const maxDuration = 300;
 export const dynamic = "force-dynamic";
@@ -28,9 +28,14 @@ export async function POST() {
   const providerLabel = PROVIDERS[project.default_provider].label;
   const key = await resolveRunKey(supabase, user.id, project);
 
-  if (key.source === "none") {
+  // The selected engine has no key. Refusing beats running: the alternative is
+  // storing another assistant's answers under this project's trend line.
+  if (key.source === "none" || key.source === "mismatch") {
     return NextResponse.json(
-      { error: `Add a ${providerLabel} key in Settings first.` },
+      {
+        error: engineKeyMessage(key),
+        ...(key.source === "mismatch" ? { engineMismatch: true, available: key.available } : {}),
+      },
       { status: 400 },
     );
   }
@@ -77,7 +82,15 @@ export async function POST() {
       await recordTrialUsage(supabase, result.tokensUsed);
     }
 
-    return NextResponse.json({ ...result, keySource: key.source });
+    // Echo the engine that actually answered. The caller asked for
+    // key.requested; a trial forces the provider's cheap model, and the client
+    // shouldn't have to re-derive which of the two it got.
+    return NextResponse.json({
+      ...result,
+      keySource: key.source,
+      provider: key.provider,
+      model: key.model,
+    });
   } catch (e) {
     return NextResponse.json({ error: humanError(e) }, { status: 500 });
   }

--- a/app/api/topics/[id]/generate/route.ts
+++ b/app/api/topics/[id]/generate/route.ts
@@ -3,7 +3,7 @@ import { createClient } from "@/lib/supabase/server";
 import { getProject } from "@/lib/data";
 import { generateVariations, humanError } from "@/lib/llm";
 import { PROVIDERS } from "@/lib/models";
-import { resolveRunKey, recordTrialUsage } from "@/lib/trial";
+import { resolveKey, recordTrialUsage } from "@/lib/trial";
 import { logDashboard } from "@/lib/activity";
 import type { Topic } from "@/lib/types";
 
@@ -49,7 +49,10 @@ export async function POST(
   count = Math.max(1, Math.min(20, count));
 
   const providerLabel = PROVIDERS[project.default_provider].label;
-  const key = await resolveRunKey(supabase, user.id, project);
+  // Lenient resolution on purpose: generated prompts are drafts the user edits,
+  // not measurements, so any key they hold will do. Runs are the opposite —
+  // see resolveRunKey.
+  const key = await resolveKey(supabase, user.id, project.default_provider, project.default_model);
 
   if (key.source === "none") {
     return NextResponse.json(

--- a/app/dashboard/runs/page.tsx
+++ b/app/dashboard/runs/page.tsx
@@ -1,7 +1,7 @@
 import { ArrowRight, PlayCircle } from "lucide-react";
 import { createClient } from "@/lib/supabase/server";
 import { getProject } from "@/lib/data";
-import { resolveKey } from "@/lib/trial";
+import { resolveRunKey, engineKeyMessage } from "@/lib/trial";
 import { PROVIDERS, modelLabel } from "@/lib/models";
 import { timeAgo } from "@/lib/utils";
 import type { Run, RunStatus } from "@/lib/types";
@@ -51,13 +51,10 @@ export default async function RunsPage() {
 
   // Ask the same resolver the run endpoint uses. Gating the button on a BYOK
   // key alone disabled it for trial users who had free runs left — the server
-  // would have accepted the request the UI refused to send.
-  const key = await resolveKey(
-    supabase,
-    user.id,
-    project.default_provider,
-    project.default_model,
-  );
+  // would have accepted the request the UI refused to send. It has to be the
+  // RUN resolver specifically: the lenient one accepts any provider's key, so
+  // the button read "ready" for an engine that has no key behind it.
+  const key = await resolveRunKey(supabase, user.id, project);
   const canRun = key.source === "own" || key.source === "trial";
 
   const { count: activePrompts } = await supabase
@@ -80,10 +77,14 @@ export default async function RunsPage() {
         // The model that will ACTUALLY run: a trial run is forced onto the
         // provider's cheap model, so naming the project default here told
         // users to expect Opus and then handed them Haiku.
-        description={`Each run asks your active prompts to ${modelLabel(
-          key.provider,
-          key.model,
-        )} and records where your brand shows up.`}
+        description={
+          canRun
+            ? `Each run asks your active prompts to ${modelLabel(
+                key.provider,
+                key.model,
+              )} and records where your brand shows up.`
+            : engineKeyMessage(key)
+        }
         action={
           <RunNow
             canRun={canRun}

--- a/app/dashboard/runs/run-now.tsx
+++ b/app/dashboard/runs/run-now.tsx
@@ -14,7 +14,7 @@ export function RunNow({
 }: {
   canRun: boolean;
   /** Why we can or can't run, so the hint names the actual blocker. */
-  keySource: "own" | "trial" | "none" | "exhausted";
+  keySource: "own" | "trial" | "none" | "exhausted" | "mismatch";
   activePrompts: number;
   providerLabel: string;
 }) {
@@ -73,6 +73,17 @@ export function RunNow({
             Settings
           </Link>{" "}
           to run.
+        </p>
+      )}
+      {/* Has keys, just not for the engine they picked. Both fixes live on the
+          same page, so the link does double duty. */}
+      {keySource === "mismatch" && (
+        <p className="text-xs text-ink-faint">
+          No {providerLabel} key saved. Add one, or change your answer engine, in{" "}
+          <Link href="/dashboard/settings" className="text-terracotta-dark hover:text-terracotta">
+            Settings
+          </Link>
+          .
         </p>
       )}
       {canRun && activePrompts === 0 && (

--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -69,7 +69,10 @@ export default async function SettingsPage() {
               </p>
             </div>
           </div>
-          <ProjectForm project={project} />
+          <ProjectForm
+            project={project}
+            configuredProviders={keys.map((k) => k.provider)}
+          />
         </CardBody>
       </Card>
 

--- a/app/dashboard/settings/project-form.tsx
+++ b/app/dashboard/settings/project-form.tsx
@@ -4,8 +4,8 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Check } from "lucide-react";
 import { Button, Input, Textarea, Select, Label, Spinner } from "@/components/ui";
-import { PROVIDER_LIST } from "@/lib/models";
-import type { Project, Schedule } from "@/lib/types";
+import { PROVIDER_LIST, PROVIDERS } from "@/lib/models";
+import type { Project, Provider, Schedule } from "@/lib/types";
 
 const SCHEDULE_LABELS: Record<Schedule, string> = {
   off: "Manual only",
@@ -24,7 +24,15 @@ function splitEngine(value: string): { provider: string; model: string } {
     : { provider: value.slice(0, sep), model: value.slice(sep + 1) };
 }
 
-export default function ProjectForm({ project }: { project: Project | null }) {
+export default function ProjectForm({
+  project,
+  configuredProviders = [],
+}: {
+  project: Project | null;
+  /** Providers the user has a key for, so the picker can flag an engine that
+   *  can't run before they discover it as a failed run. */
+  configuredProviders?: Provider[];
+}) {
   const router = useRouter();
 
   const [name, setName] = useState(project?.name ?? "");
@@ -45,6 +53,12 @@ export default function ProjectForm({ project }: { project: Project | null }) {
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Reflects the CURRENT dropdown value, not the saved project, so the warning
+  // appears while they're choosing rather than after the next failed run.
+  const selectedProvider = splitEngine(engine).provider as Provider;
+  const engineNeedsKey =
+    Boolean(PROVIDERS[selectedProvider]) && !configuredProviders.includes(selectedProvider);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -192,11 +206,19 @@ export default function ProjectForm({ project }: { project: Project | null }) {
             </optgroup>
           ))}
         </Select>
-        <p className="mt-1.5 text-xs text-ink-faint">
-          Which assistant we query for this brand. You&apos;ll need a key for the
-          matching provider in the section above. Google AI Overviews and Gemini both
-          use your Google key.
-        </p>
+        {engineNeedsKey ? (
+          <p className="mt-1.5 text-xs text-terracotta">
+            No {PROVIDERS[selectedProvider].label} key saved, so runs on this engine
+            will fail. Add one in the section above, or pick an engine you have a key
+            for. We never answer with a different assistant than the one selected.
+          </p>
+        ) : (
+          <p className="mt-1.5 text-xs text-ink-faint">
+            Which assistant we query for this brand. You&apos;ll need a key for the
+            matching provider in the section above. Google AI Overviews and Gemini both
+            use your Google key.
+          </p>
+        )}
       </div>
 
       <div>

--- a/lib/api-service.test.ts
+++ b/lib/api-service.test.ts
@@ -13,13 +13,13 @@ import {
   setPromptActive,
   triggerRunForProject,
 } from "@/lib/api-service";
-import { pickDefaultProvider, resolveKey, resolveRunKey } from "@/lib/trial";
+import { pickDefaultProvider, resolveRunKeyFor, engineKeyMessage } from "@/lib/trial";
 import { executeRun } from "@/lib/engine";
 
 vi.mock("@/lib/trial", () => ({
   pickDefaultProvider: vi.fn(),
-  resolveKey: vi.fn(),
-  resolveRunKey: vi.fn(),
+  resolveRunKeyFor: vi.fn(),
+  engineKeyMessage: vi.fn(),
 }));
 vi.mock("@/lib/engine", () => ({ executeRun: vi.fn() }));
 
@@ -140,8 +140,10 @@ function makeMention(overrides: Partial<Mention>): Mention {
 
 beforeEach(() => {
   vi.mocked(pickDefaultProvider).mockReset().mockReturnValue("anthropic");
-  vi.mocked(resolveKey).mockReset();
-  vi.mocked(resolveRunKey).mockReset();
+  vi.mocked(resolveRunKeyFor).mockReset();
+  vi.mocked(engineKeyMessage)
+    .mockReset()
+    .mockImplementation((k) => `engine message for ${k.requested.provider}`);
   vi.mocked(executeRun).mockReset();
 });
 
@@ -281,14 +283,15 @@ describe("triggerRunForProject", () => {
     expect(executeRun).not.toHaveBeenCalled();
   });
 
-  it.each(["trial", "none", "exhausted"] as const)(
+  it.each(["trial", "none", "exhausted", "mismatch"] as const)(
     "refuses to run on key source %s (BYOK-only)",
     async (source) => {
       const db = fakeDb({ projects: () => ({ data: PROJECT }) });
-      vi.mocked(resolveRunKey).mockResolvedValue({
+      vi.mocked(resolveRunKeyFor).mockResolvedValue({
         source,
         provider: "anthropic",
         model: "claude-sonnet-4-6",
+        requested: { provider: "anthropic", model: "claude-sonnet-4-6" },
       });
       const outcome = await triggerRunForProject(db as never, "user-1", "proj-1");
       expect(outcome).toMatchObject({ ok: false, code: "no_key" });
@@ -298,11 +301,12 @@ describe("triggerRunForProject", () => {
 
   it("executes with the user's own key", async () => {
     const db = fakeDb({ projects: () => ({ data: PROJECT }) });
-    vi.mocked(resolveRunKey).mockResolvedValue({
+    vi.mocked(resolveRunKeyFor).mockResolvedValue({
       source: "own",
       apiKey: "sk-ant-user-key",
       provider: "anthropic",
       model: "claude-sonnet-4-6",
+      requested: { provider: "anthropic", model: "claude-sonnet-4-6" },
     });
     vi.mocked(executeRun).mockResolvedValue({
       runId: "run-9",
@@ -322,13 +326,14 @@ describe("triggerRunForProject", () => {
     );
   });
 
-  it("resolves a caller-sent provider/model with resolveKey, not the project default", async () => {
+  it("resolves a caller-sent provider/model instead of the project default", async () => {
     const db = fakeDb({ projects: () => ({ data: PROJECT }) });
-    vi.mocked(resolveKey).mockResolvedValue({
+    vi.mocked(resolveRunKeyFor).mockResolvedValue({
       source: "own",
       apiKey: "sk-user-openai-key",
       provider: "openai",
       model: "gpt-4o-mini",
+      requested: { provider: "openai", model: "gpt-4o-mini" },
     });
     vi.mocked(executeRun).mockResolvedValue({
       runId: "run-10",
@@ -342,8 +347,7 @@ describe("triggerRunForProject", () => {
       model: "gpt-4o-mini",
     });
     expect(outcome).toMatchObject({ ok: true, result: { runId: "run-10" } });
-    expect(resolveRunKey).not.toHaveBeenCalled();
-    expect(resolveKey).toHaveBeenCalledWith(db, "user-1", "openai", "gpt-4o-mini");
+    expect(resolveRunKeyFor).toHaveBeenCalledWith(db, "user-1", "openai", "gpt-4o-mini");
     expect(executeRun).toHaveBeenCalledWith(
       expect.objectContaining({
         provider: "openai",
@@ -353,18 +357,61 @@ describe("triggerRunForProject", () => {
     );
   });
 
+  // An override naming only the provider must not carry the PROJECT's model
+  // across: "run this on openai" with the project set to claude-sonnet-4-6
+  // would otherwise ask OpenAI for a Claude model id.
+  it("drops the project model when the override changes provider", async () => {
+    const db = fakeDb({ projects: () => ({ data: PROJECT }) });
+    vi.mocked(resolveRunKeyFor).mockResolvedValue({
+      source: "own",
+      apiKey: "sk-user-openai-key",
+      provider: "openai",
+      model: "gpt-4o",
+      requested: { provider: "openai", model: "gpt-4o" },
+    });
+    vi.mocked(executeRun).mockResolvedValue({
+      runId: "run-11",
+      status: "completed",
+      totalResponses: 1,
+      tokensUsed: 10,
+    });
+
+    await triggerRunForProject(db as never, "user-1", "proj-1", { provider: "openai" });
+    expect(resolveRunKeyFor).toHaveBeenCalledWith(db, "user-1", "openai", undefined);
+  });
+
   it("names the requested provider when an override has no own key", async () => {
     const db = fakeDb({ projects: () => ({ data: PROJECT }) });
-    vi.mocked(resolveKey).mockResolvedValue({
+    vi.mocked(resolveRunKeyFor).mockResolvedValue({
       source: "none",
       provider: "openai",
       model: "gpt-4o",
+      requested: { provider: "openai", model: "gpt-4o" },
     });
     const outcome = await triggerRunForProject(db as never, "user-1", "proj-1", {
       provider: "openai",
     });
     expect(outcome).toMatchObject({ ok: false, code: "no_key" });
     expect((outcome as { message: string }).message).toContain("OpenAI");
+    expect(executeRun).not.toHaveBeenCalled();
+  });
+
+  // The reported bug, at the API surface: a caller asking for GPT-4o with only
+  // an Anthropic key on file used to get a Claude run reported as a success.
+  it("refuses rather than silently running the engine it has a key for", async () => {
+    const db = fakeDb({ projects: () => ({ data: PROJECT }) });
+    vi.mocked(resolveRunKeyFor).mockResolvedValue({
+      source: "mismatch",
+      provider: "openai",
+      model: "gpt-4o",
+      requested: { provider: "openai", model: "gpt-4o" },
+      available: ["anthropic"],
+    });
+    const outcome = await triggerRunForProject(db as never, "user-1", "proj-1", {
+      provider: "openai",
+    });
+    expect(outcome).toMatchObject({ ok: false, code: "no_key" });
+    expect((outcome as { message: string }).message).toContain("engine message for openai");
     expect(executeRun).not.toHaveBeenCalled();
   });
 });

--- a/lib/api-service.ts
+++ b/lib/api-service.ts
@@ -21,7 +21,7 @@ import {
   type TopicStat,
 } from "@/lib/metrics";
 import { executeRun, type RunContext, type RunResult } from "@/lib/engine";
-import { pickDefaultProvider, resolveKey, resolveRunKey } from "@/lib/trial";
+import { pickDefaultProvider, resolveRunKeyFor, engineKeyMessage } from "@/lib/trial";
 import { defaultModelFor, isProvider, PROVIDERS } from "@/lib/models";
 
 // Operations behind the programmatic surface, shared by the REST v1 routes and
@@ -620,24 +620,24 @@ export async function triggerRunForProject(
   }
 
   // A caller-sent provider/model overrides the project default for this run
-  // only (the project row is untouched); key resolution still prefers the
-  // requested provider and falls back like the dashboard does.
-  const key =
-    options?.provider || options?.model
-      ? await resolveKey(
-          supabase,
-          userId,
-          options.provider ?? project.default_provider,
-          options.model,
-        )
-      : await resolveRunKey(supabase, userId, project);
+  // only (the project row is untouched). Resolution is strict either way: an
+  // API caller that asks for gpt-4o and gets Claude back has no way to notice,
+  // and the run row would claim the engine it was actually given.
+  const key = await resolveRunKeyFor(
+    supabase,
+    userId,
+    options?.provider ?? project.default_provider,
+    options?.model ?? (options?.provider ? undefined : project.default_model),
+  );
   if (key.source !== "own") {
-    const providerLabel =
-      PROVIDERS[options?.provider ?? project.default_provider].label;
+    const providerLabel = PROVIDERS[key.requested.provider].label;
     return {
       ok: false,
       code: "no_key",
-      message: `API-triggered runs require your own ${providerLabel} key. Add one in Settings (free-trial runs are dashboard-only).`,
+      message:
+        key.source === "mismatch"
+          ? `${engineKeyMessage(key)} (API-triggered runs are BYOK; free-trial runs are dashboard-only.)`
+          : `API-triggered runs require your own ${providerLabel} key. Add one in Settings (free-trial runs are dashboard-only).`,
     };
   }
 

--- a/lib/trial.test.ts
+++ b/lib/trial.test.ts
@@ -3,11 +3,16 @@ import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 // trial.ts pulls in lib/data (getDecryptedKey), which calls React's cache() at
 // module load, unavailable in the node test env. Stub it so the import graph
 // stays clean; resolveKey's own use of it is mocked per-test below.
-vi.mock("@/lib/data", () => ({ getDecryptedKey: vi.fn() }));
+vi.mock("@/lib/data", () => ({
+  getDecryptedKey: vi.fn(),
+  getConfiguredProviders: vi.fn(),
+}));
 
-import { getDecryptedKey } from "@/lib/data";
+import { getDecryptedKey, getConfiguredProviders } from "@/lib/data";
 import {
   resolveKey,
+  resolveRunKeyFor,
+  engineKeyMessage,
   trialKeyFor,
   trialModelFor,
   trialEnabled,
@@ -34,6 +39,7 @@ const TRIAL_VARS = [
   "TRIAL_ANTHROPIC_API_KEY",
   "TRIAL_OPENAI_API_KEY",
   "TRIAL_GOOGLE_API_KEY",
+  "TRIAL_PERPLEXITY_API_KEY",
   "TRIAL_ANTHROPIC_MODEL",
   "TRIAL_OPENAI_MODEL",
   "TRIAL_GOOGLE_MODEL",
@@ -50,6 +56,7 @@ beforeEach(() => {
   }
   process.env.TRIAL_RUN_LIMIT = "5";
   vi.mocked(getDecryptedKey).mockReset().mockResolvedValue(null);
+  vi.mocked(getConfiguredProviders).mockReset().mockResolvedValue([]);
 });
 
 afterEach(() => {
@@ -114,6 +121,95 @@ describe("resolveKey", () => {
   });
 });
 
+// Only the named providers have a stored key.
+function ownsKeysFor(...providers: string[]) {
+  vi.mocked(getConfiguredProviders).mockResolvedValue(providers as never);
+  vi.mocked(getDecryptedKey).mockImplementation(async (_db, _user, p) =>
+    providers.includes(p) ? `key-for-${p}` : null,
+  );
+}
+
+describe("resolveRunKeyFor", () => {
+  // LET-172. The user picked GPT-4o as their answer engine and had only an
+  // Anthropic key saved; the run resolved to Claude Opus 4.8 and stored those
+  // answers as this project's monitoring data. A run must never answer as an
+  // assistant other than the one selected — the trend line is the product.
+  it("refuses to substitute another provider's key for the chosen engine", async () => {
+    ownsKeysFor("anthropic");
+    const k = await resolveRunKeyFor(db(0), "user-1", "openai", "gpt-4o");
+    expect(k.source).toBe("mismatch");
+    expect(k.apiKey).toBeUndefined();
+    expect(k.provider).toBe("openai");
+    expect(k.available).toEqual(["anthropic"]);
+  });
+
+  it("names the engine and the switch in the mismatch message", async () => {
+    ownsKeysFor("anthropic");
+    const k = await resolveRunKeyFor(db(0), "user-1", "openai", "gpt-4o");
+    const message = engineKeyMessage(k);
+    expect(message).toContain("GPT-4o");
+    expect(message).toContain("OpenAI (ChatGPT)");
+    expect(message).toContain("Anthropic (Claude)");
+  });
+
+  it("lists every switchable engine when several keys are held", async () => {
+    ownsKeysFor("anthropic", "google");
+    const k = await resolveRunKeyFor(db(0), "user-1", "openai");
+    expect(k.available).toEqual(["anthropic", "google"]);
+    expect(engineKeyMessage(k)).toContain("Anthropic (Claude) or Google (Gemini)");
+  });
+
+  it("uses the chosen engine's own key, with the requested model", async () => {
+    ownsKeysFor("openai", "anthropic");
+    const k = await resolveRunKeyFor(db(0), "user-1", "openai", "gpt-4o");
+    expect(k.source).toBe("own");
+    expect(k.apiKey).toBe("key-for-openai");
+    expect(k.model).toBe("gpt-4o");
+  });
+
+  // A trial swaps the MODEL to cap operator cost, which is fine — it's still
+  // the assistant the user picked — but `requested` has to keep the difference
+  // visible so the UI doesn't promise Opus and deliver Haiku.
+  it("takes a trial key only for the chosen provider, and records the swap", async () => {
+    process.env.TRIAL_ANTHROPIC_API_KEY = "sk-ant-trial";
+    process.env.TRIAL_ANTHROPIC_MODEL = "claude-haiku-4-5";
+    const k = await resolveRunKeyFor(db(0), "user-1", "anthropic", "claude-opus-4-8");
+    expect(k.source).toBe("trial");
+    expect(k.model).toBe("claude-haiku-4-5");
+    expect(k.requested).toEqual({ provider: "anthropic", model: "claude-opus-4-8" });
+  });
+
+  it("ignores a trial key belonging to a different provider", async () => {
+    process.env.TRIAL_ANTHROPIC_API_KEY = "sk-ant-trial";
+    const k = await resolveRunKeyFor(db(0), "user-1", "openai", "gpt-4o");
+    expect(k.source).toBe("none");
+    expect(k.apiKey).toBeUndefined();
+  });
+
+  it("reports exhausted when the chosen engine's trial is spent and no key is held", async () => {
+    process.env.TRIAL_ANTHROPIC_API_KEY = "sk-ant-trial";
+    const k = await resolveRunKeyFor(db(5), "user-1", "anthropic");
+    expect(k.source).toBe("exhausted");
+  });
+
+  // Holding a usable key elsewhere is the more actionable fact than a spent
+  // allowance: switching engine costs nothing, topping up the trial isn't a
+  // thing they can do.
+  it("prefers mismatch over exhausted when another key is available", async () => {
+    process.env.TRIAL_ANTHROPIC_API_KEY = "sk-ant-trial";
+    ownsKeysFor("openai");
+    const k = await resolveRunKeyFor(db(5), "user-1", "anthropic");
+    expect(k.source).toBe("mismatch");
+  });
+
+  it("defaults the model when none is given", async () => {
+    ownsKeysFor("openai");
+    const k = await resolveRunKeyFor(db(0), "user-1", "openai");
+    expect(k.model).toBe("gpt-4o");
+    expect(k.requested.model).toBe("gpt-4o");
+  });
+});
+
 describe("trial key resolution", () => {
   it("reads the google trial key from TRIAL_GOOGLE_API_KEY, not the openai slot", () => {
     process.env.TRIAL_GOOGLE_API_KEY = "AIzaTrialGoogle";
@@ -132,6 +228,13 @@ describe("trial key resolution", () => {
   it("counts google when deciding whether any trial is offered", () => {
     expect(trialEnabled()).toBe(false);
     process.env.TRIAL_GOOGLE_API_KEY = "AIzaTrialGoogle";
+    expect(trialEnabled()).toBe(true);
+  });
+
+  // The list was written out by hand and never gained perplexity, so a
+  // perplexity-only deployment reported that it offered no trial at all.
+  it("counts perplexity too", () => {
+    process.env.TRIAL_PERPLEXITY_API_KEY = "pplx-trial";
     expect(trialEnabled()).toBe(true);
   });
 

--- a/lib/trial.ts
+++ b/lib/trial.ts
@@ -1,7 +1,7 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Project, Provider } from "@/lib/types";
-import { getDecryptedKey } from "@/lib/data";
-import { defaultModelFor } from "@/lib/models";
+import { getDecryptedKey, getConfiguredProviders } from "@/lib/data";
+import { defaultModelFor, modelLabel, PROVIDERS } from "@/lib/models";
 
 // ------------------------------------------------------------------
 // Free-trial layer. When the operator configures a shared (trial) key, users
@@ -34,6 +34,11 @@ const TRIAL_MODEL_ENV: Record<Provider, string> = {
   perplexity: "TRIAL_PERPLEXITY_MODEL",
 };
 
+// Derived from the env map above rather than written out again, so a provider
+// added to the catalog can't be silently skipped here — omitting perplexity
+// from this list is what made a perplexity-only deployment report no trial.
+const PROVIDER_IDS = Object.keys(TRIAL_KEY_ENV) as Provider[];
+
 /** The operator's shared key for a provider, if configured. */
 export function trialKeyFor(provider: Provider): string | null {
   const v = process.env[TRIAL_KEY_ENV[provider]];
@@ -48,9 +53,7 @@ export function trialModelFor(provider: Provider, fallback: string): string {
 
 /** True if a trial is offered for at least one provider. */
 export function trialEnabled(): boolean {
-  return Boolean(
-    trialKeyFor("anthropic") || trialKeyFor("openai") || trialKeyFor("google"),
-  );
+  return PROVIDER_IDS.some((p) => trialKeyFor(p));
 }
 
 /** How many free trial runs this user has already consumed. */
@@ -66,15 +69,23 @@ export async function getTrialRunsUsed(
   return Number((data as { trial_runs_used?: number } | null)?.trial_runs_used ?? 0);
 }
 
-export type KeySource = "own" | "trial" | "none" | "exhausted";
+export type KeySource = "own" | "trial" | "none" | "exhausted" | "mismatch";
 
 export interface ResolvedKey {
   source: KeySource;
   apiKey?: string;
   provider: Provider;
   model: string; // model to run with (own -> project model; trial -> trial override)
+  /** What was ASKED for, before any substitution. `provider`/`model` above are
+   *  what will actually be called, and the two differ whenever a trial forces a
+   *  cheaper model or a non-run task falls back to another provider's key. Every
+   *  surface that tells a user which engine they're on needs both. */
+  requested: { provider: Provider; model: string };
   remaining?: number; // free runs left (for 'trial'/'exhausted')
   limit?: number; // the free-run allowance
+  /** For 'mismatch': providers the user DOES hold a key for, so the message can
+   *  name the one-click fix instead of just refusing. */
+  available?: Provider[];
 }
 
 /** The provider new projects default to: one we can actually serve (has a trial key), else anthropic. */
@@ -94,9 +105,15 @@ const PROVIDER_ORDER: Record<Provider, Provider[]> = {
 };
 
 /**
- * Resolve the best available key for a task, preferring `preferred` then falling
- * back to the other provider. Own key beats trial; trial requires free runs
- * remaining. This is what lets users never pick a provider themselves.
+ * Resolve a key for AUXILIARY work — prompt/competitor/topic suggestion — by
+ * preferring `preferred` and then falling back to any other provider the user
+ * can pay for. Own key beats trial; trial requires free runs remaining. This is
+ * what lets users never pick a provider themselves.
+ *
+ * Cross-provider fallback is safe HERE and only here: the output is a list of
+ * suggestions the user reviews, not a measurement that gets stored and charted.
+ * Monitoring runs must use resolveRunKey instead — see the note there.
+ *
  * - 'own'       the user's own key (unlimited by us)
  * - 'trial'     the operator's shared key, free runs still remaining
  * - 'exhausted' had trial access but used up their free runs -> must add own key
@@ -111,11 +128,12 @@ export async function resolveKey(
   const order = PROVIDER_ORDER[preferred];
   const modelFor = (p: Provider) =>
     p === preferred && preferredModel ? preferredModel : defaultModelFor(p);
+  const requested = { provider: preferred, model: modelFor(preferred) };
 
   // 1. The user's own key (unlimited by us).
   for (const p of order) {
     const own = await getDecryptedKey(supabase, userId, p);
-    if (own) return { source: "own", apiKey: own, provider: p, model: modelFor(p) };
+    if (own) return { source: "own", apiKey: own, provider: p, model: modelFor(p), requested };
   }
 
   // 2. A trial key, if free runs remain.
@@ -132,6 +150,7 @@ export async function resolveKey(
         apiKey: tk,
         provider: p,
         model: trialModelFor(p, modelFor(p)),
+        requested,
         remaining: Math.max(0, limit - used),
         limit,
       };
@@ -139,18 +158,98 @@ export async function resolveKey(
   }
 
   if (trialConfigured) {
-    return { source: "exhausted", provider: preferred, model: modelFor(preferred), remaining: 0, limit };
+    return { source: "exhausted", provider: preferred, model: requested.model, requested, remaining: 0, limit };
   }
-  return { source: "none", provider: preferred, model: modelFor(preferred) };
+  return { source: "none", provider: preferred, model: requested.model, requested };
 }
 
-/** Resolve the key for a project's monitoring run (delegates to resolveKey). */
+/**
+ * Resolve the key for a MONITORING RUN, for the chosen engine and nothing else.
+ *
+ * Deliberately strict where resolveKey is forgiving. A run's answers are stored
+ * with a provider/model and charted as "how this assistant talks about your
+ * brand", so quietly asking a different assistant because that's the key we
+ * happened to find doesn't degrade gracefully — it fabricates the measurement.
+ * A user with GPT-4o selected and only an Anthropic key saved got a Claude run
+ * labelled as their monitoring data, and every later point on the trend line
+ * was a different engine than the one before it.
+ *
+ * So: only the requested provider's key is acceptable. When it's missing we say
+ * which engine is selected, which key is missing, and — via 'mismatch' — which
+ * engines they could switch to instead.
+ */
+export async function resolveRunKeyFor(
+  supabase: SupabaseClient,
+  userId: string,
+  provider: Provider,
+  model?: string,
+): Promise<ResolvedKey> {
+  const requested = { provider, model: model || defaultModelFor(provider) };
+  const base = { provider, model: requested.model, requested };
+
+  const own = await getDecryptedKey(supabase, userId, provider);
+  if (own) return { ...base, source: "own", apiKey: own };
+
+  // The operator's shared key, but only for the engine actually chosen.
+  const limit = trialRunLimit();
+  const trialKey = trialKeyFor(provider);
+  if (trialKey) {
+    const used = await getTrialRunsUsed(supabase, userId);
+    if (used < limit) {
+      return {
+        ...base,
+        source: "trial",
+        apiKey: trialKey,
+        // Still a substitution, but within the chosen provider: the answers
+        // remain that assistant's, and `requested` carries the difference.
+        model: trialModelFor(provider, requested.model),
+        remaining: Math.max(0, limit - used),
+        limit,
+      };
+    }
+  }
+
+  // No key for the selected engine. Holding a key for a DIFFERENT one is the
+  // more useful thing to report than "no key": the fix is a dropdown, not a
+  // signup. This is the case that used to fall through and run on Claude.
+  const others = (await getConfiguredProviders(supabase, userId)).filter(
+    (p) => p !== provider,
+  );
+  if (others.length > 0) return { ...base, source: "mismatch", available: others };
+
+  if (trialKey) return { ...base, source: "exhausted", remaining: 0, limit };
+  return { ...base, source: "none" };
+}
+
+/** Resolve the key for a project's monitoring run (delegates to resolveRunKeyFor). */
 export async function resolveRunKey(
   supabase: SupabaseClient,
   userId: string,
   project: Project,
 ): Promise<ResolvedKey> {
-  return resolveKey(supabase, userId, project.default_provider, project.default_model);
+  return resolveRunKeyFor(supabase, userId, project.default_provider, project.default_model);
+}
+
+/**
+ * The one phrasing of "your selected engine has no key" — shared so the
+ * dashboard, the onboarding flow and the REST API can't drift into describing
+ * the same state three different ways. Handles 'mismatch', 'none' and
+ * 'exhausted'; the usable sources ('own'/'trial') have nothing to explain.
+ */
+export function engineKeyMessage(key: ResolvedKey): string {
+  const engine = modelLabel(key.requested.provider, key.requested.model);
+  const providerLabel = PROVIDERS[key.requested.provider].label;
+
+  if (key.source === "exhausted") {
+    return `You've used all ${key.limit ?? 0} free runs on ${engine}. Add your own ${providerLabel} key in Settings to keep monitoring.`;
+  }
+  if (key.source === "mismatch") {
+    const have = (key.available ?? []).map((p) => PROVIDERS[p].label);
+    const alternatives =
+      have.length === 1 ? have[0] : `${have.slice(0, -1).join(", ")} or ${have[have.length - 1]}`;
+    return `Your answer engine is set to ${engine}, but no ${providerLabel} key is saved. Add one in Settings, or switch your answer engine to ${alternatives} — you already have a key for that.`;
+  }
+  return `Your answer engine is set to ${engine}. Add a ${providerLabel} key in Settings to run.`;
 }
 
 /** Add consumed tokens to the caller's trial tally (atomic, self-scoped rpc).


### PR DESCRIPTION
Fixes [LET-172](https://linear.app/letterbrace/issue/LET-172/model-used-bug).

## The bug

GPT-4o was selected as the answer engine with only an Anthropic key saved. The run executed on **Claude Opus 4.8** and stored those answers as the project's monitoring data — no error, no notice.

`resolveKey` walks a fallback order (`openai → anthropic → google → perplexity`) and returns the first provider the user holds *any* key for. That's correct for generating prompt suggestions. It's wrong for a run: the answers are stored with a provider/model and charted as "how this assistant talks about your brand", so substituting a different assistant doesn't degrade gracefully — it fabricates the measurement, and consecutive points on a trend line can be different engines.

Worth noting the surfaces already disagreed: **cron** looked up the key for `default_provider` only and skipped with "no key", so a scheduled run quietly stopped while a manual run quietly switched engines.

## The fix

Split the lenient and strict uses apart rather than making one resolver do both:

- **`resolveKey`** keeps its cross-provider fallback and now serves only the suggestion routes (competitors, topic prompts, onboarding). Their output is a draft the user reviews before anything is saved, so any key will do.
- **`resolveRunKeyFor`** (new) is what monitoring runs use. It accepts the chosen provider's key and nothing else. When there isn't one it returns `mismatch`, carrying the providers the user *does* hold keys for, so the message can name the one-click fix instead of just refusing.

`ResolvedKey` now also carries `requested` next to the provider/model that will actually be called. The two legitimately differ when a trial forces the provider's cheap model, and every surface that names an engine needs both.

## Surfaced at each point the user could hit it

| Where | Before | After |
|---|---|---|
| Settings engine picker | generic "you'll need a key" note | warns as they choose: no OpenAI key saved, runs on this engine will fail |
| Runs page | "Each run asks your prompts to GPT-4o" | explains the missing key; Run button disabled with the fix |
| `POST /api/runs` | 200, ran on Claude | 400 naming the engine, the missing key, and the switch |
| `POST /api/v1/.../runs` (CLI/MCP) | 200, ran on Claude | `no_key` with the same message |
| Cron | skipped silently | unchanged (already strict) |

Onboarding now starts a project on an engine the user can actually run — their own key first, then the operator's trial config. Previously `pickDefaultProvider()` read env only, and with runs no longer papering over the gap, a BYOK user could land on a project whose first monitor couldn't execute with a perfectly good key in Settings.

Message wording lives in one `engineKeyMessage` helper so the dashboard, onboarding and REST API can't drift into describing the same state three ways.

## Also

`trialEnabled()` had its provider list written out by hand and never gained perplexity, so a perplexity-only deployment reported it offered no trial. Now derived from the trial env map.

## A judgment call worth reviewing

This **refuses** rather than running-and-notifying. The ticket offered either. Notify-only preserves "a run always works", but leaves mixed-engine data in the trend line, which seemed like the worse failure for a measurement product. Straightforward to flip if we'd rather warn.

## Testing

334 tests pass; typecheck, lint and build clean. New coverage: the LET-172 case itself at both the resolver and the API surface, mismatch vs. exhausted precedence, trial keys not leaking across providers, and the model-override path not carrying a Claude model id into an OpenAI request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
