### PR TITLE
Common-word domain labels never become brand terms

### DIFF
--- a/lib/mentions.test.ts
+++ b/lib/mentions.test.ts
@@ -37,3 +37,12 @@ describe("detectMention vs link surfaces", () => {
     expect(hit.mentioned).toBe(true);
   });
 });
+
+describe("common-word domain labels never become terms", () => {
+  it("you.com does not make 'you' a brand term", () => {
+    const terms = brandTerms("You.com", [], "you.com");
+    expect(terms).not.toContain("you");
+    expect(detectMention("Here is what you should do.", terms).mentioned).toBe(false);
+    expect(detectMention("You.com is a solid AI search pick.", terms).mentioned).toBe(true);
+  });
+});

--- a/lib/mentions.ts
+++ b/lib/mentions.ts
@@ -71,6 +71,15 @@ export function detectMention(text: string, terms: string[]): MentionHit {
 // Common second-level public-suffix labels (so "acme.co.uk" -> "acme", not "co").
 const PUBLIC_SLD_LABELS = new Set(["co", "com", "org", "net", "gov", "edu", "ac"]);
 
+// Domain labels that are ordinary English words match everywhere — "you"
+// (you.com) as a word-boundary term reads a ~100% mention rate off every
+// answer's prose. Such labels never become terms; the brand still matches via
+// its name and aliases ("You.com").
+const COMMON_WORD_LABELS = new Set([
+  "you", "the", "and", "for", "are", "can", "get", "one", "now", "how",
+  "who", "new", "all", "our", "out", "use", "app", "web", "here", "there", "about",
+]);
+
 // Convenience: the full term set for a brand / competitor.
 export function brandTerms(brandName: string, aliases: string[], domain?: string | null): string[] {
   const terms = [brandName, ...aliases];
@@ -93,7 +102,7 @@ export function brandTerms(brandName: string, aliases: string[], domain?: string
     } else if (labels.length === 1) {
       sld = labels[0];
     }
-    if (sld && sld.length >= 2) terms.push(sld);
+    if (sld && sld.length >= 3 && !COMMON_WORD_LABELS.has(sld)) terms.push(sld);
   }
   return terms;
 }


### PR DESCRIPTION
'you' from you.com as a word-boundary mention term matches nearly every answer's prose — a ~100% fake mention rate from day one (caught in pre-launch review of a real brand list). Ordinary-English-word labels are excluded and the label floor rises to 2→3 chars; brands still match via name + aliases. Regression-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)