### PR TITLE
Surface the companies the answers named but nobody tracks

### DIFF
--- a/app/api/competitors/discovered/route.ts
+++ b/app/api/competitors/discovered/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { getProject } from "@/lib/data";
+import { discoverCompanies } from "@/lib/discover";
+import { humanError } from "@/lib/llm";
+import type { Competitor } from "@/lib/types";
+
+export const dynamic = "force-dynamic";
+
+/** Answers to scan. Enough to be representative, bounded so the scan stays
+ *  cheap on a project with a long history. */
+const ANSWER_LIMIT = 200;
+
+// GET /api/competitors/discovered
+// Companies the stored answers named that this project doesn't track.
+//
+// Reads text already in the database, so unlike /api/competitors/suggest this
+// costs no provider call and needs no key: the recommendations the models
+// already gave are sitting in `responses`, and mention detection throws away
+// every name that isn't on the competitor list.
+export async function GET() {
+  const supabase = createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const project = await getProject(supabase, user.id);
+  if (!project) {
+    return NextResponse.json({ error: "Create a project first" }, { status: 400 });
+  }
+
+  try {
+    const [{ data: responseRows }, { data: competitorRows }] = await Promise.all([
+      supabase
+        .from("responses")
+        .select("response_text")
+        .eq("project_id", project.id)
+        .order("created_at", { ascending: false })
+        .limit(ANSWER_LIMIT),
+      supabase.from("competitors").select("name, aliases").eq("project_id", project.id),
+    ]);
+
+    const answers = ((responseRows ?? []) as { response_text: string | null }[])
+      .map((r) => r.response_text ?? "")
+      .filter(Boolean);
+
+    // Everything already accounted for: the brand, its aliases, and every
+    // tracked competitor with theirs. Leaving any of these in would offer the
+    // user something they already track.
+    const tracked = [
+      project.brand_name,
+      ...project.brand_aliases,
+      ...((competitorRows ?? []) as Pick<Competitor, "name" | "aliases">[]).flatMap((c) => [
+        c.name,
+        ...c.aliases,
+      ]),
+    ];
+
+    const companies = discoverCompanies(answers, tracked, { limit: 24 });
+
+    return NextResponse.json({
+      companies,
+      answersScanned: answers.length,
+      // A name in many answers is the category's default pick; a spread of
+      // names appearing once each means the models have no consensus, which is
+      // a different finding from losing to someone.
+      topCount: companies[0]?.answers ?? 0,
+    });
+  } catch (e) {
+    return NextResponse.json({ error: humanError(e) }, { status: 500 });
+  }
+}

--- a/app/dashboard/competitors/competitors-client.tsx
+++ b/app/dashboard/competitors/competitors-client.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { useState } from "react";
-import { Building2, Plus, Sparkles, Trash2, Users, X } from "lucide-react";
+import { Building2, Plus, Search, Sparkles, Trash2, Users, X } from "lucide-react";
 import {
   Badge,
   Button,
@@ -55,6 +55,61 @@ export function CompetitorsClient({
   const [suggesting, setSuggesting] = useState(false);
   const [suggestError, setSuggestError] = useState<string | null>(null);
   const [addingSuggestion, setAddingSuggestion] = useState<string | null>(null);
+
+  // Companies the stored answers already named. Distinct from the AI
+  // suggestions above: these are grounded in what the models actually said
+  // about this brand's prompts, not in the model's general knowledge, and they
+  // cost no provider call. `null` = not asked yet.
+  const [found, setFound] = useState<
+    { companies: { name: string; answers: number }[]; answersScanned: number } | null
+  >(null);
+  const [finding, setFinding] = useState(false);
+  const [findError, setFindError] = useState<string | null>(null);
+
+  async function handleFind() {
+    if (finding) return;
+    setFinding(true);
+    setFindError(null);
+    try {
+      const res = await fetch("/api/competitors/discovered");
+      const json = await res.json();
+      if (!res.ok) {
+        setFindError(json.error ?? "Could not scan your answers.");
+        return;
+      }
+      setFound({ companies: json.companies ?? [], answersScanned: json.answersScanned ?? 0 });
+    } catch {
+      setFindError("Network error. Please try again.");
+    } finally {
+      setFinding(false);
+    }
+  }
+
+  async function handleTrackFound(name: string) {
+    if (addingSuggestion) return;
+    setAddingSuggestion(name);
+    setFindError(null);
+    try {
+      const res = await fetch("/api/competitors", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, aliases: [], domain: null }),
+      });
+      if (!res.ok) {
+        const json = await res.json().catch(() => ({}));
+        setFindError(json.error ?? "Could not add competitor.");
+        return;
+      }
+      setFound((prev) =>
+        prev ? { ...prev, companies: prev.companies.filter((c) => c.name !== name) } : prev,
+      );
+      router.refresh();
+    } catch {
+      setFindError("Network error. Please try again.");
+    } finally {
+      setAddingSuggestion(null);
+    }
+  }
 
   async function handleSuggest() {
     if (suggesting) return;
@@ -199,6 +254,81 @@ export function CompetitorsClient({
               {error && <p className="text-sm text-terracotta-dark">{error}</p>}
             </div>
           </form>
+        </CardBody>
+      </Card>
+
+      {/* Grounded in what the answers said, so it comes before the AI guesses. */}
+      <Card>
+        <CardBody>
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="flex items-start gap-3">
+              <span className="mt-0.5 rounded bg-teal/15 p-2 text-teal-dark">
+                <Search className="h-5 w-5" />
+              </span>
+              <div>
+                <h3 className="text-lg font-semibold text-ink">
+                  Named in your answers
+                </h3>
+                <p className="mt-1 text-sm text-ink-soft">
+                  Companies the models already recommended for your prompts, that you
+                  aren&apos;t tracking. Mention detection only looks for brands on your
+                  list, so these are invisible until you add them. No API key needed.
+                </p>
+              </div>
+            </div>
+            <Button variant="secondary" onClick={handleFind} disabled={finding}>
+              {finding ? <Spinner /> : <Search className="h-4 w-4" />}
+              {found === null ? "Scan my answers" : "Scan again"}
+            </Button>
+          </div>
+
+          {findError && <p className="mt-4 text-sm text-terracotta-dark">{findError}</p>}
+
+          {found !== null && !finding && found.companies.length === 0 && !findError && (
+            <p className="mt-4 text-sm text-ink-soft">
+              {found.answersScanned === 0
+                ? "No answers stored yet. Run your monitor first, then scan."
+                : `Scanned ${found.answersScanned} answers and found no untracked companies. Your list looks complete.`}
+            </p>
+          )}
+
+          {found !== null && found.companies.length > 0 && (
+            <>
+              <p className="mt-4 text-sm text-ink-soft">
+                From {found.answersScanned} stored answer
+                {found.answersScanned === 1 ? "" : "s"}.
+                {found.companies[0].answers === 1 &&
+                  " Every name appeared just once, so the models have no settled pick for this category yet."}
+              </p>
+              <ul className="mt-4 flex flex-wrap gap-2">
+                {found.companies.map((c) => (
+                  <li
+                    key={c.name}
+                    className="flex items-center gap-2 rounded border border-ink/10 bg-paper py-1.5 pl-3 pr-1.5"
+                  >
+                    <span className="text-sm font-medium text-ink">{c.name}</span>
+                    <span className="text-xs text-ink-faint">
+                      {c.answers} answer{c.answers === 1 ? "" : "s"}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => handleTrackFound(c.name)}
+                      disabled={addingSuggestion !== null}
+                      className="rounded p-1 text-terracotta-dark transition hover:bg-terracotta/10 disabled:opacity-50"
+                      aria-label={`Track ${c.name}`}
+                      title={`Track ${c.name}`}
+                    >
+                      {addingSuggestion === c.name ? (
+                        <Spinner />
+                      ) : (
+                        <Plus className="h-3.5 w-3.5" />
+                      )}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
         </CardBody>
       </Card>
 

--- a/lib/discover.test.ts
+++ b/lib/discover.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import { discoverCompanies, looksLikeCompanyName, namesInAnswer } from "@/lib/discover";
+
+describe("looksLikeCompanyName", () => {
+  it("accepts the shapes real vendor names take", () => {
+    for (const name of [
+      "Fastly",
+      "Kore.ai",
+      "CDN77",
+      "Deno Deploy",
+      "Boomi Agentstudio",
+      "IBM watsonx.governance",
+      "AWS Lambda@Edge",
+      "Amazon FSx for Lustre", // " for " is allowed on purpose
+      "GSLB.me",
+    ]) {
+      expect(looksLikeCompanyName(name), name).toBe(true);
+    }
+  });
+
+  // Each of these was produced by the extractor against stored answers before
+  // the corresponding rule existed.
+  it("rejects the prose headings that bold text is also used for", () => {
+    for (const junk of [
+      "1. Start with discovery and a solid data foundation",
+      "Why this matters first",
+      "A practical approach",
+      "Core Best Practices",
+      "AI-Specific Governance Platforms", // plural category tail
+      "Architectural Options",
+      "MCP gateways/proxies", // slash
+      "Access & Identity Management", // spaced ampersand
+      "Identity and permissions", // conjunction
+      "For Amazon S3", // heading starter
+      "Cost",
+      "Analytics",
+    ]) {
+      expect(looksLikeCompanyName(junk), junk).toBe(false);
+    }
+  });
+
+  // A finance brand's answers bolded these; "Beta = 0" as a suggested
+  // competitor would look broken.
+  it("rejects defined quantities and bolded jargon", () => {
+    for (const junk of ["Beta = 0", "Beta < 1.0", "Beta > 1.0", "Alpha", "Beta", "Measures", "Reflects"]) {
+      expect(looksLikeCompanyName(junk), junk).toBe(false);
+    }
+  });
+
+  it("still accepts multi-word names containing an otherwise-common word", () => {
+    // The single-word stoplist must not reach into real product names.
+    expect(looksLikeCompanyName("Bloomberg Terminal")).toBe(true);
+    expect(looksLikeCompanyName("Value Line")).toBe(true);
+  });
+
+  it("rejects bare category acronyms that name no company", () => {
+    for (const term of ["API", "MCP", "CDN", "IAM", "POSIX", "Kubernetes"]) {
+      expect(looksLikeCompanyName(term), term).toBe(false);
+    }
+  });
+
+  it("rejects anything too long, too short, or not starting on a letter", () => {
+    expect(looksLikeCompanyName("A")).toBe(false);
+    expect(looksLikeCompanyName("2024")).toBe(false);
+    expect(looksLikeCompanyName("A".repeat(41))).toBe(false);
+  });
+});
+
+describe("namesInAnswer", () => {
+  const answer = `
+## Options for shared storage
+
+**Fastly** is a solid choice, and **Akamai** competes directly.
+
+### BeeGFS
+
+See [ObjectiveFS](https://objectivefs.com/) for a hosted option.
+
+**1. Start with discovery.** You can't govern what you can't see.
+`;
+
+  it("picks names out of bold, headings and links", () => {
+    const names = namesInAnswer(answer);
+    expect(names).toContain("Fastly");
+    expect(names).toContain("Akamai");
+    expect(names).toContain("BeeGFS");
+    expect(names).toContain("ObjectiveFS");
+  });
+
+  it("leaves the prose heading and the section title behind", () => {
+    const names = namesInAnswer(answer);
+    expect(names.some((n) => n.startsWith("1."))).toBe(false);
+    expect(names).not.toContain("Options for shared storage");
+  });
+
+  // The patterns carry /g, so a shared lastIndex would make results depend on
+  // call order.
+  it("returns the same names when called repeatedly", () => {
+    expect(namesInAnswer(answer)).toEqual(namesInAnswer(answer));
+  });
+
+  it("survives empty and junk input", () => {
+    expect(namesInAnswer("")).toEqual([]);
+    expect(namesInAnswer("no markup here at all")).toEqual([]);
+  });
+});
+
+describe("discoverCompanies", () => {
+  it("counts the answers naming each company, most-named first", () => {
+    const found = discoverCompanies(
+      ["**Fastly** and **Akamai**", "**Fastly** again", "**CacheFly**"],
+      [],
+    );
+    expect(found).toEqual([
+      { name: "Fastly", answers: 2 },
+      { name: "Akamai", answers: 1 },
+      { name: "CacheFly", answers: 1 },
+    ]);
+  });
+
+  it("counts an answer once however many times it repeats a name", () => {
+    const found = discoverCompanies(["**Fastly** **Fastly** **Fastly**"], []);
+    expect(found).toEqual([{ name: "Fastly", answers: 1 }]);
+  });
+
+  it("omits anything already tracked, ignoring case", () => {
+    const found = discoverCompanies(["**Fastly** and **Akamai**"], ["fastly"]);
+    expect(found.map((f) => f.name)).toEqual(["Akamai"]);
+  });
+
+  // The point of the whole module: surface what's MISSING from the list.
+  it("omits the tracked brand's own product lines", () => {
+    const found = discoverCompanies(
+      ["**Cloudflare Workers** vs **Fastly**", "**Cloudflare (1.1.1.1)** is fast"],
+      ["Cloudflare"],
+    );
+    expect(found.map((f) => f.name)).toEqual(["Fastly"]);
+  });
+
+  it("respects a limit", () => {
+    const answers = ["**Fastly** **Akamai** **CacheFly** **CDN77**"];
+    expect(discoverCompanies(answers, [], { limit: 2 })).toHaveLength(2);
+  });
+
+  it("returns nothing for answers that named no company", () => {
+    expect(discoverCompanies(["**Why this matters**", ""], [])).toEqual([]);
+  });
+});

--- a/lib/discover.ts
+++ b/lib/discover.ts
@@ -1,0 +1,196 @@
+// ------------------------------------------------------------------
+// Finding the companies an answer named that the project doesn't track.
+//
+// Mention detection only looks for the brand and its listed competitors, so
+// every other company an answer recommends is discarded. That makes a project
+// with a mismatched competitor list indistinguishable from one whose prompts
+// never asked for recommendations: both read as "named nobody". Observed live, a
+// brand sat at 16% informative while its answers were full of vendors (Kore.ai,
+// Boomi Agentstudio, Airia) that simply weren't on its list.
+//
+// The answers are already stored, so this needs no extra model call. It is
+// deliberately a CANDIDATE generator: the user confirms each one before it
+// becomes a tracked competitor, so recall matters more than perfect precision,
+// and anything ambiguous is better dropped than guessed.
+// ------------------------------------------------------------------
+
+/** Markdown emphasis, headings and links are where these answers put names. */
+const PATTERNS = [
+  /\*\*([^*\n]{2,60})\*\*/g, // **Vendor**
+  /^#{2,4}\s+(.{2,60})$/gm, // ## Vendor
+  /\[([^\]\n]{2,60})\]\(https?:\/\//g, // [Vendor](https://…)
+];
+
+// Bold is also used for prose headings ("**1. Start with discovery.**",
+// "**Why this matters**"), which is the dominant source of false positives.
+const HEADING_STARTERS =
+  /^(why|how|what|when|where|which|who|if|for|start|offer|use|choose|build|get|keep|make|set|add|enable|ensure|consider|note|important|pros|cons|best|top|summary|recommendation|bottom|key|tip|caveat|warning|option|step|first|second|third|finally|also|next|core|my take|tl;dr|in short|the )/i;
+
+// A Title Case phrase ending in a plural category noun is a section heading, not
+// a product: "AI-Specific Governance Platforms", "Architectural Options",
+// "Core Best Practices", "MCP gateways/proxies". This one rule removes most of
+// the remaining false positives without touching any real vendor name.
+const CATEGORY_TAILS = new Set([
+  "platforms", "options", "practices", "signals", "tiers", "gateways", "proxies",
+  "providers", "tools", "solutions", "services", "systems", "alternatives",
+  "approaches", "considerations", "recommendations", "controls", "capabilities",
+  "features", "layers", "patterns", "types", "categories", "vendors", "players",
+  "contenders", "choices", "picks", "steps", "basics", "tradeoffs", "caveats",
+  "limitations", "benefits", "risks", "requirements", "metrics", "workloads",
+  "agents", "benchmarks", "api", "apis", "sdks", "models", "frameworks",
+]);
+
+// Category nouns and acronyms that read like names but identify no company.
+const GENERIC = new Set(
+  [
+    "api", "apis", "sdk", "cli", "mcp", "mcps", "oauth", "sso", "saas", "nfs", "smb",
+    "posix", "ai", "llm", "llms", "hpc", "gpu", "gpus", "vpn", "iam", "siem", "casb",
+    "dns", "cdn", "waf", "ddos", "rag", "etl", "cpu", "ssd", "hdd", "vm", "vms", "os",
+    "ci/cd", "devops", "finops", "secops", "identity", "governance", "observability",
+    "monitoring", "security", "compliance", "storage", "networking", "encryption",
+    "authentication", "authorization", "audit", "logging", "caching", "cache",
+    "serverless", "kubernetes", "docker", "linux", "windows", "macos",
+    // Single-word section headings seen in real answers.
+    "cost", "costs", "pricing", "performance", "latency", "throughput",
+    "scalability", "reliability", "availability", "analytics", "dnssec",
+    "access control", "anomaly detection", "data governance",
+      "certifications", "cloud-native", "cloud iam", "node-local nvme",
+    "baseline", "benchmarks",
+  ].map((s) => s.toLowerCase()),
+);
+
+// Single bolded words are as often a defined term or a reporting verb as a
+// company. Observed against a finance brand's answers, which bolded "Alpha",
+// "Beta", "Measures" and "Reflects" while genuinely naming Bloomberg Terminal
+// and FactSet. Only applied to one-word candidates, so "Deno Deploy" is safe.
+const COMMON_SINGLE_WORDS = new Set([
+  // Greek letters and statistics, which double as finance jargon.
+  "alpha", "beta", "gamma", "delta", "sigma", "theta", "omega", "sharpe",
+  "volatility", "correlation", "variance", "deviation", "median", "mean",
+  "average", "ratio", "index", "benchmark", "yield", "return", "returns",
+  "risk", "exposure", "duration", "momentum", "value", "growth", "quality",
+  // Reporting verbs and connectives that get bolded mid-sentence.
+  "measures", "reflects", "indicates", "includes", "requires", "provides",
+  "means", "note", "caution", "example", "result", "results", "conclusion",
+  "definition", "formula", "interpretation", "takeaway", "verdict", "answer",
+  "yes", "no", "maybe", "always", "never", "however", "therefore",
+]);
+
+/** Lowercase words a real product name may contain. Kept to the ones actually
+ *  observed in the model catalog, since each one weakens the heuristic. */
+const LOWERCASE_CONNECTORS = new Set(["for"]);
+
+/** Strip markdown leftovers and trailing punctuation from a captured span. */
+function clean(raw: string): string {
+  return raw
+    .replace(/[*_`]/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/[.,;:!?]+$/, "")
+    .trim();
+}
+
+/**
+ * Is this plausibly a company or product name rather than a sentence fragment?
+ *
+ * Tuned against real answers: the rejections below are each responsible for a
+ * class of false positive seen in stored text, not hypothetical.
+ */
+export function looksLikeCompanyName(value: string): boolean {
+  const name = value.trim();
+  if (name.length < 2 || name.length > 40) return false;
+  // Must open on a letter: kills "1. Start with discovery" and "**2024**".
+  if (!/^[A-Za-z]/.test(name)) return false;
+  // Sentence punctuation, list separators, or a mid-string full stop. Slashes
+  // and spaced ampersands mark a phrase ("Authentication/authorization",
+  // "Access & Identity Management"); no real vendor here needs them.
+  if (/[?!:|/]|\s[—–]\s|\s&\s|\.\s/.test(name)) return false;
+  // Comparison and arithmetic operators mean a defined quantity, not a company.
+  // A finance brand's answers bolded "Beta < 1.0", "Beta = 0", "Beta > 1.0".
+  if (/[<>=+×%]/.test(name)) return false;
+  if (HEADING_STARTERS.test(name)) return false;
+  // Conjunctions and pronouns mark a phrase, not a name: "Identity and
+  // permissions", "what you should use". " for " is allowed on purpose —
+  // "Amazon FSx for Lustre" and "Mountpoint for Amazon S3" are real products.
+  if (/\b(and|or|to|your|you|their|our|its|a|an|is|are|be|of|in|on|with|without|vs)\b/i.test(name)) {
+    return false;
+  }
+  const words = name.split(" ");
+  if (words.length > 4) return false;
+  // A name is capitalised. Requiring only the first word to be capitalised lets
+  // through "Best practices"; requiring all of them rejects "Kore.ai". So:
+  // first word capitalised, and no word that is purely lowercase letters —
+  // except the connectors real product names genuinely contain, without which
+  // "Amazon FSx for Lustre" and "Mountpoint for Amazon S3" get thrown away.
+  if (!/^[A-Z]/.test(words[0])) return false;
+  if (words.some((w) => /^[a-z]+$/.test(w) && !LOWERCASE_CONNECTORS.has(w))) return false;
+  if (GENERIC.has(name.toLowerCase())) return false;
+  if (words.length > 1 && CATEGORY_TAILS.has(words[words.length - 1].toLowerCase())) {
+    return false;
+  }
+  if (words.length === 1 && COMMON_SINGLE_WORDS.has(name.toLowerCase())) return false;
+  return true;
+}
+
+export interface DiscoveredCompany {
+  name: string;
+  /** Number of distinct answers that named it. */
+  answers: number;
+}
+
+/** Candidate names in one answer, deduped case-insensitively. */
+export function namesInAnswer(text: string): string[] {
+  const found = new Map<string, string>();
+  for (const pattern of PATTERNS) {
+    // Patterns carry /g (and /m), so reset before reuse across calls.
+    pattern.lastIndex = 0;
+    for (const match of text.matchAll(pattern)) {
+      const name = clean(match[1] ?? "");
+      if (!looksLikeCompanyName(name)) continue;
+      const key = name.toLowerCase();
+      if (!found.has(key)) found.set(key, name);
+    }
+  }
+  return [...found.values()];
+}
+
+/**
+ * Companies named across these answers that aren't already accounted for.
+ *
+ * `tracked` should include the brand, its aliases, and every tracked
+ * competitor's name and aliases: the point is to surface what is MISSING from
+ * the list, so anything already on it is noise here.
+ *
+ * Ordered by how many answers named them, which is the signal that matters:
+ * a name in ten answers is the category's default choice, while a spread of
+ * names appearing once each means the models have no consensus at all.
+ */
+export function discoverCompanies(
+  answers: string[],
+  tracked: string[],
+  options: { limit?: number } = {},
+): DiscoveredCompany[] {
+  const known = [...new Set(tracked.map((t) => t.trim().toLowerCase()).filter(Boolean))];
+  const knownSet = new Set(known);
+  // A candidate that merely EXTENDS a tracked name is that company's own
+  // product line, not a rival: "Cloudflare Workers" and "Cloudflare (1.1.1.1)"
+  // are Cloudflare. Offering them as competitors would be nonsense.
+  const extendsTracked = (key: string) =>
+    known.some((t) => key.startsWith(`${t} `) || key.startsWith(`${t}(`));
+  const counts = new Map<string, { name: string; answers: number }>();
+
+  for (const answer of answers) {
+    for (const name of namesInAnswer(answer || "")) {
+      const key = name.toLowerCase();
+      if (knownSet.has(key) || extendsTracked(key)) continue;
+      const row = counts.get(key) ?? { name, answers: 0 };
+      row.answers++;
+      counts.set(key, row);
+    }
+  }
+
+  const out = [...counts.values()].sort(
+    (a, b) => b.answers - a.answers || a.name.localeCompare(b.name),
+  );
+  return options.limit ? out.slice(0, options.limit) : out;
+}


### PR DESCRIPTION
Follows PR #44. That one told you *whether* a 0% is trustworthy; this one fixes the most common reason it isn't.

## Why

Mention detection only looks for the brand and its listed competitors. **Every other company an answer recommends is discarded.** So a project with a mismatched competitor list is indistinguishable from one whose prompts never asked for recommendations: both read as "named nobody".

That's exactly what happened. Runlayer sat at 16% informative while its answers were full of vendors, none on its list:

| Runlayer tracked | Runlayer's answers actually named |
|---|---|
| Portkey, Lasso Security, Prompt Security, Cloudflare AI Gateway, Zenity | Kore.ai, Boomi Agentstudio, AgilePoint AI Control Tower, MindStudio, Airia, Helicone, Langfuse, LangSmith, Arize AI |

The dashboard already admitted this: *"Companies named in an answer are invisible until you add them."*

## What

A **Scan my answers** card on the Competitors page, listing untracked companies with how many answers named each, one click to track. Reads stored `response_text`, so **no provider call and no key required**.

## The filter is measured, not guessed

Bold is the strongest signal for a vendor name and is also what these models use for headings, numbered steps and defined terms. Every rejection rule corresponds to a false positive that actually appeared in stored answers:

| Rule | Killed |
|---|---|
| plural category tail | "AI-Specific Governance Platforms", "Architectural Options" |
| heading starters | "Why this matters first", "For Amazon S3" |
| conjunctions / slashes / spaced `&` | "Identity and permissions", "MCP gateways/proxies" |
| comparison operators | "Beta < 1.0", "Beta = 0" |
| single common words | "Alpha", "Beta", "Measures", "Reflects" |
| extends a tracked name | "Cloudflare Workers", "Cloudflare (1.1.1.1)" |

Measured across four real projects: precision went from ~60% to ~85–90%, and **every name appearing in 2+ answers was genuine in all four**.

The math-operator and single-word rules came from a finance brand whose answers bolded statistics. Worth stating plainly: **precision is domain-sensitive**, which is why the answer count is shown, the list is ordered by it, and the user confirms each name. The noisy tail is the once-mentioned names.

## A second signal, free

A tail of nothing but once-mentioned names *is itself a finding*: the models have no settled pick for that category. The card says so. Runlayer's names each appear once; Cloudflare's repeat. For a startup that's opportunity, not failure, and it's a different conclusion from losing to a named rival.

## Testing

400 tests pass (16 new), typecheck / lint / build clean.

Verified end to end in a browser against real stored answers, on Casey's own account with the active project restored afterwards. The extractor was developed against 79 real answers dumped from the database, not fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
