### PR TITLE
Housekeeping: org gate, column headers, readable share of voice, mobile layout

### DIFF
--- a/app/api/onboarding/complete/route.ts
+++ b/app/api/onboarding/complete/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
-import { getConfiguredProviders, getProjects, setActiveProject } from "@/lib/data";
+import { getConfiguredProviders, setActiveProject } from "@/lib/data";
 import { executeRun } from "@/lib/engine";
 import { humanError } from "@/lib/llm";
 import {
@@ -59,24 +59,14 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Brand name is required." }, { status: 400 });
   }
 
-  // The first organization is free; another one needs the user's own key.
-  // Enforced here as well as in the UI: without it, a second org could be
-  // created by posting straight to this route, and its first monitor would
-  // quietly spend one of the account's free runs.
-  const [existingProjects, providers] = await Promise.all([
-    getProjects(supabase, user.id),
-    getConfiguredProviders(supabase, user.id),
-  ]);
-  if (existingProjects.length > 0 && providers.length === 0) {
-    return NextResponse.json(
-      {
-        error:
-          "Add your own API key before monitoring another brand. Free credits cover your first organization.",
-        needsKey: true,
-      },
-      { status: 403 },
-    );
-  }
+  // Creating an organization is free and unlimited: it is configuration, not
+  // consumption. A second org used to be refused without the user's own key,
+  // on the reasoning that its first monitor would spend a free run — but the
+  // free-run allowance is counted per ACCOUNT by consume_trial_run, not per
+  // org, so extra orgs can't spend more than the allowance either way. All the
+  // gate actually did was block someone from setting up the brands they wanted
+  // to monitor before deciding to bring a key.
+  const providers = await getConfiguredProviders(supabase, user.id);
   const name =
     typeof body.name === "string" && body.name.trim() ? body.name.trim() : brand_name;
   // First entry = primary domain; the rest are phantom sites for the brand.

--- a/app/api/onboarding/onboarding-route.test.ts
+++ b/app/api/onboarding/onboarding-route.test.ts
@@ -26,7 +26,7 @@ vi.mock("@/lib/trial", () => ({
 }));
 vi.mock("@/lib/engine", () => ({ executeRun: vi.fn() }));
 
-const { getProjects, getConfiguredProviders } = await import("@/lib/data");
+const { getConfiguredProviders } = await import("@/lib/data");
 const { POST } = await import("@/app/api/onboarding/complete/route");
 
 function req(body: unknown) {
@@ -95,36 +95,33 @@ describe("POST /api/onboarding/complete — topic validation", () => {
   });
 });
 
-describe("POST /api/onboarding/complete — second-organization gate", () => {
+describe("POST /api/onboarding/complete, creating more organizations", () => {
   const good = { ...BASE, topics: [{ name: "CDN", prompts: ["best cdn?"] }] };
 
-  it("refuses a second org on the trial, before spending a free run", async () => {
-    vi.mocked(getProjects).mockResolvedValue([{ id: "p1" } as never]);
+  // A second org used to be refused without the user's own key. The free-run
+  // allowance is counted per ACCOUNT (consume_trial_run), not per org, so extra
+  // orgs can't spend more of it — the gate only stopped people setting up the
+  // brands they wanted to monitor before deciding to bring a key.
+  // Reaching the database mock, which throws by design, proves it got through.
+  it("lets a keyless account create a second org", async () => {
     vi.mocked(getConfiguredProviders).mockResolvedValue([]);
-    const res = await POST(req(good));
-    expect(res.status).toBe(403);
-    const body = await res.json();
-    expect(body.needsKey).toBe(true);
-    expect(body.error).toMatch(/own API key/);
+    await expect(POST(req(good))).rejects.toThrow(/before touching the database/);
   });
 
-  it("allows a second org once the user has their own key", async () => {
-    vi.mocked(getProjects).mockResolvedValue([{ id: "p1" } as never]);
+  it("lets an account with a key create another org", async () => {
     vi.mocked(getConfiguredProviders).mockResolvedValue(["anthropic"]);
-    // Reaching the database mock proves the gate let it through.
     await expect(POST(req(good))).rejects.toThrow(/before touching the database/);
   });
 
-  it("always allows the first org, key or not", async () => {
-    vi.mocked(getProjects).mockResolvedValue([]);
+  it("still allows the very first org, key or not", async () => {
     vi.mocked(getConfiguredProviders).mockResolvedValue([]);
     await expect(POST(req(good))).rejects.toThrow(/before touching the database/);
   });
 
-  it("gates before validating topics, so no free run is risked either way", async () => {
-    vi.mocked(getProjects).mockResolvedValue([{ id: "p1" } as never]);
+  // Topic validation is the only thing that should reject the request now.
+  it("still validates topics for a keyless account", async () => {
     vi.mocked(getConfiguredProviders).mockResolvedValue([]);
     const res = await POST(req({ ...BASE, topics: [{ name: "", prompts: [] }] }));
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(400);
   });
 });

--- a/app/dashboard/competitors/competitors-client.tsx
+++ b/app/dashboard/competitors/competitors-client.tsx
@@ -159,7 +159,7 @@ export function CompetitorsClient({
       <Card>
         <CardBody>
           <h3 className="text-lg font-semibold text-ink">Add a competitor</h3>
-          <p className="mt-1 text-sm text-ink-faint">
+          <p className="mt-1 text-sm text-ink-soft">
             Aliases and domain help Lettertrace catch every way an AI answer might refer to them.
           </p>
           <form onSubmit={handleAdd} className="mt-5 grid gap-4 sm:grid-cols-3">
@@ -211,7 +211,7 @@ export function CompetitorsClient({
               </span>
               <div>
                 <h3 className="text-lg font-semibold text-ink">Suggested competitors</h3>
-                <p className="mt-1 text-sm text-ink-faint">
+                <p className="mt-1 text-sm text-ink-soft">
                   Let AI propose direct competitors based on your brand and topics. You decide
                   which ones to track.
                 </p>

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -36,10 +36,6 @@ export default async function DashboardLayout({
   // provider, so any own key at all means they're never on the trial.
   const providers = await getConfiguredProviders(supabase, user.id);
 
-  // The first organization is free; another one needs the user's own key.
-  // Existing orgs are untouched — this only gates creating more.
-  const canAddOrg = projects.length === 0 || providers.length > 0;
-
   let trial: { used: number; limit: number; exhausted: boolean } | null = null;
   if (project && trialEnabled() && providers.length === 0) {
     const used = await getTrialRunsUsed(supabase, user.id);
@@ -69,7 +65,6 @@ export default async function DashboardLayout({
                 brandName: p.brand_name,
               }))}
               activeId={project.id}
-              canAddOrg={canAddOrg}
             />
           ) : (
             <div className="rounded border border-ink/10 bg-paper-shade/50 px-4 py-3">

--- a/app/dashboard/new/page.tsx
+++ b/app/dashboard/new/page.tsx
@@ -1,6 +1,4 @@
-import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
-import { getConfiguredProviders, getProjects } from "@/lib/data";
 import { Onboarding } from "../onboarding";
 
 export const dynamic = "force-dynamic";
@@ -8,24 +6,14 @@ export const dynamic = "force-dynamic";
 // Add another organization to the account: same wizard as first-run onboarding.
 // Completing it creates the org, makes it active, and runs its first monitor.
 //
-// Gated to match the switcher — the nav item is hidden without a key, but the
-// route is reachable by URL, and completing it would spend a free run on an
-// org that can't produce a usable result yet.
+// Deliberately ungated. Setting up a brand is configuration; the free-run
+// allowance is counted per account, so extra orgs cannot spend more of it.
 export default async function NewOrganizationPage() {
   const supabase = createClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();
   if (!user) return null;
-
-  const [projects, providers] = await Promise.all([
-    getProjects(supabase, user.id),
-    getConfiguredProviders(supabase, user.id),
-  ]);
-
-  if (projects.length > 0 && providers.length === 0) {
-    redirect("/dashboard/settings?needKey=1");
-  }
 
   return <Onboarding />;
 }

--- a/app/dashboard/onboarding.tsx
+++ b/app/dashboard/onboarding.tsx
@@ -428,47 +428,61 @@ export function Onboarding() {
             </div>
             <p className="mt-1 text-sm text-ink-soft">
               {competitors.length > 0
-                ? "We spotted these. Edit or remove any before you start — we'll track how often each is named alongside you."
+                ? "We spotted these. Edit or remove any before you start. We'll track how often each is named alongside you."
                 : "Add the brands you want to benchmark against, and we'll track how often each is named alongside you."}
             </p>
 
             {competitors.length > 0 && (
-              <div className="mt-4 space-y-2">
-                {competitors.map((c, ci) => (
-                  <div key={ci} className="flex items-center gap-2">
-                    <Input
-                      value={c.name}
-                      onChange={(e) => setCompetitorField(ci, "name", e.target.value)}
-                      placeholder="Competitor name"
-                      className="font-medium sm:max-w-[15rem]"
-                      aria-label={`Competitor ${ci + 1} name`}
-                    />
-                    <Input
-                      value={c.aliases}
-                      onChange={(e) => setCompetitorField(ci, "aliases", e.target.value)}
-                      // Short enough not to truncate in this column; a single
-                      // name works too, so the comma rule needn't be spelled out.
-                      placeholder="Other names"
-                      className="hidden text-sm sm:block"
-                      aria-label={`Competitor ${ci + 1} aliases`}
-                    />
-                    <Input
-                      value={c.domain}
-                      onChange={(e) => setCompetitorField(ci, "domain", e.target.value)}
-                      placeholder="domain.com"
-                      className="hidden text-sm sm:block sm:max-w-[12rem]"
-                      aria-label={`Competitor ${ci + 1} domain`}
-                    />
-                    <button
-                      type="button"
-                      onClick={() => removeCompetitor(ci)}
-                      className="shrink-0 rounded p-2 text-ink-faint transition hover:bg-ink/5 hover:text-terracotta-dark"
-                      aria-label={`Remove ${c.name.trim() || "competitor"}`}
+              // A grid, not a row of flex inputs, so the header labels line up
+              // with the columns they name. Aliases and domain are hidden on
+              // narrow screens and drop out of the grid flow with them.
+              <div className="mt-4">
+                <div className="hidden gap-2 pb-1.5 pl-3 sm:grid sm:grid-cols-[15rem_1fr_12rem_2.25rem]">
+                  <span className="text-xs font-medium text-ink-faint">Name</span>
+                  <span className="text-xs font-medium text-ink-faint">Other names</span>
+                  <span className="text-xs font-medium text-ink-faint">Domain</span>
+                  <span aria-hidden />
+                </div>
+                <div className="space-y-2">
+                  {competitors.map((c, ci) => (
+                    <div
+                      key={ci}
+                      className="grid grid-cols-[1fr_2.25rem] items-center gap-2 sm:grid-cols-[15rem_1fr_12rem_2.25rem]"
                     >
-                      <X className="h-4 w-4" />
-                    </button>
-                  </div>
-                ))}
+                      <Input
+                        value={c.name}
+                        onChange={(e) => setCompetitorField(ci, "name", e.target.value)}
+                        placeholder="Competitor name"
+                        className="font-medium"
+                        aria-label={`Competitor ${ci + 1} name`}
+                      />
+                      <Input
+                        value={c.aliases}
+                        onChange={(e) => setCompetitorField(ci, "aliases", e.target.value)}
+                        // Short enough not to truncate in this column; a single
+                        // name works too, so the comma rule needn't be spelled out.
+                        placeholder="Other names"
+                        className="hidden text-sm sm:block"
+                        aria-label={`Competitor ${ci + 1} aliases`}
+                      />
+                      <Input
+                        value={c.domain}
+                        onChange={(e) => setCompetitorField(ci, "domain", e.target.value)}
+                        placeholder="domain.com"
+                        className="hidden text-sm sm:block"
+                        aria-label={`Competitor ${ci + 1} domain`}
+                      />
+                      <button
+                        type="button"
+                        onClick={() => removeCompetitor(ci)}
+                        className="flex h-9 w-9 shrink-0 items-center justify-center rounded text-ink-faint transition hover:bg-ink/5 hover:text-terracotta-dark"
+                        aria-label={`Remove ${c.name.trim() || "competitor"}`}
+                      >
+                        <X className="h-4 w-4" />
+                      </button>
+                    </div>
+                  ))}
+                </div>
               </div>
             )}
 

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -164,7 +164,7 @@ export default async function DashboardPage() {
             <div className="flex flex-wrap items-center justify-between gap-3">
               <div>
                 <h3 className="text-lg font-semibold text-ink">Get started</h3>
-                <p className="mt-1 text-sm text-ink-faint">
+                <p className="mt-1 text-sm text-ink-soft">
                   Four quick steps to your first visibility report.
                 </p>
               </div>
@@ -197,7 +197,7 @@ export default async function DashboardPage() {
                           <Icon className="h-3.5 w-3.5 text-ink-faint" />
                         </div>
                         <p className="mt-0.5 font-medium text-ink">{step.title}</p>
-                        <p className="mt-0.5 text-sm text-ink-faint">
+                        <p className="mt-0.5 text-sm text-ink-soft">
                           {step.description}
                         </p>
                       </div>
@@ -375,7 +375,7 @@ export default async function DashboardPage() {
             <div className="mb-4 flex items-center justify-between">
               <div>
                 <h3 className="text-lg font-semibold text-ink">Visibility over time</h3>
-                <p className="mt-0.5 text-sm text-ink-faint">
+                <p className="mt-0.5 text-sm text-ink-soft">
                   Brand visibility and share of voice across recent runs.
                 </p>
               </div>
@@ -387,7 +387,7 @@ export default async function DashboardPage() {
         <Card>
           <CardBody>
             <h3 className="text-lg font-semibold text-ink">Brand sentiment</h3>
-            <p className="mt-0.5 text-sm text-ink-faint">
+            <p className="mt-0.5 text-sm text-ink-soft">
               Tone of answers that mention {project.brand_name}.
             </p>
             <div className="mt-4">
@@ -402,7 +402,7 @@ export default async function DashboardPage() {
         <Card>
           <CardBody>
             <h3 className="text-lg font-semibold text-ink">Share of voice</h3>
-            <p className="mt-0.5 text-sm text-ink-faint">
+            <p className="mt-0.5 text-sm text-ink-soft">
               You vs. tracked competitors in the latest run.
             </p>
             {/* Mention detection only looks for the brand and the competitors
@@ -458,7 +458,7 @@ export default async function DashboardPage() {
         <Card>
           <CardBody>
             <h3 className="text-lg font-semibold text-ink">By topic</h3>
-            <p className="mt-0.5 text-sm text-ink-faint">
+            <p className="mt-0.5 text-sm text-ink-soft">
               Where you show up most across monitored topics.
             </p>
             {topicStats.length === 0 ? (

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -416,7 +416,7 @@ export default async function DashboardPage() {
                   No competitors tracked yet, so there is nothing to compare against.
                 </p>
                 <p className="mt-1 text-sm text-ink-faint">
-                  We only look for brands you list — companies named in an answer are
+                  We only look for brands you list. Companies named in an answer are
                   invisible until you add them.
                 </p>
                 <Link

--- a/app/dashboard/settings/api-keys-manager.tsx
+++ b/app/dashboard/settings/api-keys-manager.tsx
@@ -83,7 +83,7 @@ export default function ApiKeysManager({ keys }: { keys: ApiKeyPublic[] }) {
       {freshKey && (
         <div className="rounded border border-emerald-700/20 bg-mint/30 p-4">
           <p className="text-sm font-medium text-ink">
-            Copy your new key now — it won&apos;t be shown again.
+            Copy your new key now. It won&apos;t be shown again.
           </p>
           <div className="mt-2 flex items-center gap-2">
             <code className="min-w-0 flex-1 truncate rounded bg-paper px-3 py-2 font-mono text-sm text-ink">

--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -44,7 +44,7 @@ export default async function SettingsPage() {
             </span>
             <div>
               <h3 className="text-lg font-semibold text-ink">Your model keys</h3>
-              <p className="mt-1 text-sm text-ink-faint">
+              <p className="mt-1 text-sm text-ink-soft">
                 Claude, ChatGPT, and Gemini are the assistants Lettertrace queries.
                 Your Google key also powers Google AI Overviews. Bring a key for each
                 one you want to monitor with. They&apos;re encrypted at rest.
@@ -63,7 +63,7 @@ export default async function SettingsPage() {
             </span>
             <div>
               <h3 className="text-lg font-semibold text-ink">Organization</h3>
-              <p className="mt-1 text-sm text-ink-faint">
+              <p className="mt-1 text-sm text-ink-soft">
                 {project
                   ? `Settings for ${project.brand_name}, the organization selected in the sidebar. Tune how we recognize this brand across AI answers.`
                   : "Fill this in to get started, it powers prompt generation and mention detection."}
@@ -86,7 +86,7 @@ export default async function SettingsPage() {
             </span>
             <div>
               <h3 className="text-lg font-semibold text-ink">API &amp; MCP access</h3>
-              <p className="mt-1 text-sm text-ink-faint">
+              <p className="mt-1 text-sm text-ink-soft">
                 Create a key to read your share-of-voice data from scripts
                 (REST, <code className="font-mono text-xs">/api/v1</code>) or
                 connect Lettertrace to Claude and other MCP clients at{" "}
@@ -107,7 +107,7 @@ export default async function SettingsPage() {
             </span>
             <div>
               <h3 className="text-lg font-semibold text-ink">Appearance</h3>
-              <p className="mt-1 text-sm text-ink-faint">
+              <p className="mt-1 text-sm text-ink-soft">
                 Lettertrace defaults to dark. Switch to light if you prefer, your
                 choice is remembered on this device.
               </p>

--- a/app/dashboard/settings/project-form.tsx
+++ b/app/dashboard/settings/project-form.tsx
@@ -169,7 +169,7 @@ export default function ProjectForm({
           />
           <p className="mt-1.5 text-xs text-ink-faint">
             Comma-separated, main domain first. Sources cited from any of these
-            count as yours — include phantom sites for this brand.
+            count as yours. Include phantom sites for this brand.
           </p>
         </div>
         <div>

--- a/app/dashboard/topics/topics-client.tsx
+++ b/app/dashboard/topics/topics-client.tsx
@@ -217,7 +217,7 @@ function TopicCard({
           <div className="min-w-0">
             <h3 className="text-lg font-semibold text-ink">{topic.name}</h3>
             {topic.description && (
-              <p className="mt-1 text-sm text-ink-faint">{topic.description}</p>
+              <p className="mt-1 text-sm text-ink-soft">{topic.description}</p>
             )}
             <p className="mt-2 text-xs text-ink-faint">
               {prompts.length} {prompts.length === 1 ? "prompt" : "prompts"}

--- a/app/globals.css
+++ b/app/globals.css
@@ -191,9 +191,12 @@
   }
 }
 
-/* Recharts: keep tooltips/axes on-brand in both themes. */
+/* Recharts: keep tooltips/axes on-brand in both themes.
+   ink-soft, not ink-faint: a CSS rule beats the `fill` presentation attribute
+   Recharts sets, so this is what actually decides axis-label colour, and at
+   --c-ink-faint it measured 4.63:1 on a card in dark mode. */
 .recharts-cartesian-axis-tick-value {
-  fill: rgb(var(--c-ink-faint));
+  fill: rgb(var(--c-ink-soft));
   font-size: 12px;
 }
 .recharts-default-tooltip {

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -17,7 +17,7 @@ export default function PrivacyPage() {
       intro="Lettertrace is operated by The Letter Company. This policy explains what we collect when you use the hosted service at lettertrace.com, why we collect it, and who else sees it."
     >
       <Section n={1} title="Information we collect">
-        <p><strong>Account information.</strong> Your email address, and — if you sign in with Google or GitHub — the name and profile picture that provider returns. We never receive your Google or GitHub password.</p>
+        <p><strong>Account information.</strong> Your email address, and, if you sign in with Google or GitHub, the name and profile picture that provider returns. We never receive your Google or GitHub password.</p>
         <p><strong>Monitoring configuration.</strong> The brands, domains, aliases, competitors, topics, and prompts you set up, plus your model and schedule preferences.</p>
         <p><strong>Run results.</strong> For each monitoring run we store the full text of the answers the AI models returned, the web sources they cited, and the brand and competitor mentions detected in them, along with sentiment and position.</p>
         <p><strong>Provider API keys.</strong> If you bring your own Anthropic or OpenAI key, we store it encrypted (see §5) so scheduled runs can use it. We also store a short hint such as <code>sk-…4a9c</code> so you can tell your keys apart.</p>
@@ -31,7 +31,7 @@ export default function PrivacyPage() {
         <p>When a monitoring run executes, we send your prompts to Anthropic and/or OpenAI. If web search is enabled for a project, those providers also run search queries derived from your prompts. The answers come back to us and are stored against your account.</p>
         <p><strong>Under bring-your-own-key, those requests are made with your API key, under your own account with that provider.</strong> How they handle, retain, and train on that traffic is governed by your agreement with them, not by this policy. Review Anthropic&apos;s and OpenAI&apos;s privacy terms directly.</p>
         <p>If you instead use trial runs on our shared keys, those requests are made under The Letter Company&apos;s provider accounts and are subject to our agreements with those providers.</p>
-        <p>Prompts are questions about a market or category. Do not put personal data, customer information, or confidential material into a prompt — it will be transmitted to a third-party model provider.</p>
+        <p>Prompts are questions about a market or category. Do not put personal data, customer information, or confidential material into a prompt. It will be transmitted to a third-party model provider.</p>
       </Section>
 
       <Section n={3} title="Website content we fetch">
@@ -51,7 +51,7 @@ export default function PrivacyPage() {
 
       <Section n={5} title="Security">
         <p><strong>Provider API keys are encrypted at rest using AES-256-GCM</strong> with a unique initialization vector per key. They are decrypted only in memory, at the moment a run executes.</p>
-        <p><strong>Lettertrace API keys are stored as SHA-256 hashes only</strong> — never in plaintext.</p>
+        <p><strong>Lettertrace API keys are stored as SHA-256 hashes only</strong>, never in plaintext.</p>
         <p><strong>Your data is isolated per account by Postgres Row Level Security</strong>, enforced by the database rather than only by application code. Elevated database access is limited to the scheduled-run job and the API-key-authenticated surface, where every query is scoped to the key&apos;s owner.</p>
         <p>Traffic to and from lettertrace.com is encrypted in transit over TLS. No system is perfectly secure, and we cannot guarantee absolute security.</p>
       </Section>
@@ -59,16 +59,16 @@ export default function PrivacyPage() {
       <Section n={6} title="Service providers">
         <p>We rely on the following processors to run Lettertrace:</p>
         <ul>
-          <li><strong>Supabase</strong> — database, authentication, and storage of everything described in §1.</li>
-          <li><strong>Vercel</strong> — application hosting and request logs.</li>
-          <li><strong>Anthropic</strong> and <strong>OpenAI</strong> — the AI models queried during runs, as described in §2.</li>
-          <li><strong>Google</strong> and <strong>GitHub</strong> — optional sign-in. They tell us your email, name, and profile picture; we tell them nothing about your usage.</li>
+          <li><strong>Supabase</strong>: database, authentication, and storage of everything described in §1.</li>
+          <li><strong>Vercel</strong>: application hosting and request logs.</li>
+          <li><strong>Anthropic</strong> and <strong>OpenAI</strong>: the AI models queried during runs, as described in §2.</li>
+          <li><strong>Google</strong> and <strong>GitHub</strong>: optional sign-in. They tell us your email, name, and profile picture; we tell them nothing about your usage.</li>
         </ul>
         <p>We may also disclose information where legally required, or to protect the rights and safety of our users or the service.</p>
       </Section>
 
       <Section n={7} title="Data retention">
-        <p>Your configuration and run history are retained for as long as your account is active, because the product&apos;s value is the trend over time — deleting old runs would erase the record of how your visibility changed.</p>
+        <p>Your configuration and run history are retained for as long as your account is active, because the product&apos;s value is the trend over time. Deleting old runs would erase the record of how your visibility changed.</p>
         <p>When you delete a project, its topics, prompts, competitors, runs, responses, sources, and mentions are deleted with it. When your account is deleted, everything associated with it is deleted.</p>
         <p>Deleting a provider API key removes the encrypted value immediately. Revoking a Lettertrace API key takes effect immediately.</p>
       </Section>
@@ -81,11 +81,11 @@ export default function PrivacyPage() {
           <li>Revoke Lettertrace API keys.</li>
           <li>Request a copy of your data, or deletion of your account, by emailing us.</li>
         </ul>
-        <p>Depending on where you live, you may have additional rights under the GDPR, the UK GDPR, or the CCPA — including access, correction, deletion, portability, and objecting to certain processing. We honour these requests regardless of where you are. We do not sell personal information as defined by the CCPA.</p>
+        <p>Depending on where you live, you may have additional rights under the GDPR, the UK GDPR, or the CCPA, including access, correction, deletion, portability, and objecting to certain processing. We honour these requests regardless of where you are. We do not sell personal information as defined by the CCPA.</p>
       </Section>
 
       <Section n={9} title="Cookies">
-        <p>We use cookies only for authentication — keeping you signed in and refreshing your session. We do not use advertising or cross-site tracking cookies. Clearing them signs you out.</p>
+        <p>We use cookies only for authentication, keeping you signed in and refreshing your session. We do not use advertising or cross-site tracking cookies. Clearing them signs you out.</p>
       </Section>
 
       <Section n={10} title="Children">

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -39,7 +39,7 @@ export default function TermsPage() {
       </Section>
 
       <Section n={5} title="Your content">
-        <p>You keep ownership of everything you put into Lettertrace — your brand configuration, topics, prompts, and competitor lists — and of the reports generated from your runs. You grant us a limited licence to store, process, and transmit that content as needed to operate the service for you.</p>
+        <p>You keep ownership of everything you put into Lettertrace: your brand configuration, topics, prompts, and competitor lists, and of the reports generated from your runs. You grant us a limited licence to store, process, and transmit that content as needed to operate the service for you.</p>
         <p>You are responsible for having the right to monitor the brands and domains you configure.</p>
       </Section>
 
@@ -68,11 +68,11 @@ export default function TermsPage() {
       </Section>
 
       <Section n={9} title="Third-party services">
-        <p>Lettertrace depends on Anthropic, OpenAI, Supabase, Vercel, and — if you use social sign-in — Google and GitHub. We do not control those services. Outages, changes, price increases, or policy changes on their side may affect or interrupt Lettertrace, and we are not liable for them.</p>
+        <p>Lettertrace depends on Anthropic, OpenAI, Supabase, Vercel, and, if you use social sign-in, Google and GitHub. We do not control those services. Outages, changes, price increases, or policy changes on their side may affect or interrupt Lettertrace, and we are not liable for them.</p>
       </Section>
 
       <Section n={10} title="Scope of these terms">
-        <p>These terms govern the hosted service we operate at lettertrace.com. They do not grant any licence to the Lettertrace software itself, and they do not cover any separately operated deployment of it — we provide no warranty or support for those and are not responsible for how they behave.</p>
+        <p>These terms govern the hosted service we operate at lettertrace.com. They do not grant any licence to the Lettertrace software itself, and they do not cover any separately operated deployment of it. We provide no warranty or support for those and are not responsible for how they behave.</p>
       </Section>
 
       <Section n={11} title="Availability and changes">

--- a/components/dashboard/charts.tsx
+++ b/components/dashboard/charts.tsx
@@ -5,6 +5,7 @@ import {
   BarChart,
   CartesianGrid,
   Cell,
+  LabelList,
   Legend,
   Line,
   LineChart,
@@ -144,19 +145,34 @@ export function ShareBars({
   if (!data || data.length === 0) {
     return <Placeholder label="No share of voice yet" height={180} />;
   }
+  // Competitor names are real company names ("AWS Elastic Beanstalk", "Google
+  // Cloud Run"), and a fixed 110px axis truncated them to initials. Size the
+  // label gutter to the longest name actually present, capped so one very long
+  // name can't squeeze the bars out of existence.
+  const longest = data.reduce((n, d) => Math.max(n, d.name.length), 0);
+  const axisWidth = Math.min(200, Math.max(96, longest * 7.2));
+  // Share of voice splits 100% across every tracked brand, so with a handful of
+  // competitors nobody is near 100 and a fixed 0-100 axis spent three quarters
+  // of the width on empty space — the bars ended up too short to compare, which
+  // is the one thing this chart is for. Scale to the data, rounded up to a
+  // quarter so the gridlines stay meaningful, and let the printed values keep a
+  // short axis from reading as "almost everything".
+  const maxValue = data.reduce((n, d) => Math.max(n, d.value || 0), 0);
+  const ceiling = Math.min(100, Math.max(25, Math.ceil(maxValue / 25) * 25));
   const height = Math.max(160, data.length * 44 + 24);
   return (
     <ResponsiveContainer width="100%" height={height}>
       <BarChart
         data={data}
         layout="vertical"
-        margin={{ top: 4, right: 16, bottom: 4, left: 8 }}
+        // Room on the right for the value label that used to require a hover.
+        margin={{ top: 4, right: 44, bottom: 4, left: 8 }}
         barCategoryGap={12}
       >
         <CartesianGrid stroke={t.grid} horizontal={false} />
         <XAxis
           type="number"
-          domain={[0, 100]}
+          domain={[0, ceiling]}
           tick={t.axisTick}
           tickLine={false}
           axisLine={{ stroke: t.grid }}
@@ -168,7 +184,7 @@ export function ShareBars({
           tick={t.axisTick}
           tickLine={false}
           axisLine={false}
-          width={110}
+          width={axisWidth}
         />
         <Tooltip
           cursor={{ fill: t.cursor }}
@@ -179,6 +195,15 @@ export function ShareBars({
           {data.map((entry, i) => (
             <Cell key={i} fill={entry.isBrand ? BRAND : TEAL} />
           ))}
+          {/* The number is the point of the chart; reading it shouldn't need a
+              mouse, and doesn't work at all on touch. */}
+          <LabelList
+            dataKey="value"
+            position="right"
+            formatter={(v: number) => `${Math.round(v)}%`}
+            fill={t.axisTick.fill}
+            fontSize={12}
+          />
         </Bar>
       </BarChart>
     </ResponsiveContainer>

--- a/components/dashboard/charts.tsx
+++ b/components/dashboard/charts.tsx
@@ -33,9 +33,16 @@ import { useTheme } from "@/components/theme";
 const BRAND = "#E07850"; // terracotta (you) — pops on both themes
 const TEAL = "#129C82"; // aqua (share / competitors)
 
+// `label` is the colour of every bit of text Recharts draws: axis ticks, the
+// value printed at the end of a bar, legends. It used to be --c-ink-faint,
+// which measured 4.63:1 on the card surface in dark mode — the dimmest token in
+// the system, and the reason the chart read as greyed-out next to its own
+// heading. These are the --c-ink-soft values, ~9:1, i.e. secondary text rather
+// than disabled text.
 const PALETTE = {
   light: {
     ink: "#1A1917",
+    label: "#45423C",
     faint: "#7C786F",
     grid: "rgba(26,25,23,0.08)",
     surface: "#FFFFFF",
@@ -43,6 +50,7 @@ const PALETTE = {
   },
   dark: {
     ink: "#F4F3EF",
+    label: "#BEBAB2",
     faint: "#8A867D",
     grid: "rgba(255,255,255,0.10)",
     surface: "#1F1D1A",
@@ -55,7 +63,7 @@ function useChartTheme() {
   const p = PALETTE[theme];
   return {
     ...p,
-    axisTick: { fill: p.faint, fontSize: 12 },
+    axisTick: { fill: p.label, fontSize: 12 },
     tooltipStyle: {
       borderRadius: 4,
       border: `1px solid ${p.grid}`,
@@ -64,7 +72,7 @@ function useChartTheme() {
       fontSize: 12,
       color: p.ink,
     } as const,
-    legendStyle: { fontSize: 12, color: p.faint },
+    legendStyle: { fontSize: 12, color: p.label },
   };
 }
 

--- a/components/dashboard/nav.tsx
+++ b/components/dashboard/nav.tsx
@@ -24,7 +24,11 @@ export function DashboardNav() {
   const pathname = usePathname();
 
   return (
-    <nav className="flex flex-row gap-1 md:flex-col">
+    // Six labelled items in one un-wrapping row overflowed the viewport on a
+    // phone, pushing every dashboard page ~267px wide. Wrapping keeps the
+    // labels and needs no scrolling; the column layout at md+ must not wrap, or
+    // the fixed-height sidebar would spill items into a second column.
+    <nav className="flex flex-row flex-wrap gap-1 md:flex-col md:flex-nowrap">
       {NAV_ITEMS.map(({ href, label, icon }) => {
         const active =
           href === "/dashboard"

--- a/components/dashboard/org-switcher.tsx
+++ b/components/dashboard/org-switcher.tsx
@@ -21,15 +21,9 @@ export interface OrgOption {
 export function OrgSwitcher({
   orgs,
   activeId,
-  canAddOrg,
 }: {
   orgs: OrgOption[];
   activeId: string;
-  /** False while the account is on the trial with one org already set up.
-   *  A second org can't produce a usable result on free credits — no
-   *  competitors, no calibrated prompts — and each one silently spends a
-   *  free run on its first monitor. */
-  canAddOrg: boolean;
 }) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
@@ -148,33 +142,14 @@ export function OrgSwitcher({
                 );
               })}
             </ul>
-            {canAddOrg ? (
-              <Link
-                href="/dashboard/new"
-                onClick={() => setOpen(false)}
-                className="flex items-center gap-2 border-t border-ink/10 px-4 py-2.5 text-sm font-medium text-terracotta-dark transition hover:bg-ink/5"
-              >
-                <Plus className="h-4 w-4" aria-hidden />
-                New organization
-              </Link>
-            ) : (
-              <div className="border-t border-ink/10 px-4 py-3">
-                <p className="flex items-center gap-2 text-sm font-medium text-ink-faint">
-                  <Plus className="h-4 w-4 shrink-0" aria-hidden />
-                  New organization
-                </p>
-                <p className="mt-1 text-xs text-ink-faint">
-                  Add your own API key to monitor another brand.
-                </p>
-                <Link
-                  href="/dashboard/settings"
-                  onClick={() => setOpen(false)}
-                  className="mt-1 inline-block text-xs font-medium text-terracotta-dark transition hover:text-terracotta"
-                >
-                  Add a key →
-                </Link>
-              </div>
-            )}
+            <Link
+              href="/dashboard/new"
+              onClick={() => setOpen(false)}
+              className="flex items-center gap-2 border-t border-ink/10 px-4 py-2.5 text-sm font-medium text-terracotta-dark transition hover:bg-ink/5"
+            >
+              <Plus className="h-4 w-4" aria-hidden />
+              New organization
+            </Link>
           </div>
         </>
       )}

--- a/components/dashboard/run-ready-banner.tsx
+++ b/components/dashboard/run-ready-banner.tsx
@@ -82,7 +82,7 @@ export function RunReadyBanner({
           </span>
           <div>
             <p className="text-sm font-medium text-ink">
-              {failed ? "Your latest run failed" : "Your run finished — results are ready"}
+              {failed ? "Your latest run failed" : "Your run finished, results are ready"}
             </p>
             <p className="mt-0.5 text-xs text-ink-faint">
               {failed

--- a/lib/llm/index.ts
+++ b/lib/llm/index.ts
@@ -1120,7 +1120,7 @@ Return a JSON object of this shape:
   ]
 }
 Provide 3 or 4 topics, each with 4 to 6 natural questions. Never put the company's own name in the questions.
-Provide up to 5 competitors. "aliases" are other names an AI answer might use for it (short name, product name, former name) — empty array if none. "domain" is its primary website domain, lowercase, no protocol or path — null if unsure. Return an empty array if you cannot name real competitors with confidence.`;
+Provide up to 5 competitors. "aliases" are other names an AI answer might use for it (short name, product name, former name). Empty array if none. "domain" is its primary website domain, lowercase, no protocol or path. Null if unsure. Return an empty array if you cannot name real competitors with confidence.`;
 
   const res =
     opts.provider === "anthropic"
@@ -1290,7 +1290,7 @@ export function humanError(err: unknown): string {
           : "";
       return (
         `Google rejected the request: this key's quota is used up.${wait} ` +
-        `Free-tier and trial keys allow only a few requests per minute — check the key's quota in Google AI Studio, or wait and run again.`
+        `Free-tier and trial keys allow only a few requests per minute. Check the key's quota in Google AI Studio, or wait and run again.`
       );
     }
     if (err.status >= 500) return "The AI provider had a temporary error. Please try again.";
@@ -1314,7 +1314,7 @@ export function humanError(err: unknown): string {
           : "";
       return (
         `Perplexity rejected the request: this key is over its rate limit.${wait} ` +
-        `New keys start on a low usage tier — check your tier and credit balance in the Perplexity API settings, or wait and run again.`
+        `New keys start on a low usage tier. Check your tier and credit balance in the Perplexity API settings, or wait and run again.`
       );
     }
     if (err.status >= 500) return "The AI provider had a temporary error. Please try again.";

--- a/lib/trial.ts
+++ b/lib/trial.ts
@@ -248,7 +248,7 @@ export function engineKeyMessage(key: ResolvedKey): string {
     const have = (key.available ?? []).map((p) => PROVIDERS[p].label);
     const alternatives =
       have.length === 1 ? have[0] : `${have.slice(0, -1).join(", ")} or ${have[have.length - 1]}`;
-    return `Your answer engine is set to ${engine}, but no ${providerLabel} key is saved. Add one in Settings, or switch your answer engine to ${alternatives} — you already have a key for that.`;
+    return `Your answer engine is set to ${engine}, but no ${providerLabel} key is saved. Add one in Settings, or switch your answer engine to ${alternatives}, which you already have a key for.`;
   }
   return `Your answer engine is set to ${engine}. Add ${article(providerLabel)} ${providerLabel} key in Settings to run.`;
 }
@@ -273,7 +273,7 @@ export function nextRunMessage(key: ResolvedKey): string {
   const providerLabel = PROVIDERS[key.requested.provider].label;
 
   if (key.source === "trial" && key.model !== key.requested.model) {
-    return `Your next run asks your active prompts to ${willRun}. Free runs use a cheaper model on our keys — add your own ${providerLabel} key to run ${chosen}.`;
+    return `Your next run asks your active prompts to ${willRun}. Free runs use a cheaper model on our keys. Add your own ${providerLabel} key to run ${chosen}.`;
   }
   return `Your next run asks your active prompts to ${willRun} and records where your brand shows up.`;
 }


### PR DESCRIPTION
Five housekeeping items from Casey.

## 1. Org creation no longer needs a key

The gate lived in **four** places (onboarding route 403, `/dashboard/new` redirect, `canAddOrg` in the layout, and the org switcher's blocked state). It refused a second org without the user's own key, reasoning that its first monitor would spend a free run.

That reasoning doesn't hold: the free-run allowance is counted **per account** by `consume_trial_run`, not per org, so extra orgs could never spend more of it. All the gate did was stop someone setting up the brands they wanted to monitor before deciding to bring a key. Removed in all four; the account-wide allowance is still the real limit.

## 2. Column headers on the competitor rows

Now **Name / Other names / Domain**. Changed from a row of flex inputs to a grid so the labels line up with the columns they name; the two columns hidden on narrow screens drop out of the grid flow with them.

## 3. Share of voice is readable

Three separate problems:

| Problem | Fix |
|---|---|
| Fixed 110px label gutter truncated real names ("AWS Elastic Beanstalk") | sized to the longest name present, capped at 200px |
| Percentages only in a tooltip, unreachable on touch | printed at the end of each bar |
| Axis pinned to 0-100 while nobody exceeds ~26%, so bars used a third of the width | scales to the data, rounded up to a quarter |

The last one was the real comparison killer, and only became obvious once the chart was rendered with realistic data.

## 4. Screens fit, no horizontal scrolling

**Every dashboard page overflowed by 267px at phone width.** Cause: six labelled nav items in one un-wrapping flex row (`flex flex-row` with no wrap below `md`). The nav now wraps; `md:flex-nowrap` keeps the desktop sidebar a single column.

Measured across **11 pages × 4 widths** (320 / 390 / 768 / 1280):

- before: every dashboard page overflowed at 390 and 320
- after: **zero horizontal overflow anywhere**

## 5. Em dashes removed from user-facing copy

23 occurrences across privacy, terms, onboarding, dashboard copy, form hints, the api-key notice, the run-finished banner, the run-key messages and the provider error hints.

**Code comments still contain them** (~156). Excluded deliberately: they're invisible to users and sweeping them would bury this diff. Say the word and I'll do that as a separate mechanical PR.

## Testing

384 tests pass, typecheck / lint / build clean.

Verified rendered: competitor headers aligned, mobile nav wrapping across three rows with labels intact, share of voice with the exact long names from the report, org switcher offering "New organization" with no key.

The share-of-voice check needed a project with competitor mentions. The only one that has them belongs to a teammate, so rather than sign into their account I built a throwaway project on Casey's own, screenshotted, and deleted it — cleanup verified (0 rows left, `active_project_id` restored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
