### PR TITLE
Let a project be read and fixed through the v1 API after creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,14 @@ curl -X POST https://your-app.com/api/v1/projects \
   -H "Authorization: Bearer lt_live_..." -H "Content-Type: application/json" \
   -d '{"name": "Acme", "brand_name": "Acme", "brand_domains": ["acme.io"]}'
 
+# Read one organization / update settings (only sent fields change — fix
+# aliases, replicates, or domains on a project after creation)
+curl https://your-app.com/api/v1/projects/<project-id> \
+  -H "Authorization: Bearer lt_live_..."
+curl -X PATCH https://your-app.com/api/v1/projects/<project-id> \
+  -H "Authorization: Bearer lt_live_..." -H "Content-Type: application/json" \
+  -d '{"brand_aliases": ["Acme Cloud"], "replicates": 3}'
+
 # A project's prompts / bulk-add prompts (topics are get-or-created by name)
 curl https://your-app.com/api/v1/projects/<project-id>/prompts \
   -H "Authorization: Bearer lt_live_..."

--- a/app/api/v1/projects/[id]/route.ts
+++ b/app/api/v1/projects/[id]/route.ts
@@ -1,0 +1,89 @@
+import { NextResponse } from "next/server";
+import { requireApiAuth } from "@/lib/api-guards";
+import { getOwnedProject, projectSummary, updateProject } from "@/lib/api-service";
+import { logApiRequest } from "@/lib/activity";
+import { humanError } from "@/lib/llm";
+
+export const dynamic = "force-dynamic";
+
+// GET /api/v1/projects/:id — one project's settings (the list route trims the
+// same way; this is the single-project read that was oddly missing).
+export async function GET(
+  request: Request,
+  { params }: { params: { id: string } },
+) {
+  const auth = await requireApiAuth(request, "projects:read", "v1");
+  if (auth instanceof Response) return auth;
+
+  const project = await getOwnedProject(auth.supabase, auth.userId, params.id);
+  if (!project) {
+    return NextResponse.json({ error: "Project not found" }, { status: 404 });
+  }
+  await logApiRequest(auth, request, "v1", {
+    category: "project",
+    action: "api.read_project",
+    summary: `Read organization "${project.name}" via the API`,
+    statusCode: 200,
+    projectId: params.id,
+    targetType: "project",
+    targetId: params.id,
+  });
+  return NextResponse.json({ project: projectSummary(project) });
+}
+
+// PATCH /api/v1/projects/:id — update settings; only sent fields change.
+// Updatable: name, brand_name, brand_aliases, brand_domains, description,
+// use_web_search, replicates, default_provider, default_model. Replicates
+// apply from the NEXT run; schedule is not accepted (API callers orchestrate
+// their own cadence).
+export async function PATCH(
+  request: Request,
+  { params }: { params: { id: string } },
+) {
+  const auth = await requireApiAuth(request, "projects:write", "v1");
+  if (auth instanceof Response) return auth;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  try {
+    const outcome = await updateProject(
+      auth.supabase,
+      auth.userId,
+      params.id,
+      (body ?? {}) as Record<string, unknown>,
+    );
+    if (!outcome.ok) {
+      const status = outcome.code === "not_found" ? 404 : 400;
+      await logApiRequest(auth, request, "v1", {
+        category: "project",
+        action: "api.update_project",
+        status: "failure",
+        statusCode: status,
+        projectId: params.id,
+        targetType: "project",
+        targetId: params.id,
+        summary: `Organization not updated via the API: ${outcome.message}`,
+        metadata: { reason: outcome.code },
+      });
+      return NextResponse.json({ error: outcome.message }, { status });
+    }
+    await logApiRequest(auth, request, "v1", {
+      category: "project",
+      action: "api.update_project",
+      statusCode: 200,
+      projectId: params.id,
+      targetType: "project",
+      targetId: params.id,
+      summary: `Updated organization "${outcome.project.name}" via the API`,
+      metadata: { fields: Object.keys((body ?? {}) as Record<string, unknown>) },
+    });
+    return NextResponse.json({ project: projectSummary(outcome.project) });
+  } catch (e) {
+    return NextResponse.json({ error: humanError(e) }, { status: 500 });
+  }
+}

--- a/app/api/v1/v1-routes.test.ts
+++ b/app/api/v1/v1-routes.test.ts
@@ -7,6 +7,7 @@ import {
   createPrompts,
   deleteCompetitor,
   discoverProjectCompetitors,
+  updateProject,
   getProjectHistory,
   getRunReport,
   getRunResponses,
@@ -40,6 +41,7 @@ import {
 } from "@/app/api/v1/projects/[id]/competitors/route";
 import { GET as getDiscoveredRoute } from "@/app/api/v1/projects/[id]/competitors/discovered/route";
 import { DELETE as deleteCompetitorRoute } from "@/app/api/v1/competitors/[id]/route";
+import { PATCH as patchProjectRoute } from "@/app/api/v1/projects/[id]/route";
 
 vi.mock("@/lib/api-auth", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/api-auth")>()),
@@ -53,6 +55,7 @@ vi.mock("@/lib/api-service", async (importOriginal) => ({
   createPrompts: vi.fn(),
   deleteCompetitor: vi.fn(),
   discoverProjectCompetitors: vi.fn(),
+  updateProject: vi.fn(),
   listProjectPrompts: vi.fn(),
   listRuns: vi.fn(),
   getProjectHistory: vi.fn(),
@@ -100,6 +103,7 @@ beforeEach(() => {
   vi.mocked(deleteCompetitor).mockReset();
   vi.mocked(discoverProjectCompetitors).mockReset();
   vi.mocked(listProjectCompetitors).mockReset();
+  vi.mocked(updateProject).mockReset();
   vi.mocked(listProjectPrompts).mockReset();
   vi.mocked(listRuns).mockReset();
   vi.mocked(getProjectHistory).mockReset();
@@ -808,5 +812,66 @@ describe("DELETE /api/v1/competitors/:id", () => {
     expect(res.status).toBe(200);
     expect((await res.json()).removed.name).toBe("WEKA");
     expect(deleteCompetitor).toHaveBeenCalledWith(AUTH_CTX.supabase, "user-1", "c1");
+  });
+});
+
+describe("PATCH /api/v1/projects/:id", () => {
+  it("maps not_found/invalid to 404/400", async () => {
+    vi.mocked(updateProject).mockResolvedValue({
+      ok: false,
+      code: "not_found",
+      message: "Project not found.",
+    });
+    let res = await patchProjectRoute(
+      req("/api/v1/projects/p1", {
+        method: "PATCH",
+        body: JSON.stringify({ replicates: 3 }),
+      }),
+      { params: { id: "p1" } },
+    );
+    expect(res.status).toBe(404);
+
+    vi.mocked(updateProject).mockResolvedValue({
+      ok: false,
+      code: "invalid",
+      message: "replicates must be a number (1\u201310).",
+    });
+    res = await patchProjectRoute(
+      req("/api/v1/projects/p1", {
+        method: "PATCH",
+        body: JSON.stringify({ replicates: "three" }),
+      }),
+      { params: { id: "p1" } },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns the trimmed updated project", async () => {
+    vi.mocked(updateProject).mockResolvedValue({
+      ok: true,
+      project: {
+        id: "p1",
+        user_id: "user-1",
+        name: "Acme",
+        brand_name: "Acme",
+        brand_aliases: ["Acme Cloud"],
+        replicates: 3,
+      } as never,
+    });
+    const res = await patchProjectRoute(
+      req("/api/v1/projects/p1", {
+        method: "PATCH",
+        body: JSON.stringify({ brand_aliases: ["Acme Cloud"], replicates: 3 }),
+      }),
+      { params: { id: "p1" } },
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.project.replicates).toBe(3);
+    expect(body.project).not.toHaveProperty("user_id");
+    expect(updateProject).toHaveBeenCalledWith(AUTH_CTX.supabase, "user-1", "p1", {
+      brand_aliases: ["Acme Cloud"],
+      replicates: 3,
+    });
   });
 });

--- a/lib/api-service.ts
+++ b/lib/api-service.ts
@@ -174,6 +174,115 @@ export async function createProject(
   return { ok: true, project: data as Project };
 }
 
+export type UpdateProjectOutcome =
+  | { ok: true; project: Project }
+  | { ok: false; code: "not_found" | "invalid"; message: string };
+
+/**
+ * Update a project's settings — true PATCH semantics: only the fields the
+ * caller sends change, everything else keeps its value (the dashboard's
+ * full-form save lives elsewhere). This is how a project created before its
+ * configuration was fully known gets fixed without the dashboard: aliases the
+ * brand also answers to, replicates once a rate needs tighter intervals,
+ * domains as owned sites launch.
+ *
+ * `schedule` is deliberately not accepted, same stance as createProject: API
+ * callers orchestrate their own cadence and trigger runs explicitly.
+ */
+export async function updateProject(
+  supabase: SupabaseClient,
+  userId: string,
+  projectId: string,
+  input: Record<string, unknown>,
+): Promise<UpdateProjectOutcome> {
+  const project = await getOwnedProject(supabase, userId, projectId);
+  if (!project) {
+    return { ok: false, code: "not_found", message: "Project not found." };
+  }
+
+  const update: Record<string, unknown> = {};
+
+  if ("name" in input) {
+    const name = typeof input.name === "string" ? input.name.trim() : "";
+    if (!name) {
+      return { ok: false, code: "invalid", message: "name cannot be empty." };
+    }
+    update.name = name;
+  }
+  if ("brand_name" in input) {
+    const brandName = typeof input.brand_name === "string" ? input.brand_name.trim() : "";
+    if (!brandName) {
+      return { ok: false, code: "invalid", message: "brand_name cannot be empty." };
+    }
+    update.brand_name = brandName;
+  }
+  if ("brand_aliases" in input) update.brand_aliases = toAliases(input.brand_aliases);
+  if ("brand_domains" in input) update.brand_domains = toDomains(input.brand_domains);
+  if ("description" in input) update.description = toNullableString(input.description);
+  if ("use_web_search" in input) {
+    if (typeof input.use_web_search !== "boolean") {
+      return { ok: false, code: "invalid", message: "use_web_search must be a boolean." };
+    }
+    update.use_web_search = input.use_web_search;
+  }
+  if ("replicates" in input) {
+    if (typeof input.replicates !== "number" || !Number.isFinite(input.replicates)) {
+      return { ok: false, code: "invalid", message: "replicates must be a number (1–10)." };
+    }
+    // Applies from the NEXT run; past runs keep the replicates they recorded.
+    update.replicates = Math.min(Math.max(Math.trunc(input.replicates), 1), 10);
+  }
+  // Provider and model move together (the dashboard learned this the hard
+  // way): a provider alone re-resolves its default model; a model alone is
+  // validated against the provider it will actually be sent to.
+  if ("default_provider" in input || "default_model" in input) {
+    if (
+      "default_provider" in input &&
+      (typeof input.default_provider !== "string" || !isProvider(input.default_provider))
+    ) {
+      return {
+        ok: false,
+        code: "invalid",
+        message: `Unknown provider "${String(input.default_provider)}". Use one of: ${Object.keys(PROVIDERS).join(", ")}.`,
+      };
+    }
+    const provider =
+      typeof input.default_provider === "string" && isProvider(input.default_provider)
+        ? input.default_provider
+        : project.default_provider;
+    const model =
+      typeof input.default_model === "string" && input.default_model.trim().length > 0
+        ? input.default_model.trim()
+        : undefined;
+    const engine = resolveEngine(provider, model);
+    if (!engine.ok) {
+      return { ok: false, code: "invalid", message: engine.message };
+    }
+    update.default_provider = engine.provider;
+    update.default_model = engine.model;
+  }
+
+  if (Object.keys(update).length === 0) {
+    return {
+      ok: false,
+      code: "invalid",
+      message:
+        "No recognized fields. Updatable: name, brand_name, brand_aliases, brand_domains, description, use_web_search, replicates, default_provider, default_model.",
+    };
+  }
+  update.updated_at = new Date().toISOString();
+
+  const { data, error } = await supabase
+    .from("projects")
+    .update(update)
+    .eq("id", projectId)
+    .eq("user_id", userId)
+    .select("*")
+    .single();
+  if (error || !data) throw error ?? new Error("Failed to update project.");
+  return { ok: true, project: data as Project };
+}
+
 /** A prompt row trimmed to what the API exposes, with its topic's name. */
 export interface PromptSummary {
   id: string;


### PR DESCRIPTION
Projects could be created and listed via the API but never read singly or changed — aliases, replicates, and domains were baked at creation, fixable only in the dashboard. Observed live: a fleet of API-created projects needed brand aliases (answers say "Oso", domain label is "osohq" → zero detected mentions) and the only recourse was the settings page, project by project.

- `GET /v1/projects/:id` — the missing single-project read.
- `PATCH /v1/projects/:id` — true PATCH: only sent fields change. Updatable: `name`, `brand_name`, `brand_aliases`, `brand_domains`, `description`, `use_web_search`, `replicates` (clamped 1–10, applies from the next run), `default_provider`/`default_model` (pair-resolved, same rule as the dashboard). `schedule` deliberately excluded — same stance as `createProject`.

Typecheck clean, 409 tests passing (2 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)