### PR TITLE
Validate the answer engine as a pair, not two loose fields (LET-169)

### DIFF
--- a/app/api/project/route.ts
+++ b/app/api/project/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { getProject, setActiveProject } from "@/lib/data";
-import { isProvider, defaultModelFor } from "@/lib/models";
+import { isProvider, resolveEngine } from "@/lib/models";
 import { pickDefaultProvider } from "@/lib/trial";
 import { humanError } from "@/lib/llm";
 import { logDashboard } from "@/lib/activity";
@@ -108,8 +108,21 @@ export async function POST(request: Request) {
         ...baseFields,
         updated_at: new Date().toISOString(),
       };
-      if (providerOverride) update.default_provider = providerOverride;
-      if (modelOverride) update.default_model = modelOverride;
+      // Provider and model move together. A request naming only the provider
+      // used to leave the previous model behind, persisting a pair like
+      // openai + claude-opus-4-8; a model on its own is validated against the
+      // provider it will actually be sent to.
+      if (providerOverride || modelOverride) {
+        const engine = resolveEngine(
+          providerOverride ?? existing.default_provider,
+          modelOverride,
+        );
+        if (!engine.ok) {
+          return NextResponse.json({ error: engine.message }, { status: 400 });
+        }
+        update.default_provider = engine.provider;
+        update.default_model = engine.model;
+      }
 
       const { data, error } = await supabase
         .from("projects")
@@ -134,14 +147,16 @@ export async function POST(request: Request) {
       return NextResponse.json(data);
     }
 
-    const insertProvider = providerOverride ?? pickDefaultProvider();
-    const insertModel = modelOverride ?? defaultModelFor(insertProvider);
+    const engine = resolveEngine(providerOverride ?? pickDefaultProvider(), modelOverride);
+    if (!engine.ok) {
+      return NextResponse.json({ error: engine.message }, { status: 400 });
+    }
     const { data, error } = await supabase
       .from("projects")
       .insert({
         ...baseFields,
-        default_provider: insertProvider,
-        default_model: insertModel,
+        default_provider: engine.provider,
+        default_model: engine.model,
         user_id: user.id,
       })
       .select("*")

--- a/app/api/v1/projects/[id]/runs/route.ts
+++ b/app/api/v1/projects/[id]/runs/route.ts
@@ -79,21 +79,21 @@ export async function POST(
       { ...options, context: apiActor(auth, "v1") },
     );
     if (!outcome.ok) {
+      // not_found -> 404, a bad engine override -> 400, no key -> 402 (billing).
+      const status =
+        outcome.code === "not_found" ? 404 : outcome.code === "invalid_engine" ? 400 : 402;
       await logApiRequest(auth, request, "v1", {
         category: "run",
         action: "api.trigger_run",
         status: "failure",
-        statusCode: outcome.code === "not_found" ? 404 : 402,
+        statusCode: status,
         projectId: params.id,
         targetType: "project",
         targetId: params.id,
         summary: `Run not triggered via the API: ${outcome.message}`,
         metadata: { reason: outcome.code },
       });
-      return NextResponse.json(
-        { error: outcome.message },
-        { status: outcome.code === "not_found" ? 404 : 402 },
-      );
+      return NextResponse.json({ error: outcome.message }, { status });
     }
     await logApiRequest(auth, request, "v1", {
       category: "run",

--- a/app/dashboard/settings/project-form.tsx
+++ b/app/dashboard/settings/project-form.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { Check } from "lucide-react";
 import { Button, Input, Textarea, Select, Label, Spinner } from "@/components/ui";
 import { PROVIDER_LIST, PROVIDERS } from "@/lib/models";
+import { article } from "@/lib/utils";
 import type { Project, Provider, Schedule } from "@/lib/types";
 
 const SCHEDULE_LABELS: Record<Schedule, string> = {
@@ -289,9 +290,20 @@ export default function ProjectForm({
           {saving ? "Saving..." : "Save changes"}
         </Button>
         {saved && !saving && (
+          // A bare "Saved" was the whole complaint: an engine with no key
+          // behind it saved as cheerfully as a working one, and the warning
+          // above sits pre-submit where it reads as advice rather than as the
+          // outcome. Qualify the confirmation with what is still missing.
           <span className="inline-flex items-center gap-1.5 text-sm text-ink-soft">
             <Check className="h-4 w-4 text-teal-dark" />
-            Saved
+            {engineNeedsKey ? (
+              <span>
+                Saved, but runs need {article(PROVIDERS[selectedProvider].label)}{" "}
+                {PROVIDERS[selectedProvider].label} key
+              </span>
+            ) : (
+              "Saved"
+            )}
           </span>
         )}
       </div>

--- a/lib/api-service.test.ts
+++ b/lib/api-service.test.ts
@@ -360,8 +360,9 @@ describe("triggerRunForProject", () => {
 
   // An override naming only the provider must not carry the PROJECT's model
   // across: "run this on openai" with the project set to claude-sonnet-4-6
-  // would otherwise ask OpenAI for a Claude model id.
-  it("drops the project model when the override changes provider", async () => {
+  // would otherwise ask OpenAI for a Claude model id. It now resolves to that
+  // provider's default explicitly, rather than leaving the resolver to guess.
+  it("resolves the new provider's default when the override omits a model", async () => {
     const db = fakeDb({ projects: () => ({ data: PROJECT }) });
     vi.mocked(resolveRunKeyFor).mockResolvedValue({
       source: "own",
@@ -378,7 +379,20 @@ describe("triggerRunForProject", () => {
     });
 
     await triggerRunForProject(db as never, "user-1", "proj-1", { provider: "openai" });
-    expect(resolveRunKeyFor).toHaveBeenCalledWith(db, "user-1", "openai", undefined);
+    expect(resolveRunKeyFor).toHaveBeenCalledWith(db, "user-1", "openai", "gpt-4o");
+  });
+
+  // Same validation on the per-run override: an unusable pair would otherwise
+  // be recorded on the run row and then rejected by the provider mid-run.
+  it("rejects a per-run override whose model isn't the provider's", async () => {
+    const db = fakeDb({ projects: () => ({ data: PROJECT }) });
+    const outcome = await triggerRunForProject(db as never, "user-1", "proj-1", {
+      provider: "openai",
+      model: "claude-opus-4-8",
+    });
+    expect(outcome).toMatchObject({ ok: false, code: "invalid_engine" });
+    expect(resolveRunKeyFor).not.toHaveBeenCalled();
+    expect(executeRun).not.toHaveBeenCalled();
   });
 
   it("names the requested provider when an override has no own key", async () => {
@@ -435,6 +449,33 @@ describe("createProject", () => {
       name: "Acme",
       brand_name: "Acme",
       default_provider: "mistral",
+    });
+    expect(outcome).toMatchObject({ ok: false, code: "invalid" });
+    expect(db.queries).toHaveLength(0);
+  });
+
+  // LET-169: the model was accepted as any non-empty string, so a pair like
+  // openai + claude-opus-4-8 saved cleanly and then failed at the provider,
+  // as an error naming a model the caller never chose.
+  it("rejects a model the chosen provider doesn't offer", async () => {
+    const db = fakeDb({});
+    const outcome = await createProject(db as never, "user-1", {
+      name: "Acme",
+      brand_name: "Acme",
+      default_provider: "openai",
+      default_model: "claude-opus-4-8",
+    });
+    expect(outcome).toMatchObject({ ok: false, code: "invalid" });
+    expect((outcome as { message: string }).message).toContain("claude-opus-4-8");
+    expect(db.queries).toHaveLength(0);
+  });
+
+  it("rejects a model that is in no catalog", async () => {
+    const db = fakeDb({});
+    const outcome = await createProject(db as never, "user-1", {
+      name: "Acme",
+      brand_name: "Acme",
+      default_model: "banana",
     });
     expect(outcome).toMatchObject({ ok: false, code: "invalid" });
     expect(db.queries).toHaveLength(0);

--- a/lib/api-service.ts
+++ b/lib/api-service.ts
@@ -22,7 +22,7 @@ import {
 } from "@/lib/metrics";
 import { executeRun, type RunContext, type RunResult } from "@/lib/engine";
 import { pickDefaultProvider, resolveRunKeyFor, engineKeyMessage } from "@/lib/trial";
-import { defaultModelFor, isProvider, PROVIDERS } from "@/lib/models";
+import { isProvider, resolveEngine, PROVIDERS } from "@/lib/models";
 
 // Operations behind the programmatic surface, shared by the REST v1 routes and
 // the MCP tools so the two can't drift apart. Callers authenticate with a
@@ -131,10 +131,14 @@ export async function createProject(
     typeof input.default_provider === "string" && isProvider(input.default_provider)
       ? input.default_provider
       : pickDefaultProvider();
-  const model =
-    typeof input.default_model === "string" && input.default_model.trim().length > 0
-      ? input.default_model.trim()
-      : defaultModelFor(provider);
+  // The model has to belong to the provider it will be sent to. Accepting any
+  // string here stored pairs that only failed later, at the provider, as an
+  // error naming a model id the caller never chose.
+  const engine = resolveEngine(provider, input.default_model);
+  if (!engine.ok) {
+    return { ok: false, code: "invalid", message: engine.message };
+  }
+  const model = engine.model;
 
   // `user_id` comes from the authenticated key, never the body: the insert is
   // what ties the new project to the caller on the service-role client.
@@ -598,7 +602,10 @@ export async function getRunResponses(
 
 export type TriggerOutcome =
   | { ok: true; result: RunResult }
-  | { ok: false; code: "not_found" | "no_key"; message: string };
+  // `invalid_engine` is the caller's request being malformed (a model the
+  // provider doesn't offer), distinct from `no_key` which is about billing —
+  // routes map them to 400 and 402 respectively.
+  | { ok: false; code: "not_found" | "no_key" | "invalid_engine"; message: string };
 
 /**
  * Execute a monitoring run for one of the user's projects.
@@ -623,12 +630,20 @@ export async function triggerRunForProject(
   // only (the project row is untouched). Resolution is strict either way: an
   // API caller that asks for gpt-4o and gets Claude back has no way to notice,
   // and the run row would claim the engine it was actually given.
-  const key = await resolveRunKeyFor(
-    supabase,
-    userId,
+  //
+  // Validated against the catalog first, for the same reason the project write
+  // paths are: an override naming a model the provider doesn't offer would be
+  // recorded on the run and then rejected by the provider mid-run, after the
+  // run row already existed.
+  const override = resolveEngine(
     options?.provider ?? project.default_provider,
     options?.model ?? (options?.provider ? undefined : project.default_model),
   );
+  if (!override.ok) {
+    return { ok: false, code: "invalid_engine", message: override.message };
+  }
+
+  const key = await resolveRunKeyFor(supabase, userId, override.provider, override.model);
   if (key.source !== "own") {
     const providerLabel = PROVIDERS[key.requested.provider].label;
     return {

--- a/lib/models.test.ts
+++ b/lib/models.test.ts
@@ -7,6 +7,8 @@ import {
   defaultModelFor,
   modelLabel,
   analysisModelFor,
+  isModelFor,
+  resolveEngine,
 } from "@/lib/models";
 
 afterEach(() => {
@@ -102,5 +104,73 @@ describe("analysisModelFor", () => {
   it("ignores blank overrides", () => {
     vi.stubEnv("ANALYSIS_ANTHROPIC_MODEL", "   ");
     expect(analysisModelFor("anthropic")).toBe("claude-haiku-4-5");
+  });
+});
+
+describe("isModelFor", () => {
+  it("accepts each provider's own models and rejects other providers'", () => {
+    expect(isModelFor("openai", "gpt-4o")).toBe(true);
+    expect(isModelFor("anthropic", "claude-opus-4-8")).toBe(true);
+    expect(isModelFor("openai", "claude-opus-4-8")).toBe(false);
+    expect(isModelFor("anthropic", "gpt-4o")).toBe(false);
+  });
+
+  // The pseudo-model is a real catalog entry under google, so validation has to
+  // let it through or the AI Overviews engine becomes unselectable.
+  it("accepts the Google AI Overviews pseudo-model", () => {
+    expect(isModelFor("google", GOOGLE_AI_OVERVIEWS_MODEL)).toBe(true);
+  });
+
+  it("rejects an id that is in no catalog", () => {
+    expect(isModelFor("google", "banana")).toBe(false);
+  });
+});
+
+describe("resolveEngine", () => {
+  // The bug: the write paths applied provider and model independently, so a
+  // request naming only the provider kept the old model and persisted pairs
+  // like openai + claude-opus-4-8 that only failed later, at the provider.
+  it("falls back to the provider's default when no model is given", () => {
+    for (const model of [undefined, null, "", "   ", 42]) {
+      const r = resolveEngine("openai", model);
+      expect(r).toEqual({ ok: true, provider: "openai", model: "gpt-4o" });
+    }
+  });
+
+  it("refuses a model the provider doesn't offer", () => {
+    const r = resolveEngine("openai", "claude-opus-4-8");
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.message).toContain("OpenAI (ChatGPT)");
+      expect(r.message).toContain("claude-opus-4-8");
+      // Names what IS available, so a caller doesn't have to guess.
+      expect(r.message).toContain("gpt-4o");
+    }
+  });
+
+  it("refuses an id that is in no catalog at all", () => {
+    // modelLabel echoes an unknown id verbatim, so storing this would show
+    // "banana" as the selected engine.
+    expect(resolveEngine("google", "banana").ok).toBe(false);
+  });
+
+  it("passes a valid pair through unchanged, trimming whitespace", () => {
+    expect(resolveEngine("anthropic", "  claude-haiku-4-5 ")).toEqual({
+      ok: true,
+      provider: "anthropic",
+      model: "claude-haiku-4-5",
+    });
+  });
+
+  it("accepts every model in the catalog for its own provider", () => {
+    for (const info of PROVIDER_LIST) {
+      for (const m of info.models) {
+        expect(resolveEngine(info.id, m.id)).toEqual({
+          ok: true,
+          provider: info.id,
+          model: m.id,
+        });
+      }
+    }
   });
 });

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -100,6 +100,46 @@ export function defaultModelFor(provider: Provider): string {
   return PROVIDERS[provider].models[0].id;
 }
 
+/** Does this provider actually offer this model? */
+export function isModelFor(provider: Provider, modelId: string): boolean {
+  return PROVIDERS[provider].models.some((m) => m.id === modelId);
+}
+
+export type EngineResolution =
+  | { ok: true; provider: Provider; model: string }
+  | { ok: false; message: string };
+
+/**
+ * Resolve a requested answer engine into a (provider, model) pair that can
+ * actually be called, or say why it can't.
+ *
+ * The two halves have to travel together. The write paths used to apply them
+ * independently — a request naming only a provider updated the provider and
+ * left the previous model in place — which persisted pairs like
+ * `openai` + `claude-opus-4-8`. Nothing rejected that, so it saved cleanly and
+ * then failed at the provider on the next run, as an error about a model id the
+ * user never chose. A model absent from the request therefore resolves to the
+ * provider's default rather than to whatever was there before.
+ *
+ * The catalog is the authority: an unknown model id is refused rather than
+ * stored, since `modelLabel` falls back to echoing the raw id and the UI would
+ * happily display "banana" as the selected engine.
+ */
+export function resolveEngine(provider: Provider, model: unknown): EngineResolution {
+  const requested = typeof model === "string" ? model.trim() : "";
+  if (!requested) {
+    return { ok: true, provider, model: defaultModelFor(provider) };
+  }
+  if (!isModelFor(provider, requested)) {
+    const offered = PROVIDERS[provider].models.map((m) => m.id).join(", ");
+    return {
+      ok: false,
+      message: `${PROVIDERS[provider].label} doesn't offer "${requested}". Available: ${offered}.`,
+    };
+  }
+  return { ok: true, provider, model: requested };
+}
+
 const ANALYSIS_MODEL_ENV: Record<Provider, string> = {
   anthropic: "ANALYSIS_ANTHROPIC_MODEL",
   openai: "ANALYSIS_OPENAI_MODEL",


### PR DESCRIPTION
Fixes [LET-169](https://linear.app/letterbrace/issue/LET-169/settings-answer-engine-selection-field-validation).

The screenshots show GPT-4o mini saved as the answer engine with only Claude connected, and a cheerful **"Saved"**. Digging in, there were two separate holes plus one part already fixed.

## Hole 1 — the model was never validated against the provider

`default_model` was accepted as **any non-empty string**. So these all saved cleanly:

| Payload | Was | Now |
|---|---|---|
| `{provider: "openai", model: "claude-opus-4-8"}` | 200, stored | **400** |
| `{provider: "google", model: "banana"}` | 200, stored | **400** |

They failed only later, at the provider, as an error naming a model the user never chose. And `modelLabel` echoes an unknown id verbatim, so the picker would display **"banana"** back as the current selection.

## Hole 2 — the two halves were applied independently

Worse, and not visible from the UI (which always sends both):

```js
if (providerOverride) update.default_provider = providerOverride;
if (modelOverride)    update.default_model    = modelOverride;
```

A request naming **only** `default_provider` updated the provider and left the previous model behind. Switching provider from the API was enough to persist `openai` + `gemini-pro-latest` — a pair that can never run. Verified against a live server: that request now lands on `openai`/`gpt-4o`, not `openai`/`gemini-pro-latest`.

## The fix

`resolveEngine` (lib/models) resolves the pair **together**, against the catalog:
- model absent → that provider's default, never the previous model
- model not offered by the provider → refused, naming what *is* available
- valid pair → passes through

Applied to both project write paths (`/api/project`, `createProject` for API/CLI) and to the **per-run engine override**, which had the same gap and would otherwise record an unusable pair on a run row before the provider rejected it mid-run. The v1 runs route gains a `400` for that, distinct from the `402` that means billing.

## The form

"Saved" now qualifies itself — *"Saved, but runs need an OpenAI (ChatGPT) key"* — when the chosen engine has no key. The pre-submit warning above the picker reads as advice; the complaint was about the *outcome* saying nothing.

**I did not block that save**, and would like a second opinion. Configuring the engine before bringing the key is a legitimate order, blocking creates an ordering trap (and a race with a key added in another tab), and since LET-172 runs refuse loudly rather than substitute — so nothing silently misbehaves. The warning, the qualified save, the disabled run button and the refusing API all point the same way. Easy to make it a hard block if you'd rather.

## Already fixed, worth noting

The screenshot shows the old grey *"You'll need a key for the matching provider"* helper text. LET-172 already replaced that with a terracotta warning naming the missing provider, so that part of the report is on `master` — Bala was on a build without it.

## Testing

384 tests pass (11 new), typecheck / lint / build clean.

Probed against a live signed-in server with the exact payloads above: both invalid pairs rejected 400 with the project's engine **unchanged**, provider-only save landing on the new provider's default, valid pair accepted. Engine restored afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
