### PR TITLE
Say which model the NEXT run uses, and why it differs (LET-171)

### DIFF
--- a/app/dashboard/runs/page.tsx
+++ b/app/dashboard/runs/page.tsx
@@ -1,7 +1,7 @@
 import { ArrowRight, PlayCircle } from "lucide-react";
 import { createClient } from "@/lib/supabase/server";
 import { getProject } from "@/lib/data";
-import { resolveRunKey, engineKeyMessage } from "@/lib/trial";
+import { resolveRunKey, engineKeyMessage, nextRunMessage } from "@/lib/trial";
 import { PROVIDERS, modelLabel } from "@/lib/models";
 import { timeAgo } from "@/lib/utils";
 import type { Run, RunStatus } from "@/lib/types";
@@ -74,17 +74,10 @@ export default async function RunsPage() {
     <div className="space-y-8">
       <SectionHeading
         title="Runs"
-        // The model that will ACTUALLY run: a trial run is forced onto the
-        // provider's cheap model, so naming the project default here told
-        // users to expect Opus and then handed them Haiku.
-        description={
-          canRun
-            ? `Each run asks your active prompts to ${modelLabel(
-                key.provider,
-                key.model,
-              )} and records where your brand shows up.`
-            : engineKeyMessage(key)
-        }
+        // Describes the NEXT run, and says so. The old copy claimed what
+        // "each run" asks, sitting above a list of completed runs that named a
+        // different model — see nextRunMessage.
+        description={canRun ? nextRunMessage(key) : engineKeyMessage(key)}
         action={
           <RunNow
             canRun={canRun}

--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -7,6 +7,7 @@ import KeysManager from "./keys-manager";
 import ApiKeysManager from "./api-keys-manager";
 import ProjectForm from "./project-form";
 import type { ApiKeyPublic } from "@/lib/types";
+import { trialEnabled } from "@/lib/trial";
 
 export const dynamic = "force-dynamic";
 
@@ -72,6 +73,7 @@ export default async function SettingsPage() {
           <ProjectForm
             project={project}
             configuredProviders={keys.map((k) => k.provider)}
+            onTrial={trialEnabled() && keys.length === 0}
           />
         </CardBody>
       </Card>

--- a/app/dashboard/settings/project-form.tsx
+++ b/app/dashboard/settings/project-form.tsx
@@ -27,11 +27,16 @@ function splitEngine(value: string): { provider: string; model: string } {
 export default function ProjectForm({
   project,
   configuredProviders = [],
+  onTrial = false,
 }: {
   project: Project | null;
   /** Providers the user has a key for, so the picker can flag an engine that
    *  can't run before they discover it as a failed run. */
   configuredProviders?: Provider[];
+  /** Running on the operator's shared keys, which force a cheaper model. The
+   *  picker promises "the assistant we query", so on the trial that promise is
+   *  only true of the provider, not the model. */
+  onTrial?: boolean;
 }) {
   const router = useRouter();
 
@@ -213,11 +218,19 @@ export default function ProjectForm({
             for. We never answer with a different assistant than the one selected.
           </p>
         ) : (
-          <p className="mt-1.5 text-xs text-ink-faint">
-            Which assistant we query for this brand. You&apos;ll need a key for the
-            matching provider in the section above. Google AI Overviews and Gemini both
-            use your Google key.
-          </p>
+          <div className="mt-1.5 space-y-1">
+            <p className="text-xs text-ink-faint">
+              Which assistant we query for this brand. You&apos;ll need a key for the
+              matching provider in the section above. Google AI Overviews and Gemini both
+              use your Google key.
+            </p>
+            {onTrial && (
+              <p className="text-xs text-ink-faint">
+                While you&apos;re on free runs we use a faster, cheaper model from the
+                same provider. Your own key runs exactly what you pick here.
+              </p>
+            )}
+          </div>
         )}
       </div>
 

--- a/lib/trial.test.ts
+++ b/lib/trial.test.ts
@@ -13,6 +13,7 @@ import {
   resolveKey,
   resolveRunKeyFor,
   engineKeyMessage,
+  nextRunMessage,
   trialKeyFor,
   trialModelFor,
   trialEnabled,
@@ -247,5 +248,44 @@ describe("trial key resolution", () => {
     process.env.TRIAL_ANTHROPIC_API_KEY = "sk-ant-trial";
     process.env.TRIAL_GOOGLE_API_KEY = "AIzaTrialGoogle";
     expect(pickDefaultProvider()).toBe("anthropic");
+  });
+});
+
+describe("nextRunMessage", () => {
+  // The reported bug: "Each run asks your prompts to Claude Opus 4.8" sat above
+  // a list of completed runs labelled Claude Haiku 4.5. Both were true, nothing
+  // said why, so the copy read as simply wrong.
+  it("names both models when the trial substitutes a cheaper one", async () => {
+    process.env.TRIAL_ANTHROPIC_API_KEY = "sk-ant-trial";
+    process.env.TRIAL_ANTHROPIC_MODEL = "claude-haiku-4-5";
+    const k = await resolveRunKeyFor(db(0), "user-1", "anthropic", "claude-opus-4-8");
+    const message = nextRunMessage(k);
+    expect(message).toContain("Claude Haiku 4.5");
+    expect(message).toContain("Claude Opus 4.8");
+    expect(message).toContain("Anthropic (Claude)");
+  });
+
+  it("speaks about the next run, not about runs in general", async () => {
+    ownsKeysFor("anthropic");
+    const k = await resolveRunKeyFor(db(0), "user-1", "anthropic", "claude-opus-4-8");
+    expect(nextRunMessage(k)).toMatch(/^Your next run/);
+    expect(nextRunMessage(k)).not.toMatch(/Each run/);
+  });
+
+  it("stays a single clause on an own key, with no trial aside", async () => {
+    ownsKeysFor("anthropic");
+    const k = await resolveRunKeyFor(db(0), "user-1", "anthropic", "claude-opus-4-8");
+    const message = nextRunMessage(k);
+    expect(message).toContain("Claude Opus 4.8");
+    expect(message).not.toContain("Free runs");
+  });
+
+  // No TRIAL_*_MODEL configured: the trial runs the model they picked, so
+  // there is no substitution to explain.
+  it("adds no aside when the trial runs the chosen model anyway", async () => {
+    process.env.TRIAL_ANTHROPIC_API_KEY = "sk-ant-trial";
+    const k = await resolveRunKeyFor(db(0), "user-1", "anthropic", "claude-opus-4-8");
+    expect(k.source).toBe("trial");
+    expect(nextRunMessage(k)).not.toContain("Free runs");
   });
 });

--- a/lib/trial.ts
+++ b/lib/trial.ts
@@ -253,6 +253,31 @@ export function engineKeyMessage(key: ResolvedKey): string {
   return `Your answer engine is set to ${engine}. Add ${article(providerLabel)} ${providerLabel} key in Settings to run.`;
 }
 
+/**
+ * What the NEXT run will ask, for a key that can actually run.
+ *
+ * Phrased about the next run rather than about runs in general, which is the
+ * bug this replaces: "Each run asks your prompts to Claude Opus 4.8" sat
+ * directly above a list of completed runs that said Claude Haiku 4.5, so it
+ * read as a contradiction. Both were true — the heading described the next run
+ * on the user's own key, the rows recorded earlier runs on the trial's cheaper
+ * model — but nothing said so, leaving the user to work out the rule themselves.
+ *
+ * When the trial substitutes a model, name both: the one that will run and the
+ * one their own key would use. That difference is the whole explanation, and
+ * `requested` exists to carry it.
+ */
+export function nextRunMessage(key: ResolvedKey): string {
+  const willRun = modelLabel(key.provider, key.model);
+  const chosen = modelLabel(key.requested.provider, key.requested.model);
+  const providerLabel = PROVIDERS[key.requested.provider].label;
+
+  if (key.source === "trial" && key.model !== key.requested.model) {
+    return `Your next run asks your active prompts to ${willRun}. Free runs use a cheaper model on our keys — add your own ${providerLabel} key to run ${chosen}.`;
+  }
+  return `Your next run asks your active prompts to ${willRun} and records where your brand shows up.`;
+}
+
 /** Add consumed tokens to the caller's trial tally (atomic, self-scoped rpc).
  * Recording only; the free tier is gated on runs, not tokens. */
 export async function recordTrialUsage(


### PR DESCRIPTION
Fixes [LET-171](https://linear.app/letterbrace/issue/LET-171/wrong-text-on-model-used).

## What was wrong

The Runs page said:

> Each run asks your active prompts to **Claude Opus 4.8** and records where your brand shows up.

directly above a list of completed runs labelled **Claude Haiku 4.5**.

Both statements were true. The heading described the *next* run — on the user's own key, using the project's selected engine. The rows recorded *earlier* runs, executed on the trial's deliberately cheaper model (`TRIAL_ANTHROPIC_MODEL=claude-haiku-4-5`). Nothing on the page said so, so it read as a plain contradiction, and the reporter had to work the rule out from observation:

> seems like lettertrace defaults to claude haiku 4.5 on free ones, and if there's a model key inputted, then claude 4.8

That's exactly right, and it's the thing the UI should have said.

## The fix

`nextRunMessage` speaks about the next run rather than about runs in general, and when the trial substitutes a model it names **both** — the one that will run, and the one their own key would use:

| State | Copy |
|---|---|
| Trial, model substituted | *Your next run asks your active prompts to **Claude Haiku 4.5**. Free runs use a cheaper model on our keys — add your own Anthropic (Claude) key to run **Claude Opus 4.8**.* |
| Own key | *Your next run asks your active prompts to **Claude Opus 4.8** and records where your brand shows up.* |
| Trial with no model override | same as own key — there's no substitution to explain |

`requested` (added in LET-172) already carried the chosen-vs-actual distinction; this is the first place it earns its keep in user-facing copy.

## Second instance of the same promise

The **Settings engine picker** said "Which assistant we query for this brand" — only true of the *provider* while a trial overrides the model. A user picking "Claude Opus 4.8" mid-trial was being told they'd get it. Trial users now also see: *While you're on free runs we use a faster, cheaper model from the same provider. Your own key runs exactly what you pick here.*

## Audited the rest

Every other place that names a model (`/dashboard`, the run report, the run-finished banner, the activity log) reads it from the run row, so all of them were already factual. The two forward-looking claims above were the only ones that could be wrong.

## Testing

373 tests pass (4 new), typecheck / lint / build clean.

Verified rendered in both states against live data. The trial heading now reads exactly as in the table above, sitting above a `Claude Haiku 4.5` row — consistent for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
