### PR TITLE
Let API runs return before the answers do

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,14 @@ curl https://your-app.com/api/v1/projects/<project-id>/runs \
 curl -X POST https://your-app.com/api/v1/projects/<project-id>/runs \
   -H "Authorization: Bearer lt_live_..."
 
+# A run takes minutes; {"background": true} returns 202 with the run id as
+# soon as the run exists, then poll the status endpoint until it settles.
+curl -X POST https://your-app.com/api/v1/projects/<project-id>/runs \
+  -H "Authorization: Bearer lt_live_..." -H "Content-Type: application/json" \
+  -d '{"background": true}'
+curl https://your-app.com/api/v1/runs/<run-id>/status \
+  -H "Authorization: Bearer lt_live_..."
+
 # Share-of-voice report for a run
 curl https://your-app.com/api/v1/runs/<run-id> \
   -H "Authorization: Bearer lt_live_..."

--- a/app/api/v1/projects/[id]/runs/route.ts
+++ b/app/api/v1/projects/[id]/runs/route.ts
@@ -35,8 +35,10 @@ export async function GET(
 }
 
 // POST /api/v1/projects/:id/runs — execute a monitoring run now (BYOK-only).
-// Optional body { provider?, model? } overrides the project default for this
-// run; no body keeps the default.
+// Optional body { provider?, model?, background? } — provider/model override
+// the project default for this run; background: true returns 202 as soon as
+// the run row exists (a run takes minutes; poll GET /v1/runs/:id/status).
+// No body keeps the default, synchronous behavior.
 export async function POST(
   request: Request,
   { params }: { params: { id: string } },
@@ -45,7 +47,7 @@ export async function POST(
   if (auth instanceof Response) return auth;
 
   // An absent (or empty) body is the common case and must keep working.
-  const options: { provider?: Provider; model?: string } = {};
+  const options: { provider?: Provider; model?: string; background?: boolean } = {};
   let raw: unknown = null;
   try {
     raw = await request.json();
@@ -67,6 +69,9 @@ export async function POST(
     }
     if (typeof b.model === "string" && b.model.trim().length > 0) {
       options.model = b.model.trim();
+    }
+    if (b.background === true) {
+      options.background = true;
     }
   }
 
@@ -95,16 +100,19 @@ export async function POST(
       });
       return NextResponse.json({ error: outcome.message }, { status });
     }
+    // A background acceptance is 202 (created and executing, not settled);
+    // the synchronous path stays 200 with the settled result.
+    const statusCode = outcome.result.status === "running" ? 202 : 200;
     await logApiRequest(auth, request, "v1", {
       category: "run",
       action: "api.trigger_run",
-      statusCode: 200,
+      statusCode,
       projectId: params.id,
       targetType: "run",
       targetId: outcome.result.runId,
       summary: `Triggered a run via the API (${outcome.result.status})`,
     });
-    return NextResponse.json(outcome.result);
+    return NextResponse.json(outcome.result, { status: statusCode });
   } catch (e) {
     return NextResponse.json({ error: humanError(e) }, { status: 500 });
   }

--- a/app/api/v1/runs/[id]/status/route.ts
+++ b/app/api/v1/runs/[id]/status/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+import { requireApiAuth } from "@/lib/api-guards";
+import { getRunStatus } from "@/lib/api-service";
+import { logApiRequest } from "@/lib/activity";
+
+export const dynamic = "force-dynamic";
+
+// GET /api/v1/runs/:id/status — the bare run row, for polling background runs.
+// The report route recomputes aggregate math over every response; this one is
+// a single row read, cheap enough to hit every few seconds.
+export async function GET(
+  request: Request,
+  { params }: { params: { id: string } },
+) {
+  const auth = await requireApiAuth(request, "runs:read", "v1");
+  if (auth instanceof Response) return auth;
+
+  const run = await getRunStatus(auth.supabase, auth.userId, params.id);
+  if (!run) {
+    return NextResponse.json({ error: "Run not found" }, { status: 404 });
+  }
+  await logApiRequest(auth, request, "v1", {
+    category: "run",
+    action: "api.read_status",
+    summary: `Polled run ${params.id} (${run.status}) via the API`,
+    statusCode: 200,
+    projectId: run.project_id,
+    targetType: "run",
+    targetId: params.id,
+  });
+  return NextResponse.json({
+    run: {
+      id: run.id,
+      project_id: run.project_id,
+      status: run.status,
+      provider: run.provider,
+      model: run.model,
+      prompt_count: run.prompt_count,
+      completed_count: run.completed_count,
+      replicates: run.replicates,
+      error: run.error,
+      started_at: run.started_at,
+      finished_at: run.finished_at,
+    },
+  });
+}

--- a/app/api/v1/v1-routes.test.ts
+++ b/app/api/v1/v1-routes.test.ts
@@ -7,6 +7,7 @@ import {
   getProjectHistory,
   getRunReport,
   getRunResponses,
+  getRunStatus,
   listProjectPrompts,
   listRuns,
   setPromptActive,
@@ -28,6 +29,7 @@ import { PATCH as patchPromptRoute } from "@/app/api/v1/prompts/[id]/route";
 import { GET as getReportRoute } from "@/app/api/v1/runs/[id]/route";
 import { GET as getHistoryRoute } from "@/app/api/v1/projects/[id]/history/route";
 import { GET as getResponsesRoute } from "@/app/api/v1/runs/[id]/responses/route";
+import { GET as getStatusRoute } from "@/app/api/v1/runs/[id]/status/route";
 
 vi.mock("@/lib/api-auth", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/api-auth")>()),
@@ -43,6 +45,7 @@ vi.mock("@/lib/api-service", async (importOriginal) => ({
   getProjectHistory: vi.fn(),
   getRunReport: vi.fn(),
   getRunResponses: vi.fn(),
+  getRunStatus: vi.fn(),
   setPromptActive: vi.fn(),
   triggerRunForProject: vi.fn(),
 }));
@@ -84,6 +87,7 @@ beforeEach(() => {
   vi.mocked(getProjectHistory).mockReset();
   vi.mocked(getRunReport).mockReset();
   vi.mocked(getRunResponses).mockReset();
+  vi.mocked(getRunStatus).mockReset();
   vi.mocked(setPromptActive).mockReset();
   vi.mocked(triggerRunForProject).mockReset();
 });
@@ -347,6 +351,46 @@ describe("POST /api/v1/projects/:id/runs", () => {
     );
   });
 
+  it("202s a background run and passes the flag through", async () => {
+    vi.mocked(triggerRunForProject).mockResolvedValue({
+      ok: true,
+      result: { runId: "r9", status: "running", promptCount: 12 },
+    });
+    const res = await postRunRoute(
+      req("/api/v1/projects/p1/runs", {
+        method: "POST",
+        body: JSON.stringify({ background: true }),
+      }),
+      { params: { id: "p1" } },
+    );
+    expect(res.status).toBe(202);
+    const body = await res.json();
+    expect(body.runId).toBe("r9");
+    expect(body.status).toBe("running");
+    expect(triggerRunForProject).toHaveBeenCalledWith(AUTH_CTX.supabase, "user-1", "p1", {
+      background: true,
+      context: RUN_CTX,
+    });
+  });
+
+  it("ignores a non-boolean background value", async () => {
+    vi.mocked(triggerRunForProject).mockResolvedValue({
+      ok: true,
+      result: { runId: "r1", status: "completed", totalResponses: 3, tokensUsed: 10 },
+    });
+    const res = await postRunRoute(
+      req("/api/v1/projects/p1/runs", {
+        method: "POST",
+        body: JSON.stringify({ background: "yes" }),
+      }),
+      { params: { id: "p1" } },
+    );
+    expect(res.status).toBe(200);
+    expect(triggerRunForProject).toHaveBeenCalledWith(AUTH_CTX.supabase, "user-1", "p1", {
+      context: RUN_CTX,
+    });
+  });
+
   it("400s on an unknown provider override", async () => {
     const res = await postRunRoute(
       req("/api/v1/projects/p1/runs", {
@@ -484,6 +528,41 @@ describe("GET /api/v1/runs/:id/responses", () => {
     const body = await res.json();
     expect(body.responses[0].sources[0].url).toBe("https://credal.ai/blog");
     expect(getRunResponses).toHaveBeenCalledWith(AUTH_CTX.supabase, "user-1", "r1");
+  });
+});
+
+describe("GET /api/v1/runs/:id/status", () => {
+  it("404s for an unknown or unowned run", async () => {
+    vi.mocked(getRunStatus).mockResolvedValue(null);
+    const res = await getStatusRoute(req("/api/v1/runs/r1/status"), {
+      params: { id: "r1" },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns the bare run row, trimmed", async () => {
+    vi.mocked(getRunStatus).mockResolvedValue({
+      id: "r1",
+      project_id: "p1",
+      status: "running",
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      prompt_count: 12,
+      completed_count: 5,
+      replicates: 2,
+      error: null,
+      started_at: "2026-07-30T01:00:00Z",
+      finished_at: null,
+      created_at: "2026-07-30T01:00:00Z",
+    });
+    const res = await getStatusRoute(req("/api/v1/runs/r1/status"), {
+      params: { id: "r1" },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.run).toMatchObject({ id: "r1", status: "running", completed_count: 5 });
+    expect(body.run).not.toHaveProperty("created_at");
+    expect(getRunStatus).toHaveBeenCalledWith(AUTH_CTX.supabase, "user-1", "r1");
   });
 });
 

--- a/lib/api-service.ts
+++ b/lib/api-service.ts
@@ -20,7 +20,8 @@ import {
   type RunSummary,
   type TopicStat,
 } from "@/lib/metrics";
-import { executeRun, type RunContext, type RunResult } from "@/lib/engine";
+import { waitUntil } from "@vercel/functions";
+import { executeRun, prepareRun, resumeRun, type RunContext, type RunResult } from "@/lib/engine";
 import { pickDefaultProvider, resolveRunKeyFor, engineKeyMessage } from "@/lib/trial";
 import { isProvider, resolveEngine, PROVIDERS } from "@/lib/models";
 
@@ -600,8 +601,16 @@ export async function getRunResponses(
   };
 }
 
+/** A run accepted in background mode: created and executing, not yet settled. */
+export interface BackgroundRunStart {
+  runId: string;
+  status: "running";
+  /** Planned ANSWERS (prompts × replicates), same meaning as runs.prompt_count. */
+  promptCount: number;
+}
+
 export type TriggerOutcome =
-  | { ok: true; result: RunResult }
+  | { ok: true; result: RunResult | BackgroundRunStart }
   // `invalid_engine` is the caller's request being malformed (a model the
   // provider doesn't offer), distinct from `no_key` which is about billing —
   // routes map them to 400 and 402 respectively.
@@ -619,7 +628,15 @@ export async function triggerRunForProject(
   supabase: SupabaseClient,
   userId: string,
   projectId: string,
-  options?: { provider?: Provider; model?: string; context?: RunContext },
+  options?: {
+    provider?: Provider;
+    model?: string;
+    context?: RunContext;
+    /** Return as soon as the run row exists; the queries finish after the
+     *  response is sent (a run takes minutes — no client should hold the
+     *  connection that long). Poll GET /v1/runs/:id/status to follow it. */
+    background?: boolean;
+  },
 ): Promise<TriggerOutcome> {
   const project = await getOwnedProject(supabase, userId, projectId);
   if (!project) {
@@ -656,15 +673,57 @@ export async function triggerRunForProject(
     };
   }
 
-  const result = await executeRun({
+  const runParams = {
     supabase,
     project,
     provider: key.provider,
     model: key.model,
     apiKey: key.apiKey!,
     context: options?.context,
-  });
+  };
+
+  if (options?.background) {
+    const prepared = await prepareRun(runParams);
+    // waitUntil keeps the serverless invocation alive past the response; the
+    // run settles its own row (completed/failed) exactly as in the sync path.
+    waitUntil(
+      resumeRun(prepared, runParams).catch(() => {
+        // resumeRun never rejects for per-prompt failures; this guards the
+        // run-row settle itself so a crash can't take down the invocation.
+      }),
+    );
+    return {
+      ok: true,
+      result: { runId: prepared.runId, status: "running", promptCount: prepared.jobs.length },
+    };
+  }
+
+  const result = await executeRun(runParams);
   return { ok: true, result };
+}
+
+/**
+ * The bare run row — the polling companion to background runs. Deliberately
+ * lean: the report recomputes aggregate math over every response, which is
+ * the wrong thing to hit every few seconds while a run is still answering.
+ * Ownership is checked run -> project -> user. Null when the run doesn't
+ * exist or isn't the user's.
+ */
+export async function getRunStatus(
+  supabase: SupabaseClient,
+  userId: string,
+  runId: string,
+): Promise<Run | null> {
+  const { data: runRow } = await supabase
+    .from("runs")
+    .select("*")
+    .eq("id", runId)
+    .maybeSingle();
+  const run = runRow as Run | null;
+  if (!run) return null;
+  const project = await getOwnedProject(supabase, userId, run.project_id);
+  if (!project) return null;
+  return run;
 }
 
 /** One completed run, reduced to the numbers that matter across time. */

--- a/lib/engine.ts
+++ b/lib/engine.ts
@@ -61,12 +61,7 @@ export interface RunResult {
   error?: string;
 }
 
-/**
- * Create a run for a project and execute every active prompt against the chosen
- * model with the user's key, detecting + storing brand/competitor mentions.
- * `supabase` may be a user-scoped (RLS) client or the service client (cron).
- */
-export async function executeRun(params: {
+export interface ExecuteRunParams {
   supabase: SupabaseClient;
   project: Project;
   provider: Provider;
@@ -74,8 +69,36 @@ export async function executeRun(params: {
   apiKey: string;
   /** Attribution for the activity log. Defaults to the internal system. */
   context?: RunContext;
-}): Promise<RunResult> {
-  const { supabase, project, provider, model, apiKey } = params;
+}
+
+/** A run row already created and logged, plus everything the job loop needs. */
+export interface PreparedRun {
+  runId: string;
+  /** One entry per planned ANSWER (prompts × replicates). */
+  jobs: Prompt[];
+  competitors: Competitor[];
+  attribution: {
+    userId: string;
+    projectId: string;
+    actorType: ActorType;
+    actorId: string | null;
+    actorLabel: string;
+    channel: LogChannel;
+    category: "run";
+    targetType: string;
+  };
+  startedMs: number;
+}
+
+/**
+ * Create the run row (status "running") and log run.started without executing
+ * anything. Callers that must answer immediately — a run takes minutes, and no
+ * HTTP client should have to hold a connection that long — return the run id
+ * from here and hand the PreparedRun to resumeRun after responding. Everyone
+ * else calls executeRun, which is exactly prepareRun + resumeRun.
+ */
+export async function prepareRun(params: ExecuteRunParams): Promise<PreparedRun> {
+  const { supabase, project, provider, model } = params;
   const startedMs = Date.now();
 
   // Attribution shared by every run event below. project.user_id is always the
@@ -143,7 +166,15 @@ export async function executeRun(params: {
     metadata: { provider, model, prompt_count: jobs.length, replicates },
   });
 
-  if (prompts.length === 0) {
+  return { runId, jobs, competitors, attribution, startedMs };
+}
+
+/** Execute a prepared run's jobs and settle the run row. */
+export async function resumeRun(prepared: PreparedRun, params: ExecuteRunParams): Promise<RunResult> {
+  const { supabase, project, provider, model, apiKey } = params;
+  const { runId, jobs, competitors, attribution, startedMs } = prepared;
+
+  if (jobs.length === 0) {
     await supabase
       .from("runs")
       .update({ status: "completed", finished_at: new Date().toISOString() })
@@ -339,4 +370,13 @@ export async function executeRun(params: {
   });
 
   return { runId, status, totalResponses: succeeded, tokensUsed, error: hardError };
+}
+
+/**
+ * Create a run for a project and execute every active prompt against the chosen
+ * model with the user's key, detecting + storing brand/competitor mentions.
+ * `supabase` may be a user-scoped (RLS) client or the service client (cron).
+ */
+export async function executeRun(params: ExecuteRunParams): Promise<RunResult> {
+  return resumeRun(await prepareRun(params), params);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@modelcontextprotocol/sdk": "^1.26.0",
         "@supabase/ssr": "^0.5.2",
         "@supabase/supabase-js": "^2.45.4",
+        "@vercel/functions": "^3.7.6",
         "lucide-react": "^0.451.0",
         "mcp-handler": "^1.1.0",
         "next": "14.2.15",
@@ -2296,6 +2297,84 @@
         "win32"
       ]
     },
+    "node_modules/@vercel/cli-config": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@vercel/cli-config/-/cli-config-0.2.1.tgz",
+      "integrity": "sha512-RhfyXmRLHdbnry8RJqHDc+5rGxMZ0bu+fpysZjtv3bE+BubpuwxTancHOKiH5zKQREsdwFVr3mOI2kOvxlOyxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "xdg-app-paths": "5",
+        "zod": "4.1.11"
+      }
+    },
+    "node_modules/@vercel/cli-config/node_modules/zod": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@vercel/cli-exec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/cli-exec/-/cli-exec-1.0.0.tgz",
+      "integrity": "sha512-kQF8LGie/Hbdq9/psJxLE7owRTcqMQMhgybU04gCeR7cbQAr5t8OrjefDNColJv1QSSucFt4pLwRiARVmlOnug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "execa": "5.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@vercel/functions": {
+      "version": "3.7.6",
+      "resolved": "https://registry.npmjs.org/@vercel/functions/-/functions-3.7.6.tgz",
+      "integrity": "sha512-QKlSfrgvo4pGEnzHw8Dha9GRTb5hhLBbImKi4rL4CmxClaVs+36hxgjW0MOqez57wWShstpKOWZY/mU8KuYoUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/oidc": "3.8.1"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-web-identity": "*",
+        "ws": ">=8"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-web-identity": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.8.1.tgz",
+      "integrity": "sha512-ufdalm2MWOYksyj8KVpWjoOFPJO6zoYpuyvIggIQ2bB0CFCjTCiTkGXHqAKwG77GVRjOaN3/8S5ITlZpXWmqOw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/cli-config": "0.2.1",
+        "@vercel/cli-exec": "1.0.0",
+        "jose": "^5.9.6"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@vercel/oidc/node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "2.1.9",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
@@ -4496,6 +4575,35 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
     "node_modules/expect-type": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
@@ -4985,6 +5093,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-symbol-description": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
@@ -5255,6 +5375,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
       }
     },
     "node_modules/humanize-ms": {
@@ -5748,6 +5877,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-string": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
@@ -6220,6 +6361,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "license": "MIT"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -6263,6 +6410,15 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/minimatch": {
@@ -6534,6 +6690,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -6686,6 +6854,21 @@
         "wrappy": "1"
       }
     },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/openai": {
       "version": "4.104.0",
       "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
@@ -6747,6 +6930,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/os-paths": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/os-paths/-/os-paths-4.4.0.tgz",
+      "integrity": "sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0"
       }
     },
     "node_modules/own-keys": {
@@ -8229,6 +8421,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -9305,6 +9506,31 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/xdg-app-paths": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/xdg-app-paths/-/xdg-app-paths-5.5.1.tgz",
+      "integrity": "sha512-hI3flOB4PLZIy5prbtTpirobtPE2ZtZ52szO+2mM9Efp6ErM398La+C1lIpNWDfNoQk+6Lsi6nMcCwVB7pxeMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "os-paths": "^4.0.1",
+        "xdg-portable": "^7.2.0"
+      },
+      "engines": {
+        "node": ">= 6.0"
+      }
+    },
+    "node_modules/xdg-portable": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/xdg-portable/-/xdg-portable-7.3.0.tgz",
+      "integrity": "sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "os-paths": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6.0"
+      }
     },
     "node_modules/yallist": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@supabase/ssr": "^0.5.2",
     "@supabase/supabase-js": "^2.45.4",
+    "@vercel/functions": "^3.7.6",
     "lucide-react": "^0.451.0",
     "mcp-handler": "^1.1.0",
     "next": "14.2.15",


### PR DESCRIPTION
A monitoring run holds its HTTP connection for minutes. Programmatic callers with their own deadlines (serverless crons above all) time out and lose the run — observed live: two runs lost against the same project in one cycle.

- `POST /v1/projects/:id/runs` accepts `{"background": true}` → **202** `{runId, status: "running", promptCount}` as soon as the run row exists; the queries finish after the response (`waitUntil`), settling the run row exactly as the sync path does. Default behavior unchanged.
- `GET /v1/runs/:id/status` — the bare run row for polling (`completed_count` / `prompt_count` / `error`), cheap enough to hit every few seconds, unlike the report route's full aggregate recomputation.
- Engine split into `prepareRun` + `resumeRun` with `executeRun` as their unchanged composition; dashboard/onboarding/cron paths untouched.

Typecheck clean, 411 tests passing (4 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)