### PR TITLE
Make the add-a-key nudge visible where it actually blocks you (LET-167)

### DIFF
--- a/app/dashboard/competitors/competitors-client.tsx
+++ b/app/dashboard/competitors/competitors-client.tsx
@@ -14,6 +14,8 @@ import {
   Spinner,
 } from "@/components/ui";
 import type { Competitor } from "@/lib/types";
+import { NeedsKeyNotice } from "@/components/dashboard/needs-key-notice";
+import { article } from "@/lib/utils";
 
 const ALIAS_TONES = ["teal", "sand", "mint"] as const;
 
@@ -31,7 +33,15 @@ function parseAliases(raw: string): string[] {
     .filter((a) => a.length > 0);
 }
 
-export function CompetitorsClient({ competitors }: { competitors: Competitor[] }) {
+export function CompetitorsClient({
+  competitors,
+  hasKey,
+  providerLabel,
+}: {
+  competitors: Competitor[];
+  hasKey: boolean;
+  providerLabel: string;
+}) {
   const router = useRouter();
   const [name, setName] = useState("");
   const [aliases, setAliases] = useState("");
@@ -207,11 +217,27 @@ export function CompetitorsClient({ competitors }: { competitors: Competitor[] }
                 </p>
               </div>
             </div>
-            <Button variant="secondary" onClick={handleSuggest} disabled={suggesting}>
+            <Button
+              variant="secondary"
+              onClick={handleSuggest}
+              // Was enabled without a key, so the only feedback was a server
+              // error after the click. Say so before it's spent instead.
+              disabled={!hasKey || suggesting}
+              title={!hasKey ? `Add ${article(providerLabel)} ${providerLabel} key in Settings to enable` : undefined}
+            >
               {suggesting ? <Spinner /> : <Sparkles className="h-4 w-4" />}
               {suggestions === null ? "Suggest competitors" : "Suggest again"}
             </Button>
           </div>
+
+          {!hasKey && (
+            <NeedsKeyNotice
+              compact
+              className="mt-4"
+              providerLabel={providerLabel}
+              action="suggest competitors"
+            />
+          )}
 
           {suggestError && <p className="mt-4 text-sm text-terracotta-dark">{suggestError}</p>}
 

--- a/app/dashboard/competitors/page.tsx
+++ b/app/dashboard/competitors/page.tsx
@@ -1,8 +1,9 @@
 import { Users } from "lucide-react";
 import { Button, EmptyState, SectionHeading } from "@/components/ui";
-import { getProject } from "@/lib/data";
+import { getConfiguredProviders, getProject } from "@/lib/data";
 import { createClient } from "@/lib/supabase/server";
 import type { Competitor } from "@/lib/types";
+import { PROVIDERS } from "@/lib/models";
 import { CompetitorsClient } from "./competitors-client";
 
 export const dynamic = "force-dynamic";
@@ -41,13 +42,23 @@ export default async function CompetitorsPage() {
 
   const competitors = (data as Competitor[] | null) ?? [];
 
+  // Suggestions run on the project's chosen engine, so the key that matters is
+  // that provider's — same rule the Topics page uses.
+  const configured = await getConfiguredProviders(supabase, user.id);
+  const hasKey = configured.includes(project.default_provider);
+  const providerLabel = PROVIDERS[project.default_provider].label;
+
   return (
     <div className="space-y-8">
       <SectionHeading
         title="Competitors"
         description="Ingest the competitors you want to benchmark against. Lettertrace tracks how often each one shows up in AI answers and computes share of voice."
       />
-      <CompetitorsClient competitors={competitors} />
+      <CompetitorsClient
+        competitors={competitors}
+        hasKey={hasKey}
+        providerLabel={providerLabel}
+      />
     </div>
   );
 }

--- a/app/dashboard/topics/topics-client.tsx
+++ b/app/dashboard/topics/topics-client.tsx
@@ -13,7 +13,9 @@ import {
   Select,
   Spinner,
 } from "@/components/ui";
-import { Plus, Sparkles, Trash2, X, KeyRound } from "lucide-react";
+import { Plus, Sparkles, Trash2, X } from "lucide-react";
+import { NeedsKeyNotice } from "@/components/dashboard/needs-key-notice";
+import { article } from "@/lib/utils";
 
 interface Props {
   topics: Topic[];
@@ -98,21 +100,7 @@ export function TopicsClient({ topics, prompts, hasKey, providerLabel }: Props) 
 
       {/* No key notice */}
       {!hasKey && (
-        <Card className="border-terracotta/30 bg-terracotta/[0.05]">
-          <CardBody className="flex flex-wrap items-center justify-between gap-4">
-            <div className="flex items-start gap-3">
-              <span className="mt-0.5 text-terracotta-dark">
-                <KeyRound className="h-5 w-5" />
-              </span>
-              <p className="text-sm text-ink-soft">
-                Add a {providerLabel} key in Settings to auto-generate variations.
-              </p>
-            </div>
-            <Button href="/dashboard/settings" variant="secondary" size="sm">
-              Add key
-            </Button>
-          </CardBody>
-        </Card>
+        <NeedsKeyNotice providerLabel={providerLabel} action="auto-generate variations" />
       )}
 
       {/* Topics list */}
@@ -128,6 +116,7 @@ export function TopicsClient({ topics, prompts, hasKey, providerLabel }: Props) 
               topic={topic}
               prompts={prompts.filter((p) => p.topic_id === topic.id)}
               hasKey={hasKey}
+              providerLabel={providerLabel}
             />
           ))}
         </div>
@@ -140,10 +129,12 @@ function TopicCard({
   topic,
   prompts,
   hasKey,
+  providerLabel,
 }: {
   topic: Topic;
   prompts: Prompt[];
   hasKey: boolean;
+  providerLabel: string;
 }) {
   const router = useRouter();
 
@@ -261,14 +252,24 @@ function TopicCard({
                 <option value="8">8</option>
                 <option value="12">12</option>
               </Select>
-              <Button onClick={handleGenerate} disabled={!hasKey || generating}>
+              <Button
+                onClick={handleGenerate}
+                disabled={!hasKey || generating}
+                // A disabled button explains nothing on hover, and hovering it
+                // is exactly what someone does before giving up.
+                title={!hasKey ? `Add ${article(providerLabel)} ${providerLabel} key in Settings to enable` : undefined}
+              >
                 {generating ? <Spinner /> : <Sparkles className="h-4 w-4" />}
                 {generating ? "Generating…" : "Generate"}
               </Button>
             </div>
             {genError && <p className="text-sm text-terracotta-dark">{genError}</p>}
             {!hasKey && (
-              <p className="text-xs text-ink-faint">Add a provider key in Settings to enable.</p>
+              <NeedsKeyNotice
+                compact
+                providerLabel={providerLabel}
+                action="generate variations"
+              />
             )}
           </div>
 

--- a/components/dashboard/needs-key-notice.tsx
+++ b/components/dashboard/needs-key-notice.tsx
@@ -1,0 +1,69 @@
+import Link from "next/link";
+import { KeyRound } from "lucide-react";
+import { Button, Card, CardBody } from "@/components/ui";
+import { article, cn } from "@/lib/utils";
+
+// "You need a key before this will work", in one place.
+//
+// This used to be written per-site, and drifted into three strengths: a proper
+// callout on the Topics page, one line of grey helper text next to the button
+// it actually blocks, and — on Competitors — nothing at all until the request
+// came back with an error. The weak one sat inside a topic card, so by the time
+// a user scrolled to the disabled Generate button the real notice was far
+// offscreen, and the only thing left was unclickable grey text.
+//
+// Both variants therefore carry the same three things: the alert colour, the
+// provider that's actually missing, and a link to fix it.
+export function NeedsKeyNotice({
+  providerLabel,
+  /** Completes "Add a <provider> key to …" — name the blocked action. */
+  action,
+  /** Sits beside the control it blocks, rather than at the top of a page. */
+  compact = false,
+  className,
+}: {
+  providerLabel: string;
+  action: string;
+  compact?: boolean;
+  className?: string;
+}) {
+  const message = `Add ${article(providerLabel)} ${providerLabel} key to ${action}.`;
+
+  if (compact) {
+    return (
+      <div
+        className={cn(
+          "flex flex-wrap items-center gap-x-2 gap-y-1 rounded border border-terracotta/30 bg-terracotta/[0.07] px-3 py-2",
+          className,
+        )}
+      >
+        <span className="shrink-0 text-terracotta-dark">
+          <KeyRound className="h-3.5 w-3.5" />
+        </span>
+        <p className="text-xs text-ink-soft">{message}</p>
+        <Link
+          href="/dashboard/settings"
+          className="text-xs font-semibold text-terracotta-dark underline underline-offset-2 transition-colors hover:text-terracotta"
+        >
+          Add key
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <Card className={cn("border-terracotta/30 bg-terracotta/[0.05]", className)}>
+      <CardBody className="flex flex-wrap items-center justify-between gap-4">
+        <div className="flex items-start gap-3">
+          <span className="mt-0.5 text-terracotta-dark">
+            <KeyRound className="h-5 w-5" />
+          </span>
+          <p className="text-sm text-ink-soft">{message}</p>
+        </div>
+        <Button href="/dashboard/settings" variant="secondary" size="sm">
+          Add key
+        </Button>
+      </CardBody>
+    </Card>
+  );
+}

--- a/lib/trial.ts
+++ b/lib/trial.ts
@@ -2,6 +2,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Project, Provider } from "@/lib/types";
 import { getDecryptedKey, getConfiguredProviders } from "@/lib/data";
 import { defaultModelFor, modelLabel, PROVIDERS } from "@/lib/models";
+import { article } from "@/lib/utils";
 
 // ------------------------------------------------------------------
 // Free-trial layer. When the operator configures a shared (trial) key, users
@@ -249,7 +250,7 @@ export function engineKeyMessage(key: ResolvedKey): string {
       have.length === 1 ? have[0] : `${have.slice(0, -1).join(", ")} or ${have[have.length - 1]}`;
     return `Your answer engine is set to ${engine}, but no ${providerLabel} key is saved. Add one in Settings, or switch your answer engine to ${alternatives} — you already have a key for that.`;
   }
-  return `Your answer engine is set to ${engine}. Add a ${providerLabel} key in Settings to run.`;
+  return `Your answer engine is set to ${engine}. Add ${article(providerLabel)} ${providerLabel} key in Settings to run.`;
 }
 
 /** Add consumed tokens to the caller's trial tally (atomic, self-scoped rpc).

--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { resolveRedirectBase, safePath } from "@/lib/utils";
+import { article, resolveRedirectBase, safePath } from "@/lib/utils";
 
 describe("resolveRedirectBase", () => {
   const PROD = "https://lettertrace.com";
@@ -80,5 +80,20 @@ describe("safePath", () => {
     expect(safePath(null)).toBe("/dashboard");
     expect(safePath(undefined)).toBe("/dashboard");
     expect(safePath("", "/somewhere")).toBe("/somewhere");
+  });
+});
+
+describe("article", () => {
+  // Every provider label we ship, since these are what the copy interpolates.
+  it("matches the article to each provider label", () => {
+    expect(article("Anthropic (Claude)")).toBe("an");
+    expect(article("OpenAI (ChatGPT)")).toBe("an");
+    expect(article("Google (Gemini)")).toBe("a");
+    expect(article("Perplexity (Sonar)")).toBe("a");
+  });
+
+  it("ignores case and leading space", () => {
+    expect(article("  openai")).toBe("an");
+    expect(article("GOOGLE")).toBe("a");
   });
 });

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -93,3 +93,16 @@ export function formatDate(iso: string | null): string {
     year: "numeric",
   });
 }
+
+/**
+ * "a" or "an" for a following word. Provider labels are user-visible and vary
+ * ("OpenAI (ChatGPT)" vs "Google (Gemini)"), so the copy that names them can't
+ * hardcode the article — "Add a OpenAI key" reads as a typo in the exact
+ * message that's asking someone to go and do something.
+ *
+ * Vowel-letter test only: these are product names, not arbitrary prose, and
+ * none of the ones we ship hit the awkward cases (a "user", an "hour").
+ */
+export function article(word: string): "a" | "an" {
+  return /^[aeiou]/i.test(word.trim()) ? "an" : "a";
+}


### PR DESCRIPTION
Fixes [LET-167](https://linear.app/letterbrace/issue/LET-167/nudge-to-add-key-improvement).

> nudge to add claude api key isn't strong enough here — I would either change color of "add a provider key" or add a widget

Both, as it turns out — the same message had grown three different strengths across the app.

## Why it read as weak

A proper callout *does* exist on the Topics page. It's just at the top, and the disabled **Generate** button is inside a topic card further down. By the time you're trying to generate, the callout is offscreen and all that's left is:

```
Add a provider key in Settings to enable.        ← grey, unclickable, 12px
```

next to a disabled button that explains nothing on hover. It also said "a provider key" without naming which one.

## The three strengths, unified

| Surface | Before | After |
|---|---|---|
| Topics, page level | terracotta callout + Add key button | unchanged, now shared |
| Topics, beside Generate | grey unclickable text | terracotta inline notice, names the provider, links to Settings |
| Competitors | **nothing** — Suggest was enabled and failed server-side | same inline notice, and Suggest is gated on the key |

`NeedsKeyNotice` carries both densities. Every instance now has the alert colour, the provider that's actually missing, and a link to fix it.

The Competitors gap was the worse one: the button was enabled without a key, so the only feedback was an error *after* the click. Both disabled buttons also gained a `title`, since hovering a dead button is what someone does right before giving up — that's literally the cursor position in Bala's screenshot.

## Copy fix

The message interpolates a provider label, so it rendered **"Add a OpenAI (ChatGPT) key"** — a typo in the exact sentence asking someone to go do something. `article()` in `lib/utils` fixes it here and in the run-key messages from LET-172, which name providers the same way. Tested against all four shipped provider labels.

## Note on `hasKey`

Unchanged, but worth stating since it interacts with LET-172: it means *the project's selected engine's* provider, not "any key at all". So someone holding an Anthropic key who has selected GPT-4o correctly sees "Add an OpenAI (ChatGPT) key" — consistent with runs now refusing to substitute engines.

## Testing

369 tests pass (2 new), typecheck / lint / build clean.

Verified rendered, signed in, on both pages. The account has keys, so rather than delete one from the live database I pointed the active project at an engine with no key stored — the same state a user reaches by picking an engine they haven't brought a key for. Engine and active project restored afterwards, confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
