### PR TITLE
Expose competitors over the v1 API, and say how to read a run's rates

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,20 @@ curl -X POST https://your-app.com/api/v1/projects/<project-id>/prompts \
   -H "Authorization: Bearer lt_live_..." -H "Content-Type: application/json" \
   -d '{"prompts": [{"text": "best crm for startups", "topic": "CRM"}]}'
 
+# A project's tracked competitors: list / bulk-add (already-tracked names are
+# skipped, not errors) / stop tracking one. Candidates your stored answers
+# named but nobody tracks come from /competitors/discovered — confirm the real
+# ones via the POST; an unmatched competitor list makes informativeRate lie.
+curl https://your-app.com/api/v1/projects/<project-id>/competitors \
+  -H "Authorization: Bearer lt_live_..."
+curl -X POST https://your-app.com/api/v1/projects/<project-id>/competitors \
+  -H "Authorization: Bearer lt_live_..." -H "Content-Type: application/json" \
+  -d '{"competitors": [{"name": "WEKA", "aliases": ["WekaIO"], "domain": "weka.io"}]}'
+curl https://your-app.com/api/v1/projects/<project-id>/competitors/discovered \
+  -H "Authorization: Bearer lt_live_..."
+curl -X DELETE https://your-app.com/api/v1/competitors/<competitor-id> \
+  -H "Authorization: Bearer lt_live_..."
+
 # BYOK provider keys: list (masked hints + the supported-provider catalog),
 # set/rotate, remove. Verified against the provider and encrypted before storage.
 # Read the key from a file rather than inlining it — a key typed into a shell

--- a/app/api/v1/competitors/[id]/route.ts
+++ b/app/api/v1/competitors/[id]/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { requireApiAuth } from "@/lib/api-guards";
+import { deleteCompetitor } from "@/lib/api-service";
+import { logApiRequest } from "@/lib/activity";
+import { humanError } from "@/lib/llm";
+
+export const dynamic = "force-dynamic";
+
+// DELETE /api/v1/competitors/:id — stop tracking a competitor. Past mention
+// rows keep the entity name they recorded, so old reports stay intact.
+export async function DELETE(
+  request: Request,
+  { params }: { params: { id: string } },
+) {
+  const auth = await requireApiAuth(request, "projects:write", "v1");
+  if (auth instanceof Response) return auth;
+
+  try {
+    const removed = await deleteCompetitor(auth.supabase, auth.userId, params.id);
+    if (!removed) {
+      return NextResponse.json({ error: "Competitor not found" }, { status: 404 });
+    }
+    await logApiRequest(auth, request, "v1", {
+      category: "competitor",
+      action: "api.delete_competitor",
+      summary: `Removed competitor "${removed.name}" via the API`,
+      statusCode: 200,
+      targetType: "competitor",
+      targetId: params.id,
+    });
+    return NextResponse.json({ ok: true, removed });
+  } catch (e) {
+    return NextResponse.json({ error: humanError(e) }, { status: 500 });
+  }
+}

--- a/app/api/v1/projects/[id]/competitors/discovered/route.ts
+++ b/app/api/v1/projects/[id]/competitors/discovered/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { requireApiAuth } from "@/lib/api-guards";
+import { discoverProjectCompetitors } from "@/lib/api-service";
+import { logApiRequest } from "@/lib/activity";
+import { humanError } from "@/lib/llm";
+
+export const dynamic = "force-dynamic";
+
+// GET /api/v1/projects/:id/competitors/discovered — companies the stored
+// answers named that this project doesn't track. Candidates, not truth: the
+// caller confirms which become tracked competitors (POST ../competitors).
+// Reads text already in the database — no provider call, no key needed.
+export async function GET(
+  request: Request,
+  { params }: { params: { id: string } },
+) {
+  const auth = await requireApiAuth(request, "projects:read", "v1");
+  if (auth instanceof Response) return auth;
+
+  try {
+    const discovered = await discoverProjectCompetitors(auth.supabase, auth.userId, params.id);
+    if (!discovered) {
+      return NextResponse.json({ error: "Project not found" }, { status: 404 });
+    }
+    await logApiRequest(auth, request, "v1", {
+      category: "competitor",
+      action: "api.discover_competitors",
+      summary: `Discovered ${discovered.companies.length} untracked compan${discovered.companies.length === 1 ? "y" : "ies"} via the API`,
+      statusCode: 200,
+      projectId: params.id,
+      targetType: "project",
+      targetId: params.id,
+      metadata: { answers_scanned: discovered.answersScanned },
+    });
+    return NextResponse.json(discovered);
+  } catch (e) {
+    return NextResponse.json({ error: humanError(e) }, { status: 500 });
+  }
+}

--- a/app/api/v1/projects/[id]/competitors/route.ts
+++ b/app/api/v1/projects/[id]/competitors/route.ts
@@ -1,0 +1,89 @@
+import { NextResponse } from "next/server";
+import { requireApiAuth } from "@/lib/api-guards";
+import { listProjectCompetitors, createCompetitors } from "@/lib/api-service";
+import { logApiRequest } from "@/lib/activity";
+import { humanError } from "@/lib/llm";
+
+export const dynamic = "force-dynamic";
+
+// GET /api/v1/projects/:id/competitors — the project's tracked competitors.
+export async function GET(
+  request: Request,
+  { params }: { params: { id: string } },
+) {
+  const auth = await requireApiAuth(request, "projects:read", "v1");
+  if (auth instanceof Response) return auth;
+
+  const competitors = await listProjectCompetitors(auth.supabase, auth.userId, params.id);
+  if (!competitors) {
+    return NextResponse.json({ error: "Project not found" }, { status: 404 });
+  }
+  await logApiRequest(auth, request, "v1", {
+    category: "competitor",
+    action: "api.list_competitors",
+    summary: `Listed ${competitors.length} competitor${competitors.length === 1 ? "" : "s"} via the API`,
+    statusCode: 200,
+    projectId: params.id,
+    targetType: "project",
+    targetId: params.id,
+  });
+  return NextResponse.json({ competitors });
+}
+
+// POST /api/v1/projects/:id/competitors — add tracked competitors.
+// Body: { competitors: [{ name, aliases?, domain? }] }. Names the project
+// already tracks are skipped (counted), not errors.
+export async function POST(
+  request: Request,
+  { params }: { params: { id: string } },
+) {
+  const auth = await requireApiAuth(request, "projects:write", "v1");
+  if (auth instanceof Response) return auth;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  try {
+    const outcome = await createCompetitors(
+      auth.supabase,
+      auth.userId,
+      params.id,
+      (body as Record<string, unknown> | null)?.competitors,
+    );
+    if (!outcome.ok) {
+      const status = outcome.code === "not_found" ? 404 : 400;
+      await logApiRequest(auth, request, "v1", {
+        category: "competitor",
+        action: "api.create_competitors",
+        status: "failure",
+        statusCode: status,
+        projectId: params.id,
+        targetType: "project",
+        targetId: params.id,
+        summary: `Competitors not added via the API: ${outcome.message}`,
+        metadata: { reason: outcome.code },
+      });
+      return NextResponse.json({ error: outcome.message }, { status });
+    }
+    await logApiRequest(auth, request, "v1", {
+      category: "competitor",
+      action: "api.create_competitors",
+      statusCode: 201,
+      projectId: params.id,
+      targetType: "project",
+      targetId: params.id,
+      summary: `Added ${outcome.created.length} competitor${outcome.created.length === 1 ? "" : "s"} via the API (${outcome.skipped} skipped)`,
+      metadata: { created: outcome.created.length, skipped: outcome.skipped },
+    });
+    return NextResponse.json(
+      { competitors: outcome.created, skipped: outcome.skipped },
+      { status: 201 },
+    );
+  } catch (e) {
+    return NextResponse.json({ error: humanError(e) }, { status: 500 });
+  }
+}

--- a/app/api/v1/v1-routes.test.ts
+++ b/app/api/v1/v1-routes.test.ts
@@ -2,12 +2,16 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { authenticateApiKey } from "@/lib/api-auth";
 import { getProjects } from "@/lib/data";
 import {
+  createCompetitors,
   createProject,
   createPrompts,
+  deleteCompetitor,
+  discoverProjectCompetitors,
   getProjectHistory,
   getRunReport,
   getRunResponses,
   getRunStatus,
+  listProjectCompetitors,
   listProjectPrompts,
   listRuns,
   setPromptActive,
@@ -30,6 +34,12 @@ import { GET as getReportRoute } from "@/app/api/v1/runs/[id]/route";
 import { GET as getHistoryRoute } from "@/app/api/v1/projects/[id]/history/route";
 import { GET as getResponsesRoute } from "@/app/api/v1/runs/[id]/responses/route";
 import { GET as getStatusRoute } from "@/app/api/v1/runs/[id]/status/route";
+import {
+  GET as getCompetitorsRoute,
+  POST as postCompetitorsRoute,
+} from "@/app/api/v1/projects/[id]/competitors/route";
+import { GET as getDiscoveredRoute } from "@/app/api/v1/projects/[id]/competitors/discovered/route";
+import { DELETE as deleteCompetitorRoute } from "@/app/api/v1/competitors/[id]/route";
 
 vi.mock("@/lib/api-auth", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/api-auth")>()),
@@ -38,14 +48,18 @@ vi.mock("@/lib/api-auth", async (importOriginal) => ({
 vi.mock("@/lib/data", () => ({ getProjects: vi.fn() }));
 vi.mock("@/lib/api-service", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/api-service")>()),
+  createCompetitors: vi.fn(),
   createProject: vi.fn(),
   createPrompts: vi.fn(),
+  deleteCompetitor: vi.fn(),
+  discoverProjectCompetitors: vi.fn(),
   listProjectPrompts: vi.fn(),
   listRuns: vi.fn(),
   getProjectHistory: vi.fn(),
   getRunReport: vi.fn(),
   getRunResponses: vi.fn(),
   getRunStatus: vi.fn(),
+  listProjectCompetitors: vi.fn(),
   setPromptActive: vi.fn(),
   triggerRunForProject: vi.fn(),
 }));
@@ -82,6 +96,10 @@ beforeEach(() => {
   vi.mocked(getProjects).mockReset();
   vi.mocked(createProject).mockReset();
   vi.mocked(createPrompts).mockReset();
+  vi.mocked(createCompetitors).mockReset();
+  vi.mocked(deleteCompetitor).mockReset();
+  vi.mocked(discoverProjectCompetitors).mockReset();
+  vi.mocked(listProjectCompetitors).mockReset();
   vi.mocked(listProjectPrompts).mockReset();
   vi.mocked(listRuns).mockReset();
   vi.mocked(getProjectHistory).mockReset();
@@ -480,11 +498,14 @@ describe("GET /api/v1/runs/:id", () => {
         responsesNamingNobody: 0,
         informativeRate: 1,
       },
+      verdict: "healthy",
       topics: [],
     });
     const res = await getReportRoute(req("/api/v1/runs/r1"), { params: { id: "r1" } });
     expect(res.status).toBe(200);
-    expect((await res.json()).summary.brandShareOfVoice).toBe(0.25);
+    const body = await res.json();
+    expect(body.summary.brandShareOfVoice).toBe(0.25);
+    expect(body.verdict).toBe("healthy");
   });
 });
 
@@ -644,5 +665,148 @@ describe("GET /api/v1/projects/:id/history", () => {
     expect(body.everMentioned).toBe(true);
     expect(body.firstMentionAt).toBe("2026-07-08T00:00:00Z");
     expect(getProjectHistory).toHaveBeenCalledWith(AUTH_CTX.supabase, "user-1", "p1", 5);
+  });
+});
+
+describe("GET /api/v1/projects/:id/competitors", () => {
+  it("404s for a project that isn't the caller's", async () => {
+    vi.mocked(listProjectCompetitors).mockResolvedValue(null);
+    const res = await getCompetitorsRoute(req("/api/v1/projects/p1/competitors"), {
+      params: { id: "p1" },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns the tracked competitors", async () => {
+    vi.mocked(listProjectCompetitors).mockResolvedValue([
+      {
+        id: "c1",
+        name: "WEKA",
+        aliases: ["WekaIO"],
+        domain: "weka.io",
+        created_at: "2026-07-30T00:00:00Z",
+      },
+    ]);
+    const res = await getCompetitorsRoute(req("/api/v1/projects/p1/competitors"), {
+      params: { id: "p1" },
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()).competitors[0].name).toBe("WEKA");
+    expect(listProjectCompetitors).toHaveBeenCalledWith(AUTH_CTX.supabase, "user-1", "p1");
+  });
+});
+
+describe("POST /api/v1/projects/:id/competitors", () => {
+  it("maps not_found/invalid to 404/400", async () => {
+    vi.mocked(createCompetitors).mockResolvedValue({
+      ok: false,
+      code: "not_found",
+      message: "Project not found.",
+    });
+    let res = await postCompetitorsRoute(
+      req("/api/v1/projects/p1/competitors", {
+        method: "POST",
+        body: JSON.stringify({ competitors: [{ name: "WEKA" }] }),
+      }),
+      { params: { id: "p1" } },
+    );
+    expect(res.status).toBe(404);
+
+    vi.mocked(createCompetitors).mockResolvedValue({
+      ok: false,
+      code: "invalid",
+      message: "No usable entries",
+    });
+    res = await postCompetitorsRoute(
+      req("/api/v1/projects/p1/competitors", {
+        method: "POST",
+        body: JSON.stringify({ competitors: [] }),
+      }),
+      { params: { id: "p1" } },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("201s with the created competitors and skip count", async () => {
+    vi.mocked(createCompetitors).mockResolvedValue({
+      ok: true,
+      created: [
+        {
+          id: "c1",
+          name: "WEKA",
+          aliases: [],
+          domain: "weka.io",
+          created_at: "2026-07-30T00:00:00Z",
+        },
+      ],
+      skipped: 1,
+    });
+    const res = await postCompetitorsRoute(
+      req("/api/v1/projects/p1/competitors", {
+        method: "POST",
+        body: JSON.stringify({ competitors: [{ name: "WEKA", domain: "weka.io" }] }),
+      }),
+      { params: { id: "p1" } },
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.competitors[0].id).toBe("c1");
+    expect(body.skipped).toBe(1);
+    expect(createCompetitors).toHaveBeenCalledWith(AUTH_CTX.supabase, "user-1", "p1", [
+      { name: "WEKA", domain: "weka.io" },
+    ]);
+  });
+});
+
+describe("GET /api/v1/projects/:id/competitors/discovered", () => {
+  it("404s for a project that isn't the caller's", async () => {
+    vi.mocked(discoverProjectCompetitors).mockResolvedValue(null);
+    const res = await getDiscoveredRoute(req("/api/v1/projects/p1/competitors/discovered"), {
+      params: { id: "p1" },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns the candidates with scan stats", async () => {
+    vi.mocked(discoverProjectCompetitors).mockResolvedValue({
+      companies: [{ name: "Mountpoint for Amazon S3", answers: 7 }],
+      answersScanned: 120,
+      topCount: 7,
+    });
+    const res = await getDiscoveredRoute(req("/api/v1/projects/p1/competitors/discovered"), {
+      params: { id: "p1" },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.companies[0].name).toBe("Mountpoint for Amazon S3");
+    expect(body.answersScanned).toBe(120);
+  });
+});
+
+describe("DELETE /api/v1/competitors/:id", () => {
+  it("404s for an unknown or unowned competitor", async () => {
+    vi.mocked(deleteCompetitor).mockResolvedValue(null);
+    const res = await deleteCompetitorRoute(
+      req("/api/v1/competitors/c1", { method: "DELETE" }),
+      { params: { id: "c1" } },
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("removes and echoes the competitor", async () => {
+    vi.mocked(deleteCompetitor).mockResolvedValue({
+      id: "c1",
+      name: "WEKA",
+      aliases: [],
+      domain: "weka.io",
+      created_at: "2026-07-30T00:00:00Z",
+    });
+    const res = await deleteCompetitorRoute(
+      req("/api/v1/competitors/c1", { method: "DELETE" }),
+      { params: { id: "c1" } },
+    );
+    expect(res.status).toBe(200);
+    expect((await res.json()).removed.name).toBe("WEKA");
+    expect(deleteCompetitor).toHaveBeenCalledWith(AUTH_CTX.supabase, "user-1", "c1");
   });
 });

--- a/lib/api-service.ts
+++ b/lib/api-service.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type {
+  Competitor,
   Mention,
   Project,
   Prompt,
@@ -14,13 +15,17 @@ import {
   computeMeasurementQuality,
   computeRunSummary,
   computeTopicStats,
+  measurementVerdict,
   type CitationStat,
   type EntityStat,
   type MeasurementQuality,
+  type MeasurementVerdict,
   type RunSummary,
   type TopicStat,
 } from "@/lib/metrics";
 import { waitUntil } from "@vercel/functions";
+import { normalizeCompetitorList } from "@/lib/competitors";
+import { discoverCompanies, type DiscoveredCompany } from "@/lib/discover";
 import { executeRun, prepareRun, resumeRun, type RunContext, type RunResult } from "@/lib/engine";
 import { pickDefaultProvider, resolveRunKeyFor, engineKeyMessage } from "@/lib/trial";
 import { isProvider, resolveEngine, PROVIDERS } from "@/lib/models";
@@ -381,6 +386,203 @@ export async function setPromptActive(
   };
 }
 
+/** A competitor as the API returns it (no project_id echo — it's in the URL). */
+export interface CompetitorSummary {
+  id: string;
+  name: string;
+  aliases: string[];
+  domain: string | null;
+  created_at: string;
+}
+
+function competitorSummary(c: Competitor): CompetitorSummary {
+  return {
+    id: c.id,
+    name: c.name,
+    aliases: c.aliases,
+    domain: c.domain,
+    created_at: c.created_at,
+  };
+}
+
+/** A project's tracked competitors. Null when the project isn't the user's. */
+export async function listProjectCompetitors(
+  supabase: SupabaseClient,
+  userId: string,
+  projectId: string,
+): Promise<CompetitorSummary[] | null> {
+  const project = await getOwnedProject(supabase, userId, projectId);
+  if (!project) return null;
+  const { data } = await supabase
+    .from("competitors")
+    .select("*")
+    .eq("project_id", projectId)
+    .order("created_at", { ascending: true });
+  return ((data ?? []) as Competitor[]).map(competitorSummary);
+}
+
+export type CreateCompetitorsOutcome =
+  | { ok: true; created: CompetitorSummary[]; skipped: number }
+  | { ok: false; code: "not_found" | "invalid"; message: string };
+
+/**
+ * Add tracked competitors to a project. Entries are normalized the same way
+ * the onboarding wizard's are (lib/competitors): unnamed rows dropped, the
+ * brand itself excluded, repeats collapsed. Entries whose name the project
+ * already tracks are counted in `skipped` rather than erroring — the caller
+ * is usually syncing a list, not appending blindly.
+ */
+export async function createCompetitors(
+  supabase: SupabaseClient,
+  userId: string,
+  projectId: string,
+  entries: unknown,
+): Promise<CreateCompetitorsOutcome> {
+  const project = await getOwnedProject(supabase, userId, projectId);
+  if (!project) {
+    return { ok: false, code: "not_found", message: "Project not found." };
+  }
+  if (!Array.isArray(entries) || entries.length === 0) {
+    return {
+      ok: false,
+      code: "invalid",
+      message: "competitors must be a non-empty array of { name, aliases?, domain? }.",
+    };
+  }
+
+  const list = normalizeCompetitorList(entries, {
+    exclude: [project.brand_name, ...project.brand_aliases],
+  });
+  if (list.length === 0) {
+    return {
+      ok: false,
+      code: "invalid",
+      message: "No usable entries: every competitor needs a non-empty name that isn't the brand itself.",
+    };
+  }
+
+  const { data: existingRows } = await supabase
+    .from("competitors")
+    .select("name")
+    .eq("project_id", projectId);
+  const existing = new Set(
+    ((existingRows ?? []) as { name: string }[]).map((r) => r.name.trim().toLowerCase()),
+  );
+
+  const toInsert = list.filter((c) => !existing.has(c.name.toLowerCase()));
+  const skipped = list.length - toInsert.length;
+  if (toInsert.length === 0) return { ok: true, created: [], skipped };
+
+  const { data: created, error } = await supabase
+    .from("competitors")
+    .insert(
+      toInsert.map((c) => ({
+        project_id: projectId,
+        name: c.name,
+        aliases: c.aliases,
+        domain: c.domain,
+      })),
+    )
+    .select("*");
+  if (error) throw error;
+
+  return {
+    ok: true,
+    created: ((created ?? []) as Competitor[]).map(competitorSummary),
+    skipped,
+  };
+}
+
+/**
+ * Remove a tracked competitor. Ownership is checked competitor -> project ->
+ * user. Null when it doesn't exist or isn't the user's; mention history rows
+ * keep the entity name they recorded, so past reports stay intact.
+ */
+export async function deleteCompetitor(
+  supabase: SupabaseClient,
+  userId: string,
+  competitorId: string,
+): Promise<CompetitorSummary | null> {
+  const { data: row } = await supabase
+    .from("competitors")
+    .select("*")
+    .eq("id", competitorId)
+    .maybeSingle();
+  const competitor = row as Competitor | null;
+  if (!competitor) return null;
+
+  const project = await getOwnedProject(supabase, userId, competitor.project_id);
+  if (!project) return null;
+
+  const { error } = await supabase
+    .from("competitors")
+    .delete()
+    .eq("id", competitorId)
+    .eq("project_id", project.id);
+  if (error) throw error;
+
+  return competitorSummary(competitor);
+}
+
+/** Answers scanned for discovery. Bounded so a long history stays cheap. */
+const DISCOVER_ANSWER_LIMIT = 200;
+
+export interface DiscoveredCompetitors {
+  companies: DiscoveredCompany[];
+  answersScanned: number;
+  /** Answers naming the top candidate — many means the category has a default
+   *  pick the project isn't tracking; a spread of one-offs means no consensus. */
+  topCount: number;
+}
+
+/**
+ * Companies the stored answers named that the project doesn't track — the
+ * dashboard's discovery view, exposed programmatically. Reads text already in
+ * the database (no provider call, no key needed). Candidates only: the caller
+ * confirms which become tracked competitors via createCompetitors.
+ */
+export async function discoverProjectCompetitors(
+  supabase: SupabaseClient,
+  userId: string,
+  projectId: string,
+): Promise<DiscoveredCompetitors | null> {
+  const project = await getOwnedProject(supabase, userId, projectId);
+  if (!project) return null;
+
+  const [{ data: responseRows }, { data: competitorRows }] = await Promise.all([
+    supabase
+      .from("responses")
+      .select("response_text")
+      .eq("project_id", projectId)
+      .order("created_at", { ascending: false })
+      .limit(DISCOVER_ANSWER_LIMIT),
+    supabase.from("competitors").select("name, aliases").eq("project_id", projectId),
+  ]);
+
+  const answers = ((responseRows ?? []) as { response_text: string | null }[])
+    .map((r) => r.response_text ?? "")
+    .filter(Boolean);
+
+  // Everything already accounted for: the brand, its aliases, and every
+  // tracked competitor with theirs — offering any of these back would be
+  // suggesting something the project already tracks.
+  const tracked = [
+    project.brand_name,
+    ...project.brand_aliases,
+    ...((competitorRows ?? []) as Pick<Competitor, "name" | "aliases">[]).flatMap((c) => [
+      c.name,
+      ...c.aliases,
+    ]),
+  ];
+
+  const companies = discoverCompanies(answers, tracked, { limit: 24 });
+  return {
+    companies,
+    answersScanned: answers.length,
+    topCount: companies[0]?.answers ?? 0,
+  };
+}
+
 /** Recent runs for a project. Null when the project isn't the user's. */
 export async function listRuns(
   supabase: SupabaseClient,
@@ -410,6 +612,10 @@ export interface RunReport {
   /** How many answers named any tracked company. A run that named nobody
    *  measured nothing — read this before believing a zero mention rate. */
   quality: MeasurementQuality;
+  /** How to read this run's rates — the dashboard's chip, exposed so API
+   *  consumers don't re-derive it: a 0% that's "real-gap" and a 0% that's
+   *  "no-competitors" or "thin-sample" are entirely different findings. */
+  verdict: MeasurementVerdict;
   /** Per-topic brand visibility. Letterstory plans by topic, so this is the
    *  join between "we published about X" and "are we surfacing for X". */
   topics: (TopicStat & { topic: string | null })[];
@@ -452,6 +658,7 @@ export async function getRunReport(
     { data: sourceRows },
     { data: responseTopicRows },
     { data: topicRows },
+    { count: competitorCount },
   ] = await Promise.all([
     supabase
       .from("responses")
@@ -461,6 +668,10 @@ export async function getRunReport(
     supabase.from("sources").select("response_id, url, is_owned").eq("run_id", runId),
     supabase.from("responses").select("topic_id").eq("run_id", runId),
     supabase.from("topics").select("id, name").eq("project_id", run.project_id),
+    supabase
+      .from("competitors")
+      .select("id", { count: "exact", head: true })
+      .eq("project_id", run.project_id),
   ]);
 
   const mentions = (mentionRows ?? []) as Mention[];
@@ -479,16 +690,25 @@ export async function getRunReport(
     topic: t.topicId ? topicNames.get(t.topicId) ?? null : null,
   }));
 
+  const summary = computeRunSummary(mentions, totalResponses, project.brand_name);
+  const quality = computeMeasurementQuality(mentions, totalResponses);
+
   return {
     run,
     totalResponses,
     // Pass the brand name so a run with no brand mentions still reports a brand
     // row (rate 0 with an interval) rather than omitting it — an API consumer
     // tracking "have we been mentioned yet" needs the zero, not a missing key.
-    summary: computeRunSummary(mentions, totalResponses, project.brand_name),
+    summary,
     entities: computeEntityStats(mentions, totalResponses, project.brand_name),
     citations: computeCitationStats(sources, totalResponses),
-    quality: computeMeasurementQuality(mentions, totalResponses),
+    quality,
+    verdict: measurementVerdict({
+      totalResponses,
+      informativeRate: quality.informativeRate,
+      brandMentioned: summary.brandResponsesMentioned > 0,
+      competitorsTracked: competitorCount ?? 0,
+    }),
     topics: topicStats,
   };
 }


### PR DESCRIPTION
Every measurement-quality number leans on competitors — with none tracked, `informativeRate` collapses to the brand's own mention rate and gates nothing — but competitors were dashboard/wizard-only, so API-created projects were born blind.

- `GET`/`POST /v1/projects/:id/competitors` — list + bulk-add via the shared `lib/competitors` normalization (brand excluded, repeats collapsed; already-tracked names counted as `skipped`, not errors).
- `GET /v1/projects/:id/competitors/discovered` — the answer-mining discovery view (no provider call), returning candidates to confirm via the POST.
- `DELETE /v1/competitors/:id` — stop tracking; past mention rows keep their recorded entity name.
- The v1 run report now includes `verdict` — the dashboard's `measurementVerdict` (`no-data` / `no-competitors` / `thin-sample` / `real-gap` / `healthy`) — so API consumers read a 0% the same way the UI does.

Typecheck clean, 415 tests passing (8 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)