### PR TITLE
informativeRate: page-targeted answers don't count against naming quality

### DIFF
--- a/lib/api-service.test.ts
+++ b/lib/api-service.test.ts
@@ -314,6 +314,42 @@ describe("getRunReport", () => {
     // 3 competitors registered + informative answers → never "no-competitors".
     expect(report!.verdict).not.toBe("no-competitors");
   });
+
+  // Page-targeted answers are how-to explanations that name nobody; counting
+  // them in informativeRate flipped healthy runs to thin-sample the moment a
+  // brand started tracking pages.
+  it("excludes page-targeted responses from the naming-quality basis", async () => {
+    const db = fakeDb({
+      runs: () => ({ data: makeRun({}) }),
+      projects: () => ({ data: PROJECT }),
+      responses: () => ({
+        count: 4,
+        data: [
+          { id: "resp-1", topic_id: null, prompt_id: "ask-1" },
+          { id: "resp-2", topic_id: null, prompt_id: "ask-1" },
+          { id: "resp-3", topic_id: null, prompt_id: "page-1" },
+          { id: "resp-4", topic_id: null, prompt_id: "page-1" },
+        ],
+      }),
+      // One naming answer among the two non-page responses; page answers name nobody.
+      mentions: () => ({ data: [makeMention({ response_id: "resp-1" })] }),
+      prompts: () => ({
+        data: [
+          { id: "ask-1", target_url: null },
+          { id: "page-1", target_url: "https://blog.example.com/posts/guide" },
+        ],
+      }),
+      competitors: () => ({ count: 2 }),
+    });
+
+    const report = await getRunReport(db as never, "user-1", "run-1");
+    // Basis is the 2 non-page responses → 1/2 informative, not 1/4.
+    expect(report!.quality.totalResponses).toBe(2);
+    expect(report!.quality.informativeRate).toBe(0.5);
+    // The run's own total stays the full 4.
+    expect(report!.totalResponses).toBe(4);
+    expect(report!.verdict).not.toBe("thin-sample");
+  });
 });
 
 describe("triggerRunForProject", () => {

--- a/lib/api-service.ts
+++ b/lib/api-service.ts
@@ -891,7 +891,25 @@ export async function getRunReport(
   }));
 
   const summary = computeRunSummary(mentions, totalResponses, project.brand_name);
-  const quality = computeMeasurementQuality(mentions, totalResponses);
+  // Page-targeted prompts (target_url) measure RETRIEVAL of one page — their
+  // answers are how-to explanations that legitimately name nobody. Counting
+  // them in the naming-quality basis would read "you added page tracking" as
+  // "your prompts can't elicit names" and flip healthy runs to thin-sample,
+  // so informativeRate is computed over the non-page responses only.
+  // (summary/entities/citations keep the full run — only naming quality has a
+  // reduced basis, and quality.totalResponses reports that basis.)
+  const pagePromptIds = new Set(
+    ((promptTargetRows ?? []) as { id: string; target_url: string | null }[])
+      .filter((p) => p.target_url)
+      .map((p) => p.id),
+  );
+  const pageResponseIds = new Set(
+    responseRows.filter((r) => r.prompt_id && pagePromptIds.has(r.prompt_id)).map((r) => r.id),
+  );
+  const quality = computeMeasurementQuality(
+    mentions.filter((m) => !pageResponseIds.has(m.response_id)),
+    Math.max(0, totalResponses - pageResponseIds.size),
+  );
 
   return {
     run,
@@ -1243,6 +1261,9 @@ export async function getProjectHistory(
     const totalResponses = run.completed_count;
     const summary = computeRunSummary(mentions, totalResponses, project.brand_name);
     const citations = computeCitationStats(sourcesByRun.get(run.id) ?? [], totalResponses);
+    // NB: history's informativeRate is portfolio-wide (page-targeted responses
+    // included) — this endpoint deliberately avoids per-run response/prompt
+    // joins to stay cheap. The run REPORT carries the naming-basis rate.
     const quality = computeMeasurementQuality(mentions, totalResponses);
     return {
       runId: run.id,


### PR DESCRIPTION
Observed on a live project: adding page-targeted prompts (target_url) flipped the same portfolio from real-gap to thin-sample on one engine — the page probes' how-to answers name nobody, which is correct behavior for them, but they were diluting informativeRate below the 0.5 gate.

The run report now computes naming quality over non-page responses only (quality.totalResponses reports that basis); the verdict follows. Everything else — run totals, summary, entities, citations, pages — keeps the full response set. History's informativeRate stays portfolio-wide by design (that endpoint deliberately avoids per-run response/prompt joins; documented inline).

Regression test: 4 responses (2 page-targeted naming nobody, 2 ask-shaped with 1 naming) → informativeRate 0.5, not 0.25, and no thin-sample verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)