### PR TITLE
Nudge the user to check results when a run finishes (LET-170)

### DIFF
--- a/app/api/runs/seen/route.ts
+++ b/app/api/runs/seen/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { getProject } from "@/lib/data";
+import { markResultsSeen } from "@/lib/results-seen";
+import { humanError } from "@/lib/llm";
+
+export const dynamic = "force-dynamic";
+
+// POST /api/runs/seen — record that the signed-in user has looked at their
+// active project's results, clearing the "run finished" nudge.
+//
+// Two callers, deliberately different: opening a run report sends that run's
+// id, so the mark lands on its finish time and a NEWER unread run stays
+// flagged; dismissing the banner sends nothing, acknowledging everything so far.
+export async function POST(request: Request) {
+  const supabase = createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const project = await getProject(supabase, user.id);
+  if (!project) {
+    return NextResponse.json({ error: "No project" }, { status: 400 });
+  }
+
+  let runId: string | null = null;
+  try {
+    const body = (await request.json()) as Record<string, unknown>;
+    if (typeof body?.runId === "string" && body.runId.trim()) runId = body.runId.trim();
+  } catch {
+    // No body at all is the dismiss case, not an error.
+  }
+
+  try {
+    const outcome = await markResultsSeen(supabase, project, runId);
+    if (!outcome.ok) {
+      return NextResponse.json({ error: "Run not found" }, { status: 404 });
+    }
+    // `changed` lets the viewer skip a router.refresh() it doesn't need, which
+    // is what keeps mark-on-view from bouncing between write and re-render.
+    return NextResponse.json({ changed: outcome.changed, seenAt: outcome.seenAt });
+  } catch (e) {
+    return NextResponse.json({ error: humanError(e) }, { status: 500 });
+  }
+}

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -4,10 +4,14 @@ import { DashboardNav } from "@/components/dashboard/nav";
 import { OrgSwitcher } from "@/components/dashboard/org-switcher";
 import { SignOutButton } from "@/components/dashboard/signout";
 import { TrialBanner } from "@/components/dashboard/trial-banner";
+import { RunReadyBanner } from "@/components/dashboard/run-ready-banner";
 import { ThemeToggle } from "@/components/theme";
 import { createClient } from "@/lib/supabase/server";
 import { getProject, getProjects, getConfiguredProviders } from "@/lib/data";
+import { getUnseenRun } from "@/lib/results-seen";
 import { trialEnabled, trialRunLimit, getTrialRunsUsed } from "@/lib/trial";
+import { modelLabel } from "@/lib/models";
+import { timeAgo } from "@/lib/utils";
 
 export const dynamic = "force-dynamic";
 
@@ -42,6 +46,11 @@ export default async function DashboardLayout({
     const limit = trialRunLimit();
     trial = { used, limit, exhausted: used >= limit };
   }
+
+  // A finished run the owner hasn't opened. Lives in the layout so it follows
+  // them across the dashboard rather than only appearing on the page they
+  // happened to be on when the run landed.
+  const unseenRun = project ? await getUnseenRun(supabase, project) : null;
 
   return (
     <div className="min-h-screen bg-paper md:flex">
@@ -91,6 +100,19 @@ export default async function DashboardLayout({
 
       <main className="flex-1 overflow-y-auto px-6 py-8 md:px-10 md:h-screen">
         <div className="mx-auto max-w-6xl">
+          {/* Above the trial banner: this one is timely and clears itself,
+              where the BYOK nudge is standing context. */}
+          {unseenRun && (
+            <RunReadyBanner
+              runId={unseenRun.id}
+              status={unseenRun.status === "failed" ? "failed" : "completed"}
+              answers={unseenRun.completed_count}
+              plannedAnswers={unseenRun.prompt_count}
+              modelName={modelLabel(unseenRun.provider, unseenRun.model)}
+              finishedAgo={timeAgo(unseenRun.finished_at ?? unseenRun.created_at)}
+              error={unseenRun.error}
+            />
+          )}
           {trial && (
             <TrialBanner used={trial.used} limit={trial.limit} exhausted={trial.exhausted} />
           )}

--- a/app/dashboard/runs/[id]/mark-seen.tsx
+++ b/app/dashboard/runs/[id]/mark-seen.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useRouter } from "next/navigation";
+
+/**
+ * Opening a run's report IS checking the results, so it clears the nudge —
+ * whether the user got here from the banner, the Runs list, or a bookmark.
+ *
+ * Renders nothing. The write is fire-and-forget: a failed mark just means the
+ * banner is still there next time, which is the harmless direction to fail in.
+ */
+export function MarkResultsSeen({ runId }: { runId: string }) {
+  const router = useRouter();
+  // React 18 mounts effects twice in dev StrictMode, and this posts a write.
+  const sent = useRef(false);
+
+  useEffect(() => {
+    if (sent.current) return;
+    sent.current = true;
+
+    let active = true;
+    void (async () => {
+      try {
+        const res = await fetch("/api/runs/seen", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ runId }),
+        });
+        const data = (await res.json().catch(() => ({}))) as { changed?: boolean };
+        // Only re-render when the mark actually moved: refreshing on every view
+        // would remount this component and post again, forever.
+        if (active && res.ok && data.changed) router.refresh();
+      } catch {
+        // Ignored on purpose — see the note above.
+      }
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, [runId, router]);
+
+  return null;
+}

--- a/app/dashboard/runs/[id]/page.tsx
+++ b/app/dashboard/runs/[id]/page.tsx
@@ -14,6 +14,7 @@ import {
   StatCard,
   EmptyState,
 } from "@/components/ui";
+import { MarkResultsSeen } from "./mark-seen";
 
 export const dynamic = "force-dynamic";
 
@@ -111,6 +112,9 @@ export default async function RunDetailPage({ params }: { params: { id: string }
 
   return (
     <div className="space-y-8">
+      {/* Reaching this page is what "checked the results" means, so it clears
+          the dashboard nudge however the user arrived. */}
+      <MarkResultsSeen runId={run.id} />
       <div className="space-y-4">
         <a
           href="/dashboard/runs"

--- a/components/dashboard/run-ready-banner.tsx
+++ b/components/dashboard/run-ready-banner.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { BarChart3, TriangleAlert, X } from "lucide-react";
+import { Button } from "@/components/ui";
+import { cn } from "@/lib/utils";
+
+// Shown at the top of the dashboard when a monitoring run has finished that the
+// owner hasn't opened yet — the counterpart to TrialBanner, which nudges toward
+// BYOK. Until this existed a finished run announced itself nowhere: the
+// scheduler completes runs while nobody is watching, and a manual run just
+// appears as another row in the Runs list.
+//
+// Clearing it is a real write (projects.results_seen_at), not local state, so
+// the nudge doesn't reappear on the next device or the next navigation.
+export function RunReadyBanner({
+  runId,
+  status,
+  answers,
+  plannedAnswers,
+  modelName,
+  finishedAgo,
+  error,
+}: {
+  runId: string;
+  status: "completed" | "failed";
+  answers: number;
+  plannedAnswers: number;
+  modelName: string;
+  /** Pre-formatted on the server so this stays a pure render. */
+  finishedAgo: string;
+  error: string | null;
+}) {
+  const router = useRouter();
+  const [dismissing, setDismissing] = useState(false);
+  const [hidden, setHidden] = useState(false);
+
+  const failed = status === "failed";
+
+  // Dismiss acknowledges everything finished so far, so it sends no run id.
+  async function dismiss() {
+    setDismissing(true);
+    setHidden(true); // optimistic: the nudge should feel instant
+    try {
+      await fetch("/api/runs/seen", { method: "POST" });
+      router.refresh();
+    } catch {
+      // The mark didn't land, so put it back rather than pretending it cleared.
+      setHidden(false);
+    } finally {
+      setDismissing(false);
+    }
+  }
+
+  if (hidden) return null;
+
+  return (
+    <div
+      className={cn(
+        "mb-6 rounded border px-5 py-4",
+        failed
+          ? "border-terracotta/30 bg-terracotta/[0.07]"
+          : "border-mint/30 bg-mint/[0.07]",
+      )}
+    >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-start gap-3">
+          <span
+            className={cn(
+              "mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded",
+              failed
+                ? "bg-terracotta/15 text-terracotta-dark"
+                : "bg-mint/20 text-mint-ink",
+            )}
+          >
+            {failed ? (
+              <TriangleAlert className="h-4 w-4" />
+            ) : (
+              <BarChart3 className="h-4 w-4" />
+            )}
+          </span>
+          <div>
+            <p className="text-sm font-medium text-ink">
+              {failed ? "Your latest run failed" : "Your run finished — results are ready"}
+            </p>
+            <p className="mt-0.5 text-xs text-ink-faint">
+              {failed
+                ? error ??
+                  `No answers were stored on ${modelName}. Monitoring is not collecting data until this is fixed.`
+                : `${answers} of ${plannedAnswers} ${
+                    plannedAnswers === 1 ? "answer" : "answers"
+                  } collected on ${modelName}, ${finishedAgo}. See where your brand showed up.`}
+            </p>
+          </div>
+        </div>
+
+        <div className="flex shrink-0 items-center gap-2">
+          <Button
+            href={`/dashboard/runs/${runId}`}
+            size="sm"
+            variant={failed ? "secondary" : "primary"}
+          >
+            {failed ? "See what happened" : "View results"}
+          </Button>
+          <button
+            type="button"
+            onClick={dismiss}
+            disabled={dismissing}
+            aria-label="Dismiss"
+            className="rounded p-1.5 text-ink-faint transition-colors hover:bg-ink/[0.06] hover:text-ink disabled:opacity-50"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/api-service.test.ts
+++ b/lib/api-service.test.ts
@@ -92,6 +92,7 @@ const PROJECT: Project = {
   description: null,
   default_provider: "anthropic",
   default_model: "claude-sonnet-4-6",
+  results_seen_at: null,
   schedule: "off",
   use_web_search: true,
   replicates: 1,

--- a/lib/results-seen.test.ts
+++ b/lib/results-seen.test.ts
@@ -104,6 +104,21 @@ describe("getUnseenRun", () => {
     const { db } = fakeDb({ runs: run({ finished_at: null }) });
     expect(await getUnseenRun(db, project())).toBeNull();
   });
+
+  // Postgres renders timestamptz as "+00:00" and toISOString() produces "Z",
+  // so these two are the same instant written two ways. Compared as text the
+  // suffix decides it ('Z' > '+') and an already-seen run reads as unseen.
+  it("compares instants, not the string they were written as", async () => {
+    const { db } = fakeDb({ runs: run({ finished_at: "2026-07-20T10:05:00.000+00:00" }) });
+    const seen = project({ results_seen_at: "2026-07-20T10:05:00.000Z" });
+    expect(await getUnseenRun(db, seen)).toBeNull();
+  });
+
+  it("still flags a genuinely newer run across the two formats", async () => {
+    const { db } = fakeDb({ runs: run({ finished_at: "2026-07-20T10:06:00.000+00:00" }) });
+    const seen = project({ results_seen_at: "2026-07-20T10:05:00.000Z" });
+    expect(await getUnseenRun(db, seen)).toMatchObject({ id: "run-1" });
+  });
 });
 
 describe("markResultsSeen", () => {
@@ -151,6 +166,13 @@ describe("markResultsSeen", () => {
       ok: false,
       code: "not_found",
     });
+    expect(updates).toHaveLength(0);
+  });
+
+  it("does not rewrite when the mark already covers that instant in another format", async () => {
+    const { db, updates } = fakeDb({ runs: { finished_at: "2026-07-20T10:05:00.000+00:00" } });
+    const already = project({ results_seen_at: "2026-07-20T10:05:00.000Z" });
+    expect(await markResultsSeen(db, already, "run-1")).toMatchObject({ changed: false });
     expect(updates).toHaveLength(0);
   });
 

--- a/lib/results-seen.test.ts
+++ b/lib/results-seen.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import type { Project, Run } from "@/lib/types";
+import { getUnseenRun, markResultsSeen } from "@/lib/results-seen";
+
+const PROJECT: Project = {
+  id: "proj-1",
+  user_id: "user-1",
+  name: "Credal",
+  brand_name: "Credal",
+  brand_aliases: [],
+  brand_domains: ["credal.ai"],
+  description: null,
+  default_provider: "anthropic",
+  default_model: "claude-sonnet-4-6",
+  schedule: "off",
+  use_web_search: true,
+  replicates: 1,
+  last_run_at: null,
+  results_seen_at: null,
+  created_at: "2026-07-01T00:00:00.000Z",
+  updated_at: "2026-07-01T00:00:00.000Z",
+};
+
+function project(overrides: Partial<Project> = {}): Project {
+  return { ...PROJECT, ...overrides };
+}
+
+const RUN: Run = {
+  id: "run-1",
+  project_id: "proj-1",
+  status: "completed",
+  provider: "anthropic",
+  model: "claude-sonnet-4-6",
+  prompt_count: 10,
+  completed_count: 10,
+  replicates: 1,
+  error: null,
+  started_at: "2026-07-20T10:00:00.000Z",
+  finished_at: "2026-07-20T10:05:00.000Z",
+  created_at: "2026-07-20T10:00:00.000Z",
+};
+
+function run(overrides: Partial<Run> = {}): Run {
+  return { ...RUN, ...overrides };
+}
+
+/**
+ * Records every update and answers reads from the given rows. Chains are
+ * terminal at maybeSingle(), which is all these two helpers use.
+ */
+function fakeDb(rows: { runs?: unknown }) {
+  const updates: Record<string, unknown>[] = [];
+  const builder = (table: string) => {
+    const chain: Record<string, unknown> = {};
+    const self = () => chain;
+    for (const m of ["select", "eq", "in", "not", "order", "limit"]) chain[m] = self;
+    chain.update = (values: Record<string, unknown>) => {
+      updates.push(values);
+      return { eq: async () => ({ error: null }) };
+    };
+    chain.maybeSingle = async () => ({
+      data: table === "runs" ? (rows.runs ?? null) : null,
+    });
+    return chain;
+  };
+  return { db: { from: builder } as never, updates };
+}
+
+describe("getUnseenRun", () => {
+  it("flags the newest finished run when results have never been opened", async () => {
+    const { db } = fakeDb({ runs: run() });
+    expect(await getUnseenRun(db, project({ results_seen_at: null }))).toMatchObject({
+      id: "run-1",
+    });
+  });
+
+  it("stays quiet once the run has been seen", async () => {
+    const { db } = fakeDb({ runs: run() });
+    const seen = project({ results_seen_at: "2026-07-20T10:05:00.000Z" });
+    expect(await getUnseenRun(db, seen)).toBeNull();
+  });
+
+  it("flags a run that finished after the last look", async () => {
+    const { db } = fakeDb({ runs: run({ finished_at: "2026-07-21T09:00:00.000Z" }) });
+    const seen = project({ results_seen_at: "2026-07-20T10:05:00.000Z" });
+    expect(await getUnseenRun(db, seen)).toMatchObject({ id: "run-1" });
+  });
+
+  // A silent failure is worse than a silent success: monitoring has stopped
+  // collecting and nothing said so.
+  it("flags a failed run too", async () => {
+    const { db } = fakeDb({
+      runs: run({ status: "failed", completed_count: 0, error: "Invalid API key" }),
+    });
+    expect(await getUnseenRun(db, project())).toMatchObject({ status: "failed" });
+  });
+
+  it("has nothing to say when there are no finished runs", async () => {
+    const { db } = fakeDb({ runs: null });
+    expect(await getUnseenRun(db, project())).toBeNull();
+  });
+
+  it("ignores a run row with no finish time", async () => {
+    const { db } = fakeDb({ runs: run({ finished_at: null }) });
+    expect(await getUnseenRun(db, project())).toBeNull();
+  });
+});
+
+describe("markResultsSeen", () => {
+  it("marks against the viewed run's finish time, not now", async () => {
+    const { db, updates } = fakeDb({ runs: { finished_at: "2026-07-20T10:05:00.000Z" } });
+    const outcome = await markResultsSeen(db, project(), "run-1");
+    expect(outcome).toMatchObject({ ok: true, changed: true });
+    expect(updates[0]).toEqual({ results_seen_at: "2026-07-20T10:05:00.000Z" });
+  });
+
+  // The point of marking against the run rather than now(): opening last
+  // week's report must not bury the run that finished this morning.
+  it("does not mark a newer unread run as seen", async () => {
+    const { db } = fakeDb({ runs: { finished_at: "2026-07-14T10:00:00.000Z" } });
+    const { seenAt } = (await markResultsSeen(db, project(), "old-run")) as {
+      seenAt: string;
+    };
+    const newer = run({ finished_at: "2026-07-20T10:05:00.000Z" });
+    const after = project({ results_seen_at: seenAt });
+    const { db: db2 } = fakeDb({ runs: newer });
+    expect(await getUnseenRun(db2, after)).toMatchObject({ id: "run-1" });
+  });
+
+  it("never moves the high-water mark backwards", async () => {
+    const { db, updates } = fakeDb({ runs: { finished_at: "2026-07-14T10:00:00.000Z" } });
+    const already = project({ results_seen_at: "2026-07-20T10:05:00.000Z" });
+    const outcome = await markResultsSeen(db, already, "old-run");
+    expect(outcome).toMatchObject({ ok: true, changed: false });
+    expect(updates).toHaveLength(0);
+  });
+
+  it("dismissing with no run id acknowledges everything so far", async () => {
+    const { db, updates } = fakeDb({});
+    const outcome = await markResultsSeen(db, project());
+    expect(outcome).toMatchObject({ ok: true, changed: true });
+    const seenAt = (updates[0] as { results_seen_at: string }).results_seen_at;
+    expect(new Date(seenAt).getTime()).toBeGreaterThan(Date.parse(RUN.finished_at!));
+  });
+
+  // The id is attacker-controlled input on a route that otherwise says "you
+  // have read everything"; an unverifiable run must not clear the nudge.
+  it("refuses a run id that isn't this project's", async () => {
+    const { db, updates } = fakeDb({ runs: null });
+    expect(await markResultsSeen(db, project(), "someone-elses-run")).toEqual({
+      ok: false,
+      code: "not_found",
+    });
+    expect(updates).toHaveLength(0);
+  });
+
+  it("treats an unfinished run as acknowledging what has finished", async () => {
+    const { db, updates } = fakeDb({ runs: { finished_at: null } });
+    const outcome = await markResultsSeen(db, project(), "run-in-flight");
+    expect(outcome).toMatchObject({ ok: true, changed: true });
+    expect(updates).toHaveLength(1);
+  });
+});

--- a/lib/results-seen.ts
+++ b/lib/results-seen.ts
@@ -1,0 +1,102 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Project, Run } from "@/lib/types";
+
+// ------------------------------------------------------------------
+// "Has the owner looked at this run yet?"
+//
+// A run finishing produces no signal at all today. The scheduler and the REST
+// API both finish runs while nobody is on the page, and even a manual run just
+// quietly becomes another row in a list — so the data a user is paying tokens
+// for can sit unread indefinitely. projects.results_seen_at is the high-water
+// mark of "I have looked", and anything that finished after it is worth a nudge.
+//
+// A timestamp rather than a per-run seen flag: the question is never "which of
+// these twelve runs have I read", it's "is there anything new since I last
+// looked". One column answers that, and it can't drift out of sync with the
+// runs table.
+// ------------------------------------------------------------------
+
+/** Runs worth nudging about: both outcomes are news the user hasn't been told.
+ *  A silent failure is if anything MORE worth surfacing than a silent success —
+ *  it means monitoring has stopped and nothing said so. */
+const FINISHED = ["completed", "failed"] as const;
+
+/**
+ * The project's most recent finished run, if it finished after the owner last
+ * looked at results. Null when there's nothing new — which is the common case,
+ * so this is one indexed row read on the dashboard's critical path.
+ */
+export async function getUnseenRun(
+  supabase: SupabaseClient,
+  project: Project,
+): Promise<Run | null> {
+  const { data } = await supabase
+    .from("runs")
+    .select("*")
+    .eq("project_id", project.id)
+    .in("status", FINISHED as unknown as string[])
+    .not("finished_at", "is", null)
+    .order("finished_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  const run = data as Run | null;
+  if (!run?.finished_at) return null;
+
+  // Never looked: the newest finished run is unseen. That's the right first
+  // impression for an account that has runs but has never opened one.
+  if (!project.results_seen_at) return run;
+  return run.finished_at > project.results_seen_at ? run : null;
+}
+
+export type MarkSeenOutcome =
+  | { ok: true; changed: boolean; seenAt: string }
+  | { ok: false; code: "not_found" };
+
+/**
+ * Record that the owner has looked at this project's results.
+ *
+ * With a `runId`, the mark lands on that run's finish time rather than now:
+ * opening an older report shouldn't silently mark a NEWER run as read, which
+ * is exactly the run they still need to see. Without one (an explicit dismiss)
+ * it lands on now, acknowledging everything that has finished so far.
+ *
+ * The high-water mark only ever moves forward, so re-opening an old report
+ * can't resurrect a nudge the user already cleared.
+ */
+export async function markResultsSeen(
+  supabase: SupabaseClient,
+  project: Project,
+  runId?: string | null,
+): Promise<MarkSeenOutcome> {
+  let seenAt = new Date().toISOString();
+
+  if (runId) {
+    const { data } = await supabase
+      .from("runs")
+      .select("finished_at")
+      .eq("id", runId)
+      .eq("project_id", project.id)
+      .maybeSingle();
+    const run = data as { finished_at: string | null } | null;
+    // Unknown run, or someone else's: say so rather than quietly marking
+    // everything read on the strength of an id we couldn't verify.
+    if (!run) return { ok: false, code: "not_found" };
+    // A run still in flight has no finish time to mark against; treat viewing
+    // it as acknowledging everything already finished.
+    if (run.finished_at) seenAt = run.finished_at;
+  }
+
+  const current = project.results_seen_at;
+  if (current && current >= seenAt) {
+    return { ok: true, changed: false, seenAt: current };
+  }
+
+  const { error } = await supabase
+    .from("projects")
+    .update({ results_seen_at: seenAt })
+    .eq("id", project.id);
+  if (error) throw error;
+
+  return { ok: true, changed: true, seenAt };
+}

--- a/lib/results-seen.ts
+++ b/lib/results-seen.ts
@@ -22,6 +22,20 @@ import type { Project, Run } from "@/lib/types";
 const FINISHED = ["completed", "failed"] as const;
 
 /**
+ * Is `a` strictly later than `b`? Compared as instants, not as strings.
+ *
+ * These timestamps arrive in two shapes — Postgres renders timestamptz as
+ * `…+00:00` while `toISOString()` produces `…Z` — and comparing those as text
+ * orders them by the suffix character once the digits match, not by time. It
+ * happens to come out right today only because every value we compare has been
+ * normalized by a read from Postgres first. That's an invisible dependency on
+ * where the string came from, so parse instead and let the format stop mattering.
+ */
+function isAfter(a: string, b: string): boolean {
+  return Date.parse(a) > Date.parse(b);
+}
+
+/**
  * The project's most recent finished run, if it finished after the owner last
  * looked at results. Null when there's nothing new — which is the common case,
  * so this is one indexed row read on the dashboard's critical path.
@@ -46,7 +60,7 @@ export async function getUnseenRun(
   // Never looked: the newest finished run is unseen. That's the right first
   // impression for an account that has runs but has never opened one.
   if (!project.results_seen_at) return run;
-  return run.finished_at > project.results_seen_at ? run : null;
+  return isAfter(run.finished_at, project.results_seen_at) ? run : null;
 }
 
 export type MarkSeenOutcome =
@@ -88,7 +102,7 @@ export async function markResultsSeen(
   }
 
   const current = project.results_seen_at;
-  if (current && current >= seenAt) {
+  if (current && !isAfter(seenAt, current)) {
     return { ok: true, changed: false, seenAt: current };
   }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -64,6 +64,8 @@ export interface Project {
   /** Times each active prompt is asked per run (1–10). >1 buys confidence in a "no mention". */
   replicates: number;
   last_run_at: string | null;
+  /** When the owner last opened this project's results. Null = never. */
+  results_seen_at: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -203,6 +203,15 @@ alter table public.projects
   add column if not exists replicates integer not null default 1
   check (replicates between 1 and 10);
 
+-- When the owner last actually LOOKED at this project's results. A run
+-- finishing is silent otherwise: the scheduler and the API both finish runs
+-- while nobody is on the page, and even a manual run just appears in a list.
+-- Comparing a run's finished_at against this is what decides whether to nudge.
+-- Null means never looked, so the newest finished run is unseen — which is the
+-- right first impression for an account that has runs but has never opened one.
+alter table public.projects
+  add column if not exists results_seen_at timestamptz;
+
 -- ---------- competitors ----------------------------------------------
 create table if not exists public.competitors (
   id uuid primary key default gen_random_uuid(),


### PR DESCRIPTION
Fixes [LET-170](https://linear.app/letterbrace/issue/LET-170/check-results-pop-up).

> no notification -or- check run results at the top

## Why

A finished run announces itself nowhere. The scheduler and the REST API both complete runs while nobody is on the page, and even a manual run just becomes another row in the Runs list — so data the user spent tokens collecting can sit unread indefinitely.

This adds the counterpart to `TrialBanner`: same slot, same shape, same visual language.

```
┌────────────────────────────────────────────────────────────────────────┐
│ 📊  Your run finished — results are ready                              │
│     11 of 11 answers collected on Claude Haiku 4.5, 4m ago.            │
│     See where your brand showed up.        [ View results ]  [ × ]     │
└────────────────────────────────────────────────────────────────────────┘
```

It renders in the dashboard **layout**, so it follows the user across Runs / Topics / Competitors rather than only appearing wherever they happened to be when the run landed. It sits above the trial banner: this one is timely and clears itself, where the BYOK nudge is standing context.

## "Unseen" is server state, not local state

`projects.results_seen_at` — a high-water mark of when the owner last opened results. Local storage would have been less code and wrong: runs finish on the server while the user is away, and the nudge would then reappear on their next device.

Two ways it clears, deliberately different:

| Action | Marks seen at | Why |
|---|---|---|
| Opening a run report | that run's `finished_at` | reading last week's report must not bury the run that finished this morning |
| Dismissing the banner (×) | now | an explicit "I've acknowledged everything so far" |

The mark only ever moves forward, so re-opening an old report can't resurrect a nudge already cleared. Opening the report clears it however the user got there — banner, Runs list, or a bookmark — because reaching that page *is* checking the results.

## Failed runs get it too

Slightly beyond the literal ask, and I think clearly within its intent: a run that failed is if anything **more** worth surfacing than one that succeeded — monitoring has stopped collecting and, until now, nothing said so. Same banner, terracotta tone, the run's error as the body, "See what happened" as the CTA. Easy to drop if you'd rather keep this to the success case.

## Schema

```sql
alter table public.projects
  add column if not exists results_seen_at timestamptz;
```

Idempotent and additive, matching the existing `schema.sql` convention. **Needs applying to the Supabase project before deploy.** Null means never looked, so an account with existing runs gets one nudge for its most recent run — which is the right first impression.

## Testing

346 tests pass (12 new), typecheck, lint and build clean. New coverage: unseen detection across never-looked / already-seen / newer-run / failed / no-runs, the mark-doesn't-bury-a-newer-run case, the high-water mark not moving backwards, and a run id belonging to another project being refused rather than clearing the nudge.

Smoke-tested against a dev server: `/dashboard` still redirects when signed out, `POST /api/runs/seen` 401s unauthenticated, no runtime errors from the new layout query.

I did **not** verify the banner visually in a signed-in session — that needs a real account with a finished run, so it's worth a look when you review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
