### PR TITLE
Fix run report: pages[] and verdict read the wrong query results

### DIFF
--- a/lib/api-service.test.ts
+++ b/lib/api-service.test.ts
@@ -274,6 +274,46 @@ describe("getRunReport", () => {
     expect(report!.entities[0].type).toBe("brand"); // brand sorts first
     expect(report!.entities[1]).toMatchObject({ name: "Rival", shareOfVoice: 0.75 });
   });
+
+  // Regression: the prompts and competitors queries once had their results
+  // swapped in the destructure — pages[] was always empty and the verdict
+  // read no-competitors no matter how many were registered.
+  it("routes prompt targets into pages[] and the competitor count into the verdict", async () => {
+    const db = fakeDb({
+      runs: () => ({ data: makeRun({}) }),
+      projects: () => ({ data: PROJECT }),
+      responses: () => ({
+        count: 2,
+        data: [
+          { id: "resp-1", topic_id: null, prompt_id: "prompt-1" },
+          { id: "resp-2", topic_id: null, prompt_id: "prompt-1" },
+        ],
+      }),
+      mentions: () => ({ data: [makeMention({ response_id: "resp-1" })] }),
+      sources: () => ({
+        data: [
+          { response_id: "resp-1", url: "https://blog.example.com/posts/guide?utm_source=openai", is_owned: true },
+        ],
+      }),
+      prompts: () => ({
+        data: [{ id: "prompt-1", target_url: "https://blog.example.com/posts/guide" }],
+      }),
+      competitors: () => ({ count: 3 }),
+    });
+
+    const report = await getRunReport(db as never, "user-1", "run-1");
+    expect(report!.pages).toEqual([
+      expect.objectContaining({
+        url: "https://blog.example.com/posts/guide",
+        prompts: 1,
+        totalResponses: 2,
+        responsesCiting: 1,
+        citedRate: 0.5,
+      }),
+    ]);
+    // 3 competitors registered + informative answers → never "no-competitors".
+    expect(report!.verdict).not.toBe("no-competitors");
+  });
 });
 
 describe("triggerRunForProject", () => {

--- a/lib/api-service.ts
+++ b/lib/api-service.ts
@@ -851,8 +851,8 @@ export async function getRunReport(
     { data: sourceRows },
     { data: responseTopicRows },
     { data: topicRows },
-    { count: competitorCount },
     { data: promptTargetRows },
+    { count: competitorCount },
   ] = await Promise.all([
     supabase
       .from("responses")


### PR DESCRIPTION
getRunReport's Promise.all destructure listed the competitors count before the prompt-target rows, but the queries ran in the opposite order. Result, for every report since target_url landed:

- **pages[]** was computed from the competitors head-count result (data: null) — always empty, even with target_url prompts and matching cited sources.
- **verdict** got its competitorsTracked from the prompts query (no count requested → 0) — every report degraded to "no-competitors" regardless of how many competitors were registered.

One-line fix (swap the two destructure positions) plus a regression test that routes both results to their consumers: a prompt with target_url + a citing source must produce a page stat, and a non-zero competitor count must keep the verdict off "no-competitors".

🤖 Generated with [Claude Code](https://claude.com/claude-code)