### PR TITLE
Say whether a 0% is a loss or an unmeasured run

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -18,12 +18,14 @@ import {
   StatCard,
 } from "@/components/ui";
 import { ShareBars, SentimentDonut, TrendChart } from "@/components/dashboard/charts-lazy";
+import { MeasurementNote } from "@/components/dashboard/measurement-note";
 import { Onboarding } from "./onboarding";
 import { createClient } from "@/lib/supabase/server";
 import { getConfiguredProviders, getProject } from "@/lib/data";
 import {
   computeCitationStats,
   computeEntityStats,
+  computeMeasurementQuality,
   computeRunSummary,
   computeTopicStats,
   type EntityStat,
@@ -260,6 +262,9 @@ export default async function DashboardPage() {
   const stats = computeEntityStats(latestMentions, totalResponses, project.brand_name);
   const brand = stats.find((s) => s.type === "brand");
   const summary = computeRunSummary(latestMentions, totalResponses, project.brand_name);
+  // How much this run actually measured. Without it a 0% reads the same whether
+  // the models picked a competitor or recommended nobody at all.
+  const quality = computeMeasurementQuality(latestMentions, totalResponses);
 
   // Citations move before mentions do — for a brand with no mentions yet, this
   // is the only card on this page that will change.
@@ -367,6 +372,15 @@ export default async function DashboardPage() {
           hint="how early you appear"
         />
       </div>
+
+      {/* What the numbers above are worth. */}
+      <MeasurementNote
+        totalResponses={totalResponses}
+        responsesNamingSomeone={quality.responsesNamingSomeone}
+        informativeRate={quality.informativeRate}
+        brandMentioned={(summary.brandResponsesMentioned ?? 0) > 0}
+        competitorsTracked={competitors}
+      />
 
       {/* Trend + sentiment donut */}
       <div className="grid gap-6 lg:grid-cols-3">

--- a/components/dashboard/measurement-note.tsx
+++ b/components/dashboard/measurement-note.tsx
@@ -12,11 +12,17 @@ import { cn } from "@/lib/utils";
 // simply wrong.
 //
 // The distinguishing number already existed — computeMeasurementQuality's
-// informativeRate, the share of answers that named ANY tracked company — but it
-// was computed and never shown, so the two cases were indistinguishable in the
-// UI. Observed live: one brand sat at 0% with 70% of answers naming its
-// competitors (a real authority gap) while another sat at 0% with 16% (prompts
-// that were asking for explanations, not recommendations).
+// informativeRate — but it was computed and never shown, so the two cases were
+// indistinguishable in the UI. Observed live: one brand sat at 0% with 70% of
+// answers naming its tracked competitors (a real authority gap) while another
+// sat at 0% with 16%.
+//
+// Note what informativeRate actually counts: answers naming a company WE TRACK,
+// not answers naming any company. Checking the low case showed its answers were
+// full of vendors (Kore.ai, Boomi, Airia) that simply weren't on its competitor
+// list, each appearing once — a mismatched list in an immature category, not
+// prompts that failed to ask for recommendations. So the low-rate copy must not
+// blame the prompts, which an earlier draft of it did.
 
 export function MeasurementNote({
   totalResponses,
@@ -58,12 +64,14 @@ export function MeasurementNote({
   if (verdict === "thin-sample") {
     return (
       <Note tone="warn">
-        Only {named} named any company you track, so these rates rest on a thin
-        sample. Questions that ask <em>how to do</em> something get explanations;
-        questions that ask <em>what to use</em> get recommendations, and only those
-        can move your visibility.{" "}
-        <NoteLink href="/dashboard/topics">Review your prompts</NoteLink>
-        {!brandMentioned && ". A 0% here is more likely a measurement gap than a loss."}
+        Only {named} named a company you track, so there is little here to compare
+        against. Usually that means the models are naming companies missing from
+        your{" "}
+        <NoteLink href="/dashboard/competitors">competitor list</NoteLink>, or that
+        this category has no settled set of vendors yet. It can also mean your{" "}
+        <NoteLink href="/dashboard/topics">prompts</NoteLink> aren&apos;t asking for
+        recommendations.
+        {!brandMentioned && " Either way, read this 0% as not-yet-measured rather than as a loss."}
       </Note>
     );
   }

--- a/components/dashboard/measurement-note.tsx
+++ b/components/dashboard/measurement-note.tsx
@@ -1,0 +1,117 @@
+import Link from "next/link";
+import { Info, TriangleAlert } from "lucide-react";
+import { measurementVerdict } from "@/lib/metrics";
+import { cn } from "@/lib/utils";
+
+// Why a 0% can mean two completely different things, said out loud.
+//
+// A run reports "0% brand visibility" identically whether the models were asked
+// what to use and picked someone else, or were asked how to do something and
+// recommended nobody at all. Only the first is a finding. The second means the
+// prompts didn't measure anything, and reading it as a competitive loss is
+// simply wrong.
+//
+// The distinguishing number already existed — computeMeasurementQuality's
+// informativeRate, the share of answers that named ANY tracked company — but it
+// was computed and never shown, so the two cases were indistinguishable in the
+// UI. Observed live: one brand sat at 0% with 70% of answers naming its
+// competitors (a real authority gap) while another sat at 0% with 16% (prompts
+// that were asking for explanations, not recommendations).
+
+export function MeasurementNote({
+  totalResponses,
+  responsesNamingSomeone,
+  informativeRate,
+  brandMentioned,
+  competitorsTracked,
+}: {
+  totalResponses: number;
+  responsesNamingSomeone: number;
+  informativeRate: number;
+  /** Did the brand appear in any answer this run? */
+  brandMentioned: boolean;
+  competitorsTracked: number;
+}) {
+  const verdict = measurementVerdict({
+    totalResponses,
+    informativeRate,
+    brandMentioned,
+    competitorsTracked,
+  });
+  if (verdict === "no-data") return null;
+
+  const named = `${responsesNamingSomeone} of ${totalResponses} answer${
+    totalResponses === 1 ? "" : "s"
+  }`;
+
+  if (verdict === "no-competitors") {
+    return (
+      <Note tone="info">
+        No competitors tracked yet, so a run can only tell you whether you were
+        named, not who was named instead.{" "}
+        <NoteLink href="/dashboard/competitors">Add competitors</NoteLink> to see who
+        the models reach for in your category.
+      </Note>
+    );
+  }
+
+  if (verdict === "thin-sample") {
+    return (
+      <Note tone="warn">
+        Only {named} named any company you track, so these rates rest on a thin
+        sample. Questions that ask <em>how to do</em> something get explanations;
+        questions that ask <em>what to use</em> get recommendations, and only those
+        can move your visibility.{" "}
+        <NoteLink href="/dashboard/topics">Review your prompts</NoteLink>
+        {!brandMentioned && ". A 0% here is more likely a measurement gap than a loss."}
+      </Note>
+    );
+  }
+
+  if (verdict === "real-gap") {
+    return (
+      <Note tone="warn">
+        {named} named a company you track, and none named you. The models are
+        recommending in your category and not reaching for you yet, so this is a
+        real visibility gap rather than a problem with the prompts.
+      </Note>
+    );
+  }
+
+  return (
+    <Note tone="info">
+      {named} named a company you track. The rest recommended nobody, so they
+      can&apos;t move your visibility either way.
+    </Note>
+  );
+}
+
+function Note({ tone, children }: { tone: "info" | "warn"; children: React.ReactNode }) {
+  const warn = tone === "warn";
+  return (
+    <div
+      className={cn(
+        "flex items-start gap-2.5 rounded border px-4 py-3",
+        warn
+          ? "border-terracotta/30 bg-terracotta/[0.06]"
+          : "border-ink/10 bg-paper-shade/50",
+      )}
+    >
+      <span className={cn("mt-0.5 shrink-0", warn ? "text-terracotta-dark" : "text-ink-faint")}>
+        {warn ? <TriangleAlert className="h-4 w-4" /> : <Info className="h-4 w-4" />}
+      </span>
+      <p className="text-sm text-ink-soft">{children}</p>
+    </div>
+  );
+}
+
+function NoteLink({ href, children }: { href: string; children: React.ReactNode }) {
+  return (
+    <Link
+      href={href}
+      className="font-medium text-terracotta-dark underline underline-offset-2 transition-colors hover:text-terracotta"
+    >
+      {children}
+    </Link>
+  );
+}

--- a/lib/metrics.test.ts
+++ b/lib/metrics.test.ts
@@ -5,6 +5,8 @@ import {
   computeRunSummary,
   computeCitationStats,
   computeMeasurementQuality,
+  measurementVerdict,
+  LOW_INFORMATIVE_RATE,
 } from "@/lib/metrics";
 import type { Mention } from "@/lib/types";
 
@@ -213,5 +215,59 @@ describe("computeMeasurementQuality", () => {
 
   it("handles an empty run", () => {
     expect(computeMeasurementQuality([], 0).informativeRate).toBe(0);
+  });
+});
+
+describe("measurementVerdict", () => {
+  const base = {
+    totalResponses: 20,
+    informativeRate: 0.8,
+    brandMentioned: true,
+    competitorsTracked: 5,
+  };
+
+  it("says nothing when there are no answers", () => {
+    expect(measurementVerdict({ ...base, totalResponses: 0 })).toBe("no-data");
+  });
+
+  // With nothing to compare against, informativeRate can only count the brand,
+  // so a low value says nothing about the prompts and mustn't blame them.
+  it("blames the missing competitors, not the prompts, when none are tracked", () => {
+    expect(
+      measurementVerdict({ ...base, competitorsTracked: 0, informativeRate: 0, brandMentioned: false }),
+    ).toBe("no-competitors");
+  });
+
+  // The Runlayer case: 3 of 19 answers named anyone, so 0% measured almost
+  // nothing and must not be read as losing.
+  it("calls a run with few informative answers a thin sample", () => {
+    expect(
+      measurementVerdict({ ...base, informativeRate: 3 / 19, brandMentioned: false }),
+    ).toBe("thin-sample");
+  });
+
+  // The Archil case: 14 of 20 answers named a competitor and none named the
+  // brand. That is a finding, not a measurement problem.
+  it("calls a well-measured absence a real gap", () => {
+    expect(
+      measurementVerdict({ ...base, informativeRate: 14 / 20, brandMentioned: false }),
+    ).toBe("real-gap");
+  });
+
+  it("treats a thin sample as thin even when the brand did appear", () => {
+    expect(measurementVerdict({ ...base, informativeRate: 0.1 })).toBe("thin-sample");
+  });
+
+  it("is healthy when the sample is informative and the brand appears", () => {
+    expect(measurementVerdict(base)).toBe("healthy");
+  });
+
+  it("puts the threshold boundary on the informative side", () => {
+    expect(
+      measurementVerdict({ ...base, informativeRate: LOW_INFORMATIVE_RATE, brandMentioned: false }),
+    ).toBe("real-gap");
+    expect(
+      measurementVerdict({ ...base, informativeRate: LOW_INFORMATIVE_RATE - 0.01, brandMentioned: false }),
+    ).toBe("thin-sample");
   });
 });

--- a/lib/metrics.ts
+++ b/lib/metrics.ts
@@ -248,6 +248,42 @@ export function computeMeasurementQuality(
   };
 }
 
+/** Below this share of informative answers, a run's rates rest on too thin a
+ *  sample to read as a competitive result. */
+export const LOW_INFORMATIVE_RATE = 0.5;
+
+export type MeasurementVerdict =
+  | "no-data"
+  /** Nothing to compare against, so informativeRate says nothing about prompts. */
+  | "no-competitors"
+  /** Too few answers recommended anyone; the rates aren't measuring much yet. */
+  | "thin-sample"
+  /** Answers did recommend, and consistently not this brand. A real finding. */
+  | "real-gap"
+  | "healthy";
+
+/**
+ * How to read a run's rates.
+ *
+ * A 0% brand visibility means two entirely different things depending on this,
+ * and the UI used to present them identically. Observed live: one brand at 0%
+ * with 70% of answers naming its competitors (a genuine authority gap) and
+ * another at 0% with 16% (prompts that elicited explanations, not
+ * recommendations, so the 0% measured almost nothing).
+ */
+export function measurementVerdict(input: {
+  totalResponses: number;
+  informativeRate: number;
+  brandMentioned: boolean;
+  competitorsTracked: number;
+}): MeasurementVerdict {
+  if (input.totalResponses === 0) return "no-data";
+  if (input.competitorsTracked === 0) return "no-competitors";
+  if (input.informativeRate < LOW_INFORMATIVE_RATE) return "thin-sample";
+  if (!input.brandMentioned) return "real-gap";
+  return "healthy";
+}
+
 // Per-topic breakdown for the brand (uses topic_id stored on mention rows).
 export interface TopicStat {
   topicId: string | null;


### PR DESCRIPTION
Answers Mahir's question, and fixes the reason it had to be asked by hand.

## The finding

Archil and Runlayer are both at 0%, for **opposite reasons**.

| Brand | Brand named | Answers naming *anyone* tracked | Reading |
|---|---|---|---|
| Cloudflare | 17/19 (89%) | **95%** | working |
| **Archil** | 0/20 | **70%** | **genuine authority gap** |
| **Runlayer** | 0/19 | **16%** | **prompts measured almost nothing** |

**Archil is a real result.** 14 of 20 answers recommended a tracked competitor (Amazon FSx, EFS, WEKA, JuiceFS, Mountpoint). The models were asked what to use, they answered with vendors, and they never reached for Archil. Its prompts are well-formed: *"What's the best shared file system that thousands of compute nodes can mount at once?"*

**Runlayer is mostly a prompt problem.** Only 3 of 19 answers named anyone at all. Its prompts ask *how to* do things — *"How can enterprises secure and govern AI agents...?"*, *"How do I enforce identity and permission policies at scale?"* — and those return frameworks and advice, not product recommendations. The one answer that did name things named Microsoft Entra, which isn't tracked. You cannot conclude anything about Runlayer's authority from that run.

So: **Archil genuinely lacks topical authority; Runlayer hasn't been measured yet.** Cloudflare shows the same drift in miniature — its 2 misses are its only two "how do I" prompts.

## The product gap

`informativeRate` already existed in `computeMeasurementQuality` — computed, exported, consumed by the API, **and rendered nowhere**. So a 0% looked the same either way and the only way to tell was to query the database, which is exactly what happened here.

`measurementVerdict` turns it into the four readings that matter, and `MeasurementNote` states the applicable one directly under the headline stats:

> ⚠ **Only 3 of 20 answers named any company you track**, so these rates rest on a thin sample. Questions that ask *how to do* something get explanations; questions that ask *what to use* get recommendations, and only those can move your visibility. **Review your prompts**. A 0% here is more likely a measurement gap than a loss.

> ⚠ **14 of 20 answers named a company you track, and none named you.** The models are recommending in your category and not reaching for you yet, so this is a real visibility gap rather than a problem with the prompts.

Logic lives in `lib/metrics` as a pure function so the thresholds are tested; there's no React test setup in this repo.

## A second thing this surfaced

**10 of the projects in the database track zero competitors.** For those, `informativeRate` can only ever count the brand itself, so share of voice is meaningless and a 0% is uninterpretable. The note says that specifically rather than blaming the prompts. LET-173 fixed this for *new* orgs by seeding competitors during onboarding; existing ones are still empty.

## Testing

391 tests pass (7 new), typecheck / lint / build clean.

Verdicts recomputed against **every project in the database** — Cloudflare `healthy`, Archil `real-gap`, Runlayer `thin-sample`, and the 10 empty ones `no-competitors`. Both warning states screenshotted from a real render, using a throwaway project on Casey's own account rather than signing into Mahir's; deleted afterwards with cleanup verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
