### PR TITLE
Capture competitors during onboarding (LET-173)

### DIFF
--- a/app/api/onboarding/complete/route.ts
+++ b/app/api/onboarding/complete/route.ts
@@ -11,6 +11,7 @@ import {
   engineKeyMessage,
 } from "@/lib/trial";
 import { defaultModelFor } from "@/lib/models";
+import { normalizeCompetitorList } from "@/lib/competitors";
 import { logDashboard } from "@/lib/activity";
 import type { Project } from "@/lib/types";
 
@@ -100,6 +101,14 @@ export async function POST(request: Request) {
       })
     : [];
 
+  // Competitors are optional — a project with none is valid, it just can't
+  // report share of voice yet. The brand and its aliases are excluded however
+  // they arrived: a client can post this body without ever having asked for
+  // suggestions, so the model-side filtering isn't sufficient on its own.
+  const competitors = normalizeCompetitorList(body.competitors, {
+    exclude: [brand_name, ...brand_aliases],
+  });
+
   const incomplete = topics
     .map((t, i) => ({ i, t }))
     .filter(({ t }) => !t.name || t.prompts.length === 0);
@@ -157,12 +166,32 @@ export async function POST(request: Request) {
   await logDashboard(user, request, {
     category: "onboarding",
     action: "onboarding.completed",
-    summary: `Set up "${brand_name}" with ${topics.length} topic${topics.length === 1 ? "" : "s"}`,
+    summary: `Set up "${brand_name}" with ${topics.length} topic${topics.length === 1 ? "" : "s"} and ${competitors.length} competitor${competitors.length === 1 ? "" : "s"}`,
     projectId: project.id,
     targetType: "project",
     targetId: project.id,
-    metadata: { topics: topics.length, brand_name },
+    metadata: { topics: topics.length, competitors: competitors.length, brand_name },
   });
+
+  // Persist competitors before the first run: executeRun reads them to detect
+  // rival mentions, so seeding them after the run would leave that run's
+  // answers scored against the brand alone and no share of voice to show.
+  if (competitors.length > 0) {
+    const { error: compErr } = await supabase.from("competitors").insert(
+      competitors.map((c) => ({
+        project_id: project.id,
+        name: c.name,
+        aliases: c.aliases,
+        domain: c.domain,
+      })),
+    );
+    // Non-fatal: the project and its topics are already real, and the user can
+    // add competitors from the Competitors page. Losing them shouldn't cost
+    // them the whole onboarding they just completed.
+    if (compErr) {
+      console.error("[onboarding] competitor insert failed:", compErr.message);
+    }
+  }
 
   // Persist topics + their prompts.
   for (const topic of topics) {

--- a/app/api/onboarding/onboarding-competitors.test.ts
+++ b/app/api/onboarding/onboarding-competitors.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Unlike onboarding-route.test.ts — which stops at validation and mocks the
+// database as a tripwire — this file lets the request through to a recording
+// fake, because the bug being covered is a write that never happened.
+
+const inserts: { table: string; values: unknown }[] = [];
+
+const PROJECT = {
+  id: "proj-1",
+  user_id: "user-1",
+  brand_name: "Acme",
+  brand_domains: ["acme.com"],
+  default_provider: "anthropic",
+  default_model: "claude-sonnet-4-6",
+};
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: () => ({
+    auth: { getUser: async () => ({ data: { user: { id: "user-1", email: "a@b.co" } } }) },
+    from: (table: string) => ({
+      insert(values: unknown) {
+        inserts.push({ table, values });
+        const row = table === "projects" ? PROJECT : { id: `${table}-row` };
+        return {
+          select: () => ({ single: async () => ({ data: row, error: null }) }),
+          // Batch inserts are awaited directly, with no .select() after them.
+          then: (ok: (v: unknown) => unknown) => Promise.resolve({ error: null }).then(ok),
+        };
+      },
+      select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: null }) }) }),
+      update: () => ({ eq: async () => ({ error: null }) }),
+    }),
+  }),
+}));
+
+vi.mock("@/lib/data", () => ({
+  setActiveProject: vi.fn(),
+  getProjects: vi.fn(async () => []),
+  getConfiguredProviders: vi.fn(async () => []),
+}));
+vi.mock("@/lib/llm", () => ({ humanError: (e: unknown) => String(e) }));
+vi.mock("@/lib/activity", () => ({ logDashboard: vi.fn() }));
+vi.mock("@/lib/trial", () => ({
+  pickDefaultProvider: () => "anthropic",
+  // No key: the route returns before executing a run, which is all we need.
+  resolveRunKey: vi.fn(async () => ({
+    source: "none",
+    provider: "anthropic",
+    model: "claude-sonnet-4-6",
+    requested: { provider: "anthropic", model: "claude-sonnet-4-6" },
+  })),
+  engineKeyMessage: () => "add a key",
+  recordTrialUsage: vi.fn(),
+  consumeTrialRun: vi.fn(),
+}));
+vi.mock("@/lib/engine", () => ({ executeRun: vi.fn() }));
+
+const { POST } = await import("@/app/api/onboarding/complete/route");
+
+function req(body: unknown) {
+  return new Request("http://localhost/api/onboarding/complete", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+const BASE = {
+  brand_name: "Acme",
+  name: "Acme",
+  brand_domains: ["acme.com"],
+  topics: [{ name: "CDN", prompts: ["best cdn?"] }],
+};
+
+const competitorInserts = () =>
+  inserts.filter((i) => i.table === "competitors").flatMap((i) => i.values as never[]);
+
+beforeEach(() => {
+  inserts.length = 0;
+  vi.clearAllMocks();
+});
+
+describe("POST /api/onboarding/complete — competitors", () => {
+  // The reported bug: onboarding collected nothing and saved nothing, so the
+  // Competitors page was empty the moment setup finished.
+  it("saves the competitors sent with onboarding", async () => {
+    const res = await POST(
+      req({
+        ...BASE,
+        competitors: [
+          { name: "Asana", aliases: ["asana.com"], domain: "Asana.com" },
+          { name: "Notion", aliases: [], domain: null },
+        ],
+      }),
+    );
+    expect(res.status).toBe(200);
+
+    expect(competitorInserts()).toEqual([
+      { project_id: "proj-1", name: "Asana", aliases: ["asana.com"], domain: "asana.com" },
+      { project_id: "proj-1", name: "Notion", aliases: [], domain: null },
+    ]);
+  });
+
+  // executeRun reads competitors to detect rival mentions, so they have to
+  // exist before the first run or that run scores the brand alone.
+  it("writes competitors before the topics the first run asks", async () => {
+    await POST(req({ ...BASE, competitors: [{ name: "Asana" }] }));
+    const tables = inserts.map((i) => i.table);
+    expect(tables.indexOf("competitors")).toBeLessThan(tables.indexOf("topics"));
+  });
+
+  it("writes nothing when none are sent", async () => {
+    const res = await POST(req(BASE));
+    expect(res.status).toBe(200);
+    expect(inserts.some((i) => i.table === "competitors")).toBe(false);
+  });
+
+  it("drops blank rows rather than failing the whole setup", async () => {
+    await POST(req({ ...BASE, competitors: [{ name: "  " }, { name: "Asana" }] }));
+    expect(competitorInserts().map((c: { name: string }) => c.name)).toEqual(["Asana"]);
+  });
+
+  // Both of these would hit the (project_id, name) unique index and abort the
+  // batch, losing every competitor including the good ones.
+  it("collapses duplicates that differ only by case", async () => {
+    await POST(req({ ...BASE, competitors: [{ name: "Asana" }, { name: "asana" }] }));
+    expect(competitorInserts()).toHaveLength(1);
+  });
+
+  it("refuses to track the brand as its own competitor", async () => {
+    await POST(
+      req({
+        ...BASE,
+        brand_aliases: ["Acme Corp"],
+        competitors: [{ name: "Acme" }, { name: "acme corp" }, { name: "Asana" }],
+      }),
+    );
+    expect(competitorInserts().map((c: { name: string }) => c.name)).toEqual(["Asana"]);
+  });
+
+  it("accepts aliases sent as a comma-separated string", async () => {
+    await POST(req({ ...BASE, competitors: [{ name: "Monday", aliases: "monday.com, Monday" }] }));
+    expect(competitorInserts()[0]).toMatchObject({ aliases: ["monday.com", "Monday"] });
+  });
+
+  it("ignores a competitors field that isn't a list", async () => {
+    const res = await POST(req({ ...BASE, competitors: "Asana" }));
+    expect(res.status).toBe(200);
+    expect(inserts.some((i) => i.table === "competitors")).toBe(false);
+  });
+});

--- a/app/api/onboarding/suggest/route.ts
+++ b/app/api/onboarding/suggest/route.ts
@@ -40,6 +40,7 @@ export async function POST(request: Request) {
       scraped: false,
       description: "",
       topics: [],
+      competitors: [],
       reason: key.source === "exhausted" ? "trial_exhausted" : "no_key",
       error: scrape.ok ? undefined : scrape.error,
     });
@@ -50,6 +51,7 @@ export async function POST(request: Request) {
       scraped: false,
       description: "",
       topics: [],
+      competitors: [],
       reason: "scrape_failed",
       error: scrape.error,
     });
@@ -67,9 +69,10 @@ export async function POST(request: Request) {
     await logDashboard(user, request, {
       category: "onboarding",
       action: "onboarding.suggested",
-      summary: `Analyzed ${domain || brandName} and suggested ${suggestion.topics.length} topic${suggestion.topics.length === 1 ? "" : "s"} with AI`,
+      summary: `Analyzed ${domain || brandName} and suggested ${suggestion.topics.length} topic${suggestion.topics.length === 1 ? "" : "s"} and ${suggestion.competitors.length} competitor${suggestion.competitors.length === 1 ? "" : "s"} with AI`,
       metadata: {
         topics: suggestion.topics.length,
+        competitors: suggestion.competitors.length,
         tokens: suggestion.tokens,
         keySource: key.source,
         domain,
@@ -79,6 +82,7 @@ export async function POST(request: Request) {
       scraped: suggestion.topics.length > 0,
       description: suggestion.description,
       topics: suggestion.topics,
+      competitors: suggestion.competitors,
       title: scrape.title ?? "",
     });
   } catch (e) {
@@ -86,6 +90,7 @@ export async function POST(request: Request) {
       scraped: false,
       description: "",
       topics: [],
+      competitors: [],
       reason: "ai_failed",
       error: humanError(e),
     });

--- a/app/dashboard/onboarding.tsx
+++ b/app/dashboard/onboarding.tsx
@@ -19,6 +19,13 @@ interface Topic {
   prompts: string[];
 }
 
+interface CompetitorDraft {
+  name: string;
+  /** Comma-separated while editing; split on submit, like the settings form. */
+  aliases: string;
+  domain: string;
+}
+
 type Step = "brand" | "topics" | "searching";
 
 export function Onboarding() {
@@ -31,8 +38,9 @@ export function Onboarding() {
   const [domain, setDomain] = useState("");
   const [description, setDescription] = useState("");
 
-  // Step 2: topics
+  // Step 2: topics + competitors
   const [topics, setTopics] = useState<Topic[]>([]);
+  const [competitors, setCompetitors] = useState<CompetitorDraft[]>([]);
   // Per-block validation, keyed by topic index. Blocks used to be dropped
   // silently when incomplete, so a user could "start monitoring" with three
   // topics on screen and have one saved.
@@ -73,6 +81,21 @@ export function Onboarding() {
       if (data?.description && !description.trim()) {
         setDescription(String(data.description));
       }
+
+      // Seeded from the same site read as the topics — no extra call.
+      setCompetitors(
+        Array.isArray(data?.competitors)
+          ? data.competitors
+              .map((c: { name?: unknown; aliases?: unknown; domain?: unknown }) => ({
+                name: typeof c?.name === "string" ? c.name : "",
+                aliases: Array.isArray(c?.aliases)
+                  ? c.aliases.filter((a: unknown): a is string => typeof a === "string").join(", ")
+                  : "",
+                domain: typeof c?.domain === "string" ? c.domain : "",
+              }))
+              .filter((c: CompetitorDraft) => c.name.trim().length > 0)
+          : [],
+      );
 
       if (suggested.length > 0) {
         setTopics(suggested);
@@ -119,6 +142,16 @@ export function Onboarding() {
   }
   function addTopic() {
     setTopics((prev) => [...prev, { name: "", prompts: [""] }]);
+  }
+
+  function setCompetitorField(i: number, field: keyof CompetitorDraft, value: string) {
+    setCompetitors((prev) => prev.map((c, idx) => (idx === i ? { ...c, [field]: value } : c)));
+  }
+  function removeCompetitor(i: number) {
+    setCompetitors((prev) => prev.filter((_, idx) => idx !== i));
+  }
+  function addCompetitor() {
+    setCompetitors((prev) => [...prev, { name: "", aliases: "", domain: "" }]);
   }
 
   // --- Step 2 -> complete + run ----------------------------------------------
@@ -168,6 +201,18 @@ export function Onboarding() {
           brand_domains: domain.trim() ? [domain.trim()] : [],
           description: description.trim() || null,
           topics: cleaned,
+          // Blank rows are just unused inputs, so drop them rather than
+          // blocking the submit — a nameless competitor holds nothing else.
+          competitors: competitors
+            .map((c) => ({
+              name: c.name.trim(),
+              aliases: c.aliases
+                .split(",")
+                .map((a) => a.trim())
+                .filter(Boolean),
+              domain: c.domain.trim() || null,
+            }))
+            .filter((c) => c.name.length > 0),
         }),
       });
       const data = await res.json();
@@ -372,6 +417,70 @@ export function Onboarding() {
             <Plus className="h-4 w-4" />
             Add topic
           </button>
+
+          {/* Competitors. Optional by design — share of voice needs them, but
+              a user who doesn't know their rivals yet shouldn't be stuck at
+              the last step of setup. */}
+          <div className="mt-10">
+            <div className="flex items-baseline justify-between gap-3">
+              <h2 className="text-lg font-semibold text-ink">Who do you compete with?</h2>
+              <span className="text-xs text-ink-faint">Optional</span>
+            </div>
+            <p className="mt-1 text-sm text-ink-soft">
+              {competitors.length > 0
+                ? "We spotted these. Edit or remove any before you start — we'll track how often each is named alongside you."
+                : "Add the brands you want to benchmark against, and we'll track how often each is named alongside you."}
+            </p>
+
+            {competitors.length > 0 && (
+              <div className="mt-4 space-y-2">
+                {competitors.map((c, ci) => (
+                  <div key={ci} className="flex items-center gap-2">
+                    <Input
+                      value={c.name}
+                      onChange={(e) => setCompetitorField(ci, "name", e.target.value)}
+                      placeholder="Competitor name"
+                      className="font-medium sm:max-w-[15rem]"
+                      aria-label={`Competitor ${ci + 1} name`}
+                    />
+                    <Input
+                      value={c.aliases}
+                      onChange={(e) => setCompetitorField(ci, "aliases", e.target.value)}
+                      // Short enough not to truncate in this column; a single
+                      // name works too, so the comma rule needn't be spelled out.
+                      placeholder="Other names"
+                      className="hidden text-sm sm:block"
+                      aria-label={`Competitor ${ci + 1} aliases`}
+                    />
+                    <Input
+                      value={c.domain}
+                      onChange={(e) => setCompetitorField(ci, "domain", e.target.value)}
+                      placeholder="domain.com"
+                      className="hidden text-sm sm:block sm:max-w-[12rem]"
+                      aria-label={`Competitor ${ci + 1} domain`}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => removeCompetitor(ci)}
+                      className="shrink-0 rounded p-2 text-ink-faint transition hover:bg-ink/5 hover:text-terracotta-dark"
+                      aria-label={`Remove ${c.name.trim() || "competitor"}`}
+                    >
+                      <X className="h-4 w-4" />
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            <button
+              type="button"
+              onClick={addCompetitor}
+              className="mt-4 inline-flex items-center gap-1.5 rounded border border-dashed border-ink/20 px-4 py-2.5 text-sm font-medium text-ink-soft transition hover:border-ink/40 hover:bg-ink/[0.02]"
+            >
+              <Plus className="h-4 w-4" />
+              Add competitor
+            </button>
+          </div>
 
           {error && <p className="mt-4 text-sm text-terracotta-dark">{error}</p>}
 

--- a/lib/competitors.test.ts
+++ b/lib/competitors.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { normalizeCompetitor, normalizeCompetitorList } from "@/lib/competitors";
+
+describe("normalizeCompetitor", () => {
+  it("trims the name and lowercases the domain", () => {
+    expect(normalizeCompetitor({ name: "  Asana ", domain: " Asana.COM " })).toEqual({
+      name: "Asana",
+      aliases: [],
+      domain: "asana.com",
+    });
+  });
+
+  it("accepts aliases as an array or as one comma-separated string", () => {
+    expect(normalizeCompetitor({ name: "Monday", aliases: ["monday.com", " Monday "] }).aliases)
+      .toEqual(["monday.com", "Monday"]);
+    expect(normalizeCompetitor({ name: "Monday", aliases: "monday.com, Monday ,," }).aliases)
+      .toEqual(["monday.com", "Monday"]);
+  });
+
+  it("treats a blank or missing domain as null", () => {
+    expect(normalizeCompetitor({ name: "X", domain: "   " }).domain).toBeNull();
+    expect(normalizeCompetitor({ name: "X" }).domain).toBeNull();
+  });
+
+  it("survives junk without throwing", () => {
+    expect(normalizeCompetitor(null)).toEqual({ name: "", aliases: [], domain: null });
+    expect(normalizeCompetitor({ name: 42, aliases: 7, domain: {} })).toEqual({
+      name: "",
+      aliases: [],
+      domain: null,
+    });
+  });
+});
+
+describe("normalizeCompetitorList", () => {
+  it("drops unnamed rows instead of rejecting the batch", () => {
+    const list = normalizeCompetitorList([
+      { name: "Asana" },
+      { name: "   " },
+      { name: "Notion" },
+    ]);
+    expect(list.map((c) => c.name)).toEqual(["Asana", "Notion"]);
+  });
+
+  // Both would abort the insert: `competitors` is unique on (project_id, name).
+  it("collapses case-insensitive repeats, keeping the first", () => {
+    const list = normalizeCompetitorList([
+      { name: "Asana", domain: "asana.com" },
+      { name: "asana", domain: "other.com" },
+    ]);
+    expect(list).toHaveLength(1);
+    expect(list[0].domain).toBe("asana.com");
+  });
+
+  it("excludes the brand and its aliases, case-insensitively", () => {
+    const list = normalizeCompetitorList(
+      [{ name: "Acme" }, { name: "acme corp" }, { name: "Asana" }],
+      { exclude: ["Acme", "Acme Corp"] },
+    );
+    expect(list.map((c) => c.name)).toEqual(["Asana"]);
+  });
+
+  it("ignores blank entries in the exclude list", () => {
+    const list = normalizeCompetitorList([{ name: "Asana" }], { exclude: ["", "  "] });
+    expect(list.map((c) => c.name)).toEqual(["Asana"]);
+  });
+
+  it("caps the list when a limit is given", () => {
+    const many = Array.from({ length: 9 }, (_, i) => ({ name: `Rival ${i}` }));
+    expect(normalizeCompetitorList(many, { limit: 5 })).toHaveLength(5);
+    expect(normalizeCompetitorList(many)).toHaveLength(9);
+  });
+
+  it("returns an empty list for anything that isn't an array", () => {
+    for (const junk of [null, undefined, "Asana", 3, { name: "Asana" }]) {
+      expect(normalizeCompetitorList(junk)).toEqual([]);
+    }
+  });
+});

--- a/lib/competitors.ts
+++ b/lib/competitors.ts
@@ -1,0 +1,71 @@
+// ------------------------------------------------------------------
+// Turning untrusted competitor input into rows we can insert.
+//
+// Two callers need the identical treatment and would otherwise drift apart:
+// the model's suggestions during onboarding (lib/llm) and the onboarding
+// request body itself (app/api/onboarding/complete), which a client can send
+// without ever having asked for suggestions. Both must strip the brand itself
+// and collapse repeats, because `competitors` carries a unique index on
+// (project_id, name) and one duplicate aborts the whole batch insert.
+// ------------------------------------------------------------------
+
+export interface CompetitorInput {
+  name: string;
+  aliases: string[];
+  domain: string | null;
+}
+
+/** Accepts an array of strings, or one comma-separated string, or nothing. */
+function toAliases(value: unknown): string[] {
+  const parts = Array.isArray(value)
+    ? value.map((a) => (typeof a === "string" ? a : ""))
+    : typeof value === "string"
+      ? value.split(",")
+      : [];
+  return parts.map((a) => a.trim()).filter((a) => a.length > 0);
+}
+
+/** One untrusted entry, trimmed. The name may still be empty — callers decide
+ *  whether that's a reason to drop the row or to reject the request. */
+export function normalizeCompetitor(value: unknown): CompetitorInput {
+  const o = (value ?? {}) as Record<string, unknown>;
+  return {
+    name: typeof o.name === "string" ? o.name.trim() : "",
+    aliases: toAliases(o.aliases),
+    // Domains are compared against cited source hosts, which are lowercased.
+    domain:
+      typeof o.domain === "string" && o.domain.trim().length > 0
+        ? o.domain.trim().toLowerCase()
+        : null,
+  };
+}
+
+/**
+ * A whole list, ready to insert: unnamed rows dropped, `exclude` removed, and
+ * repeats collapsed case-insensitively (first occurrence wins, so the entry
+ * the user sees first is the one that survives).
+ *
+ * Unnamed rows are dropped rather than rejected: a competitor with no name
+ * carries nothing else the user would lose, unlike a topic, so refusing an
+ * entire submission over one blank row would be hostile.
+ */
+export function normalizeCompetitorList(
+  value: unknown,
+  options: { exclude?: string[]; limit?: number } = {},
+): CompetitorInput[] {
+  const blocked = new Set(
+    (options.exclude ?? []).map((n) => n.trim().toLowerCase()).filter(Boolean),
+  );
+  const seen = new Set<string>();
+
+  const list = (Array.isArray(value) ? value : [])
+    .map(normalizeCompetitor)
+    .filter((c) => {
+      const key = c.name.toLowerCase();
+      if (!c.name || blocked.has(key) || seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+
+  return options.limit ? list.slice(0, options.limit) : list;
+}

--- a/lib/llm/index.ts
+++ b/lib/llm/index.ts
@@ -2,6 +2,7 @@ import Anthropic from "@anthropic-ai/sdk";
 import OpenAI from "openai";
 import type { Provider, Sentiment } from "@/lib/types";
 import { GOOGLE_AI_OVERVIEWS_MODEL, analysisModelFor } from "@/lib/models";
+import { normalizeCompetitorList } from "@/lib/competitors";
 
 // ------------------------------------------------------------------
 // Provider adapters. Every call here uses the *user's own* API key (BYOK).
@@ -1084,11 +1085,17 @@ Return a JSON object: { "results": [ { "key": "<key>", "sentiment": "positive|ne
   }
 }
 
-const SUGGEST_SYSTEM = `You help set up brand-monitoring. Given a company name and text scraped from its website, infer what the company does, then propose monitoring topics. For each topic, write realistic questions a real person would type into an AI assistant (ChatGPT or Claude) where a company like this could be recommended, compared, or mentioned. Do NOT mention the company's own name in the questions. Return ONLY JSON.`;
+const SUGGEST_SYSTEM = `You help set up brand-monitoring. Given a company name and text scraped from its website, infer what the company does, then propose monitoring topics and the company's direct competitors. For each topic, write realistic questions a real person would type into an AI assistant (ChatGPT or Claude) where a company like this could be recommended, compared, or mentioned. Do NOT mention the company's own name in the questions.
+
+For competitors, act as a strict judge: only name real companies/products you are confident exist and genuinely compete for the same buyers in the same category. Prefer well-known, currently active competitors over obscure or defunct ones. Never include the company itself. Fewer, correct suggestions beat a padded list. Return ONLY JSON.`;
 
 export interface SiteSuggestion {
   description: string;
   topics: { name: string; prompts: string[] }[];
+  /** Direct competitors inferred from the same site read. Share of voice is
+   *  meaningless without something to compare against, so onboarding seeds
+   *  these rather than leaving the user to discover the Competitors page. */
+  competitors: { name: string; aliases: string[]; domain: string | null }[];
 }
 
 /** From scraped site text, infer what the company does and suggest topics + prompts. */
@@ -1107,9 +1114,13 @@ Return a JSON object of this shape:
   "description": "one concise sentence describing what the company does",
   "topics": [
     { "name": "short topic label", "prompts": ["question 1", "question 2", "question 3", "question 4"] }
+  ],
+  "competitors": [
+    { "name": "Competitor Inc", "aliases": ["short name"], "domain": "competitor.com" }
   ]
 }
-Provide 3 or 4 topics, each with 4 to 6 natural questions. Never put the company's own name in the questions.`;
+Provide 3 or 4 topics, each with 4 to 6 natural questions. Never put the company's own name in the questions.
+Provide up to 5 competitors. "aliases" are other names an AI answer might use for it (short name, product name, former name) — empty array if none. "domain" is its primary website domain, lowercase, no protocol or path — null if unsure. Return an empty array if you cannot name real competitors with confidence.`;
 
   const res =
     opts.provider === "anthropic"
@@ -1137,9 +1148,18 @@ Provide 3 or 4 topics, each with 4 to 6 natural questions. Never put the company
       })
       .filter((t) => t.name.length > 0 && t.prompts.length > 0)
       .slice(0, 5);
-    return { description, topics, tokens: res.tokens };
+
+    // Models do name the company as its own competitor, and do repeat one
+    // across the list; both would break the insert, so normalize here rather
+    // than trusting the response.
+    const competitors = normalizeCompetitorList(parsed.competitors, {
+      exclude: [opts.brandName],
+      limit: 5,
+    });
+
+    return { description, topics, competitors, tokens: res.tokens };
   } catch {
-    return { description: "", topics: [], tokens: res.tokens };
+    return { description: "", topics: [], competitors: [], tokens: res.tokens };
   }
 }
 


### PR DESCRIPTION
Fixes [LET-173](https://linear.app/letterbrace/issue/LET-173/competitors-during-onboarding-not-saved).

## What was actually happening

Nothing was being lost in a save — **there was no competitor input in onboarding to lose.** The wizard is two steps (brand → topics) and `handleStart` posted only `brand_name`, `brand_domains`, `description` and `topics`. `/api/onboarding/complete` never touched the `competitors` table.

Competitors were purely a *post*-onboarding task: the "Get started" checklist's step 2, and the Competitors page. So finishing setup landed you on an empty Competitors page and a product that couldn't report share of voice — its core comparison — until you went and found that page yourself. That's the screenshot on the ticket.

## The fix

Competitors now come from the site read onboarding **already performs**. `suggestFromSite` asks for them in the same call that produces the description and topics, so this adds **no extra request, no extra latency, and no extra trial tokens**.

Step 2 shows them pre-filled beside the topics — editable, removable, with a manual add for anyone the model missed:

```
Who do you compete with?                                    Optional
We spotted these. Edit or remove any before you start.

  [ Asana        ] [ Asana Inc  ] [ asana.com  ]  ×
  [ Monday.com   ] [ Monday     ] [ monday.com ]  ×
  [ Notion       ] [ Other names] [ notion.so  ]  ×
  [ + Add competitor ]
```

The section is **optional** by design: share of voice needs competitors, but someone who doesn't know their rivals yet shouldn't be stuck at the last step of setup.

## Two ordering/correctness details worth review

**Competitors are written before topics.** `executeRun` reads the competitor list to detect rival mentions, so seeding them after the first run would leave that run scored against the brand alone — a first impression of "0% share of voice" that isn't true. There's a test pinning the write order.

**A failed competitor insert is logged, not fatal.** The project and its topics are already real at that point, and the Competitors page still exists. Losing the competitors shouldn't cost someone the whole onboarding they just finished.

## Normalization extracted

`lib/competitors.ts` is now shared by the model-side parse and the request-body parse. Both need the same treatment, and `competitors` carries a unique index on `(project_id, name)` — **one duplicate aborts the batch and takes the good rows with it**. Models do name the company as its own competitor and do repeat entries, so this strips the brand (plus its aliases) and collapses case-insensitive repeats.

Filtering only the model's output would not have been enough: a client can post this body without ever having asked for suggestions.

I left `app/api/competitors/route.ts` (the single-competitor page endpoint) alone to keep the diff focused — note it does *not* lowercase domains where the new helper does, so that's a small inconsistency to reconcile separately if you want.

## Testing

367 tests pass (18 new), typecheck / lint / build clean.

Verified in a real browser, signed in, driving the wizard end to end — with both onboarding API calls intercepted, so it created **no rows, spent no provider tokens and consumed no trial run**. Confirmed after the fact: still 13 projects, no stray competitor rows.

Seeded Asana / Monday.com / Notion, removed Notion, added Trello by hand, submitted. The request body the client built:

```json
[
  { "name": "Asana",      "aliases": ["Asana Inc"], "domain": "asana.com" },
  { "name": "Monday.com", "aliases": ["Monday"],    "domain": "monday.com" },
  { "name": "Trello",     "aliases": [],            "domain": null }
]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
