### PR TITLE
Link-aware measurement: links are citations, not mentions

### DIFF
--- a/lib/api-service.ts
+++ b/lib/api-service.ts
@@ -926,6 +926,7 @@ export async function getRunReport(
       informativeRate: quality.informativeRate,
       brandMentioned: summary.brandResponsesMentioned > 0,
       competitorsTracked: competitorCount ?? 0,
+      informativeBasis: quality.totalResponses,
     }),
     pages: computePageStats(
       (promptTargetRows ?? []) as { id: string; target_url: string | null }[],

--- a/lib/engine.test.ts
+++ b/lib/engine.test.ts
@@ -35,3 +35,15 @@ describe("isOwnedDomain", () => {
     expect(isOwnedDomain("", "notion.so")).toBe(false);
   });
 });
+
+describe("extractInlineLinks", () => {
+  it("extracts markdown targets and bare URLs, dedupes by page, trims punctuation", async () => {
+    const { extractInlineLinks } = await import("@/lib/engine");
+    const links = extractInlineLinks(
+      "See [the guide](https://blog.example.com/posts/guide?utm_source=openai) and https://blog.example.com/posts/guide. Also https://other.io/x.",
+    );
+    expect(links).toHaveLength(2);
+    expect(links[0].domain).toBe("blog.example.com");
+    expect(links[1].url).toBe("https://other.io/x");
+  });
+});

--- a/lib/engine.ts
+++ b/lib/engine.ts
@@ -2,6 +2,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import type { ActorType, Competitor, LogChannel, Project, Prompt, Provider } from "@/lib/types";
 import { runQuery, analyzeResponse, humanError, type AnalyzeEntity } from "@/lib/llm";
 import { detectMention, brandTerms } from "@/lib/mentions";
+import { pageKey } from "@/lib/metrics";
 import { modelLabel } from "@/lib/models";
 import { logActivity } from "@/lib/activity";
 
@@ -31,6 +32,20 @@ export function hostOf(domain: string | null): string {
 }
 
 // A cited source is "owned" when its domain is, or is a subdomain of, the host.
+/** Links written inline in the answer text (markdown targets + bare URLs),
+ *  deduped by page identity, trailing punctuation trimmed. These are real
+ *  citations some engines never repeat in their structured source list. */
+export function extractInlineLinks(text: string): { url: string; domain: string }[] {
+  const found = new Map<string, { url: string; domain: string }>();
+  for (const match of text.matchAll(/\bhttps?:\/\/[^\s<>"')\]]+/gi)) {
+    const url = match[0].replace(/[.,;:!?]+$/, "");
+    const key = pageKey(url);
+    if (!key || found.has(key)) continue;
+    found.set(key, { url, domain: hostOf(url) });
+  }
+  return [...found.values()];
+}
+
 export function isOwnedDomain(sourceDomain: string, ownedHost: string): boolean {
   if (!ownedHost || !sourceDomain) return false;
   return sourceDomain === ownedHost || sourceDomain.endsWith(`.${ownedHost}`);
@@ -230,18 +245,37 @@ export async function resumeRun(prepared: PreparedRun, params: ExecuteRunParams)
       const responseId = respRow.id as string;
       succeeded++;
 
-      // Store the web sources the model cited (native web search).
-      if (sources.length > 0) {
-        const sourceRows = sources.map((s) => ({
-          response_id: responseId,
-          run_id: runId,
-          project_id: project.id,
-          url: s.url,
-          domain: s.domain,
-          title: s.title,
-          snippet: s.snippet,
-          is_owned: ownedHosts.some((h) => isOwnedDomain(s.domain, h)),
-        }));
+      // Store the web sources the model cited: the provider's structured
+      // citations PLUS links written inline in the answer text. Some engines
+      // (ChatGPT especially) cite as markdown links without repeating them in
+      // the structured list — skipping those under-counts citations, and the
+      // pages it misses are often the very ones being tracked. Inline links
+      // are deduped against the structured set by page identity (host+path).
+      const structuredKeys = new Set(sources.map((s) => pageKey(s.url)).filter(Boolean));
+      const inline = extractInlineLinks(answer).filter((l) => !structuredKeys.has(pageKey(l.url)));
+      if (sources.length > 0 || inline.length > 0) {
+        const sourceRows = [
+          ...sources.map((s) => ({
+            response_id: responseId,
+            run_id: runId,
+            project_id: project.id,
+            url: s.url,
+            domain: s.domain,
+            title: s.title,
+            snippet: s.snippet,
+            is_owned: ownedHosts.some((h) => isOwnedDomain(s.domain, h)),
+          })),
+          ...inline.map((l) => ({
+            response_id: responseId,
+            run_id: runId,
+            project_id: project.id,
+            url: l.url,
+            domain: l.domain,
+            title: null,
+            snippet: null,
+            is_owned: ownedHosts.some((h) => isOwnedDomain(l.domain, h)),
+          })),
+        ];
         await supabase.from("sources").insert(sourceRows);
       }
 

--- a/lib/mentions.test.ts
+++ b/lib/mentions.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { brandTerms, detectMention, stripLinkSurfaces } from "@/lib/mentions";
+
+describe("stripLinkSurfaces", () => {
+  it("blanks markdown links, bare URLs and www hosts — preserving length", () => {
+    const text = "See [runlayer.com](https://llms.runlayer.com/blog/x) and https://acme.io/docs, or www.acme.io now.";
+    const stripped = stripLinkSurfaces(text);
+    expect(stripped.length).toBe(text.length);
+    expect(stripped).not.toMatch(/runlayer|acme/i);
+    expect(stripped).toContain("See ");
+    expect(stripped).toContain(" now.");
+  });
+});
+
+describe("detectMention vs link surfaces", () => {
+  const terms = brandTerms("Runlayer", [], "runlayer.com");
+
+  it("a brand string inside a link is a citation, not a mention", () => {
+    const hit = detectMention(
+      "You can stop shadow MCP usage ([runlayer.com](https://llms.runlayer.com/blog/runlayer-vs-arcade?x=1)).",
+      terms,
+    );
+    expect(hit.mentioned).toBe(false);
+  });
+
+  it("prose naming still counts, even next to a link", () => {
+    const hit = detectMention(
+      "Runlayer is one option here — see https://llms.runlayer.com/blog/runlayer-vs-arcade for a comparison.",
+      terms,
+    );
+    expect(hit.mentioned).toBe(true);
+    expect(hit.count).toBe(1); // the URL occurrences don't inflate the count
+  });
+
+  it("brands whose NAME is a domain keep matching in prose", () => {
+    const hit = detectMention("For search, You.com is a solid pick.", ["You.com"]);
+    expect(hit.mentioned).toBe(true);
+  });
+});

--- a/lib/mentions.ts
+++ b/lib/mentions.ts
@@ -27,11 +27,29 @@ function buildRegex(terms: string[]): RegExp | null {
   return new RegExp(pattern, "gi");
 }
 
+/**
+ * Link surfaces aren't prose naming. A brand string inside a URL, a markdown
+ * link (text OR target — link text is usually the URL itself), or a
+ * scheme-less www host means the answer LINKED a page — that's a citation,
+ * tracked through sources — not that it NAMED the brand. Counting it as a
+ * mention once minted a first-mention milestone off "[brand.com](https://…)".
+ * Matched spans are blanked with spaces so positions in the original text
+ * stay valid.
+ */
+export function stripLinkSurfaces(text: string): string {
+  const blank = (m: string) => " ".repeat(m.length);
+  return text
+    .replace(/\[([^\]]*)\]\(([^)]*)\)/g, blank) // whole markdown links
+    .replace(/\bhttps?:\/\/[^\s<>"')\]]+/gi, blank) // bare URLs
+    .replace(/\bwww\.[^\s<>"')\]]+/gi, blank); // scheme-less www hosts
+}
+
 export function detectMention(text: string, terms: string[]): MentionHit {
   const absent: MentionHit = { mentioned: false, count: 0, firstPosition: -1 };
   if (!text) return absent;
   const re = buildRegex(terms);
   if (!re) return absent;
+  text = stripLinkSurfaces(text);
 
   let count = 0;
   let firstIndex = -1;

--- a/lib/metrics.test.ts
+++ b/lib/metrics.test.ts
@@ -220,6 +220,24 @@ describe("computeMeasurementQuality", () => {
   });
 });
 
+describe("measurementVerdict interval-aware thin-sample gate", () => {
+  const base = { totalResponses: 30, brandMentioned: false, competitorsTracked: 3 };
+
+  it("a borderline rate on a real sample is not thin — the interval clears the floor", () => {
+    // 14/30 informative: point rate 0.47 (< 0.5) but Wilson upper ~0.64.
+    expect(measurementVerdict({ ...base, informativeRate: 0.47, informativeBasis: 30 })).toBe("real-gap");
+  });
+
+  it("a confidently uninformative sample still reads thin-sample", () => {
+    // 6/30 informative: Wilson upper ~0.36 — the zero measures nothing.
+    expect(measurementVerdict({ ...base, informativeRate: 0.2, informativeBasis: 30 })).toBe("thin-sample");
+  });
+
+  it("without a basis the point-rate gate applies (old reports)", () => {
+    expect(measurementVerdict({ ...base, informativeRate: 0.47 })).toBe("thin-sample");
+  });
+});
+
 describe("measurementVerdict", () => {
   const base = {
     totalResponses: 20,

--- a/lib/metrics.ts
+++ b/lib/metrics.ts
@@ -276,10 +276,21 @@ export function measurementVerdict(input: {
   informativeRate: number;
   brandMentioned: boolean;
   competitorsTracked: number;
+  /** The naming-quality sample behind informativeRate. When provided, the
+   *  thin-sample gate becomes interval-aware: a run reads thin-sample only
+   *  when the sample is CONFIDENTLY uninformative (Wilson upper bound below
+   *  the floor), so a 0.47 on 30 answers doesn't flap a verdict that a 0.50
+   *  would have passed. */
+  informativeBasis?: number;
 }): MeasurementVerdict {
   if (input.totalResponses === 0) return "no-data";
   if (input.competitorsTracked === 0) return "no-competitors";
-  if (input.informativeRate < LOW_INFORMATIVE_RATE) return "thin-sample";
+  const thin =
+    input.informativeBasis && input.informativeBasis > 0
+      ? wilsonInterval(Math.round(input.informativeRate * input.informativeBasis), input.informativeBasis).high <
+        LOW_INFORMATIVE_RATE
+      : input.informativeRate < LOW_INFORMATIVE_RATE;
+  if (thin) return "thin-sample";
   if (!input.brandMentioned) return "real-gap";
   return "healthy";
 }


### PR DESCRIPTION
Live review of real runs surfaced three measurement gaps, fixed together because they're one story — what a link in an answer means:

1. **Mentions**: a brand string inside a markdown link/URL minted a first-mention milestone ("[brand.com](https://…)"). Link surfaces (markdown links whole, bare URLs, www hosts) are now blanked before mention matching, length-preserving. Prose naming beside a link still counts; dotted brand names (You.com) still match in prose.
2. **Citations**: engines (ChatGPT especially) cite pages as inline markdown links they never repeat in the structured source list — those are now extracted and stored as sources, deduped by page identity (host+path), so citation stats and per-page cited-hit rates stop under-counting the very pages being tracked.
3. **Verdicts**: with the naming basis available, thin-sample becomes interval-aware — only a Wilson-upper-bound-below-floor sample reads thin, so borderline rates (0.47 on 30 answers) stop flapping against the hard 0.5 gate. Callers without a basis keep the old point-rate behavior.

Tests for all three (link-vs-prose cases, dedupe/trim, boundary rates). Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)