### PR TITLE
Give an interrupted run a terminal state

### DIFF
--- a/app/api/cron/run/route.ts
+++ b/app/api/cron/run/route.ts
@@ -1,7 +1,13 @@
 import crypto from "node:crypto";
 import { NextResponse } from "next/server";
 import { createServiceClient } from "@/lib/supabase/server";
-import { executeRun } from "@/lib/engine";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import {
+  executeRun,
+  settleAbandonedRun,
+  ABANDONED_RUN_MS,
+  INTERRUPTED_RUN_ERROR,
+} from "@/lib/engine";
 import { decryptSecret } from "@/lib/crypto";
 import type { Project } from "@/lib/types";
 
@@ -27,6 +33,36 @@ interface ProjectResult {
   totalResponses?: number;
 }
 
+/**
+ * Settle runs that nothing is executing any more.
+ *
+ * A run row is written "running" up front and settled by the code that executes
+ * it — so if that process dies mid-flight, nothing ever settles it. Background
+ * runs made this reachable in normal operation: they outlive the response but
+ * not the invocation, so a portfolio large enough to exceed maxDuration leaves
+ * the row "running" permanently, and GET /v1/runs/:id/status reports that to a
+ * poller forever.
+ *
+ * This is the only place that can fix a row whose executor is already gone, so
+ * it runs on every tick regardless of whether any project is due. Returns what
+ * it settled so an operator can see it in the response rather than inferring it
+ * from a client complaint.
+ */
+async function sweepAbandonedRuns(supabase: SupabaseClient): Promise<string[]> {
+  const cutoff = new Date(Date.now() - ABANDONED_RUN_MS).toISOString();
+  const { data } = await supabase
+    .from("runs")
+    .select("id")
+    .eq("status", "running")
+    .lt("started_at", cutoff);
+
+  const settled: string[] = [];
+  for (const row of (data ?? []) as { id: string }[]) {
+    if (await settleAbandonedRun(supabase, row.id, INTERRUPTED_RUN_ERROR)) settled.push(row.id);
+  }
+  return settled;
+}
+
 // Scheduler entrypoint. Runs every due project. Supports POST (manual curl)
 // and GET (Vercel Cron, which sends the Authorization: Bearer $CRON_SECRET header).
 // Constant-time comparison so the secret can't be probed via response timing.
@@ -44,13 +80,20 @@ async function handle(request: Request) {
 
   const supabase = createServiceClient();
 
+  // Before anything else, and unconditionally: a stranded row is stranded
+  // whether or not a project happens to be due this tick.
+  const sweptRunIds = await sweepAbandonedRuns(supabase);
+
   const { data: projectRows, error: projErr } = await supabase
     .from("projects")
     .select("*")
     .neq("schedule", "off");
 
   if (projErr) {
-    return NextResponse.json({ error: projErr.message }, { status: 500 });
+    return NextResponse.json(
+      { error: projErr.message, sweptRuns: sweptRunIds },
+      { status: 500 },
+    );
   }
 
   const projects = (projectRows ?? []) as Project[];
@@ -102,7 +145,7 @@ async function handle(request: Request) {
     }
   }
 
-  return NextResponse.json({ processed: results });
+  return NextResponse.json({ processed: results, sweptRuns: sweptRunIds });
 }
 
 export async function POST(request: Request) {

--- a/lib/api-service.test.ts
+++ b/lib/api-service.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Mention, Project, Run } from "@/lib/types";
 import {
+  getRunStatus,
   createProject,
   createPrompts,
   getOwnedProject,
@@ -21,7 +22,15 @@ vi.mock("@/lib/trial", () => ({
   resolveRunKeyFor: vi.fn(),
   engineKeyMessage: vi.fn(),
 }));
-vi.mock("@/lib/engine", () => ({ executeRun: vi.fn() }));
+// Only the run EXECUTORS are stubbed. The abandoned-run helpers stay real:
+// they are the thing under test in getRunStatus, and mocking them would assert
+// that we called something rather than that a stranded row gets settled.
+vi.mock("@/lib/engine", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/engine")>()),
+  executeRun: vi.fn(),
+  prepareRun: vi.fn(),
+  resumeRun: vi.fn(),
+}));
 
 // ------------------------------------------------------------------
 // A tiny fake of the supabase query builder: per-table handlers receive the
@@ -884,5 +893,53 @@ describe("getRunResponses", () => {
       },
     ]);
     expect(second).toMatchObject({ prompt_text: null, sources: [], mentions: [] });
+  });
+});
+
+describe("getRunStatus", () => {
+  const longAgo = new Date(Date.now() - 60 * 60_000).toISOString();
+  const justNow = new Date(Date.now() - 30_000).toISOString();
+
+  it("returns a live run untouched", async () => {
+    const db = fakeDb({
+      runs: () => ({ data: makeRun({ status: "running", started_at: justNow, finished_at: null }) }),
+      projects: () => ({ data: PROJECT }),
+    });
+    const run = await getRunStatus(db as never, "user-1", "run-1");
+    expect(run?.status).toBe("running");
+    // Nothing was written: a run in flight is not the sweeper's business.
+    expect(db.queries.some((q) => q.modifiers.some(([m]) => m === "update"))).toBe(false);
+  });
+
+  // The bug this closes: a background run outlives its invocation, the process
+  // is killed before it can settle its own row, and the row reads "running"
+  // forever — so a client polling this endpoint polls forever too.
+  it("settles a run that outlived any invocation that could finish it", async () => {
+    const db = fakeDb({
+      // The guarded update returns the rows it changed; the read returns the
+      // row. Same table, two shapes, so branch on which one this is.
+      runs: (q) =>
+        q.modifiers.some(([m]) => m === "update")
+          ? { data: [{ id: "run-1" }] }
+          : { data: makeRun({ status: "running", started_at: longAgo, finished_at: null }) },
+      projects: () => ({ data: PROJECT }),
+    });
+    const run = await getRunStatus(db as never, "user-1", "run-1");
+    expect(run?.status).toBe("failed");
+    expect(run?.error).toMatch(/interrupted/i);
+    expect(run?.finished_at).toBeTruthy();
+
+    const update = db.queries.find((q) => q.modifiers.some(([m]) => m === "update"));
+    expect(update?.table).toBe("runs");
+    // Guarded, so a run that settled itself in the meantime keeps its result.
+    expect(update?.filters).toContainEqual(["eq", "status", "running"]);
+  });
+
+  it("still refuses a run that isn't the caller's", async () => {
+    const db = fakeDb({
+      runs: () => ({ data: makeRun({ status: "running", started_at: longAgo }) }),
+      projects: () => ({ data: null }),
+    });
+    expect(await getRunStatus(db as never, "someone-else", "run-1")).toBeNull();
   });
 });

--- a/lib/api-service.ts
+++ b/lib/api-service.ts
@@ -29,7 +29,16 @@ import {
 import { waitUntil } from "@vercel/functions";
 import { normalizeCompetitorList } from "@/lib/competitors";
 import { discoverCompanies, type DiscoveredCompany } from "@/lib/discover";
-import { executeRun, prepareRun, resumeRun, type RunContext, type RunResult } from "@/lib/engine";
+import {
+  executeRun,
+  prepareRun,
+  resumeRun,
+  isAbandoned,
+  settleAbandonedRun,
+  INTERRUPTED_RUN_ERROR,
+  type RunContext,
+  type RunResult,
+} from "@/lib/engine";
 import { pickDefaultProvider, resolveRunKeyFor, engineKeyMessage } from "@/lib/trial";
 import { isProvider, resolveEngine, PROVIDERS } from "@/lib/models";
 
@@ -1131,9 +1140,18 @@ export async function triggerRunForProject(
     // waitUntil keeps the serverless invocation alive past the response; the
     // run settles its own row (completed/failed) exactly as in the sync path.
     waitUntil(
-      resumeRun(prepared, runParams).catch(() => {
-        // resumeRun never rejects for per-prompt failures; this guards the
-        // run-row settle itself so a crash can't take down the invocation.
+      resumeRun(prepared, runParams).catch(async (err) => {
+        // resumeRun never rejects for per-prompt failures, so reaching here
+        // means the settle itself failed — and swallowing that left the row
+        // reading "running" forever, with the status endpoint reporting it to
+        // a poller that would never see a terminal state. Settle it here
+        // instead. Only a killed invocation can still strand a row, which is
+        // what the cron sweeper is for.
+        await settleAbandonedRun(
+          supabase,
+          prepared.runId,
+          `The run stopped unexpectedly: ${err instanceof Error ? err.message : "unknown error"}`,
+        ).catch(() => {});
       }),
     );
     return {
@@ -1167,6 +1185,22 @@ export async function getRunStatus(
   if (!run) return null;
   const project = await getOwnedProject(supabase, userId, run.project_id);
   if (!project) return null;
+
+  // Settle a provably-dead run on the way past. The cron sweeper catches these
+  // too, but a poller shouldn't have to wait for the next scheduled tick to be
+  // told the thing it is polling is over — this endpoint exists precisely to
+  // answer "is it done yet", and "running" is a wrong answer for a run nothing
+  // is executing. The write is guarded and idempotent, so concurrent pollers
+  // and the sweeper can all race it harmlessly.
+  if (isAbandoned(run)) {
+    const settled = await settleAbandonedRun(supabase, run.id, INTERRUPTED_RUN_ERROR);
+    if (settled) {
+      return { ...run, status: "failed", error: INTERRUPTED_RUN_ERROR, finished_at: new Date().toISOString() };
+    }
+    // Lost the race: someone else settled it. Re-read rather than report stale.
+    const { data: fresh } = await supabase.from("runs").select("*").eq("id", run.id).maybeSingle();
+    return (fresh as Run | null) ?? run;
+  }
   return run;
 }
 

--- a/lib/engine.test.ts
+++ b/lib/engine.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { hostOf, isOwnedDomain } from "@/lib/engine";
+import {
+  hostOf,
+  isOwnedDomain,
+  isAbandoned,
+  settleAbandonedRun,
+  ABANDONED_RUN_MS,
+} from "@/lib/engine";
 
 describe("hostOf", () => {
   it("normalizes a messy domain entry to a registrable host", () => {
@@ -45,5 +51,95 @@ describe("extractInlineLinks", () => {
     expect(links).toHaveLength(2);
     expect(links[0].domain).toBe("blog.example.com");
     expect(links[1].url).toBe("https://other.io/x");
+  });
+});
+
+describe("isAbandoned", () => {
+  const started = (msAgo: number) => ({
+    status: "running",
+    started_at: new Date(Date.now() - msAgo).toISOString(),
+  });
+
+  it("leaves a run alone while an invocation could still be working on it", () => {
+    expect(isAbandoned(started(0))).toBe(false);
+    expect(isAbandoned(started(4 * 60_000))).toBe(false);
+    // Right up to the threshold: never race a run that is merely slow.
+    expect(isAbandoned(started(ABANDONED_RUN_MS - 1000))).toBe(false);
+  });
+
+  it("flags a run that has outlived any invocation that could settle it", () => {
+    expect(isAbandoned(started(ABANDONED_RUN_MS + 1000))).toBe(true);
+    expect(isAbandoned(started(6 * 60 * 60_000))).toBe(true);
+  });
+
+  it("only ever considers running rows", () => {
+    const old = new Date(Date.now() - 24 * 60 * 60_000).toISOString();
+    expect(isAbandoned({ status: "completed", started_at: old })).toBe(false);
+    expect(isAbandoned({ status: "failed", started_at: old })).toBe(false);
+    expect(isAbandoned({ status: "pending", started_at: old })).toBe(false);
+  });
+
+  it("does not flag a running row with no start time", () => {
+    // Nothing can be concluded about its age; the alternative is failing runs
+    // at random on a row shape the writer never produces.
+    expect(isAbandoned({ status: "running", started_at: null })).toBe(false);
+  });
+
+  // The threshold has to sit above the platform ceiling every run route caps
+  // at (maxDuration = 300s), or the sweeper starts killing live runs.
+  it("is comfortably above the longest an invocation can last", () => {
+    expect(ABANDONED_RUN_MS).toBeGreaterThan(300_000);
+  });
+});
+
+describe("settleAbandonedRun", () => {
+  /** Records the filters a chained update was scoped by. */
+  function fakeDb(rows: { id: string }[]) {
+    const filters: [string, unknown][] = [];
+    let updated: Record<string, unknown> | null = null;
+    const db = {
+      from: () => ({
+        update: (values: Record<string, unknown>) => {
+          updated = values;
+          const chain = {
+            eq: (col: string, val: unknown) => {
+              filters.push([col, val]);
+              return chain;
+            },
+            select: async () => ({ data: rows }),
+          };
+          return chain;
+        },
+      }),
+    };
+    return { db: db as never, filters, updated: () => updated };
+  }
+
+  it("settles the row as failed, with the reason and a finish time", async () => {
+    const { db, updated } = fakeDb([{ id: "run-1" }]);
+    expect(await settleAbandonedRun(db, "run-1", "interrupted")).toBe(true);
+    expect(updated()).toMatchObject({ status: "failed", error: "interrupted" });
+    expect(typeof (updated() as { finished_at: string }).finished_at).toBe("string");
+  });
+
+  // The guard is the whole safety property: a run that settled itself between
+  // the sweeper's read and this write must not have its real result replaced
+  // by a failure.
+  it("only touches rows still marked running", async () => {
+    const { db, filters } = fakeDb([{ id: "run-1" }]);
+    await settleAbandonedRun(db, "run-1", "interrupted");
+    expect(filters).toContainEqual(["id", "run-1"]);
+    expect(filters).toContainEqual(["status", "running"]);
+  });
+
+  it("reports false when it changed nothing, so callers can't double-count", async () => {
+    const { db } = fakeDb([]);
+    expect(await settleAbandonedRun(db, "run-1", "interrupted")).toBe(false);
+  });
+
+  it("leaves completed_count alone — answers stored before the cut are real", async () => {
+    const { db, updated } = fakeDb([{ id: "run-1" }]);
+    await settleAbandonedRun(db, "run-1", "interrupted");
+    expect(Object.keys(updated() ?? {})).not.toContain("completed_count");
   });
 });

--- a/lib/engine.ts
+++ b/lib/engine.ts
@@ -76,6 +76,66 @@ export interface RunResult {
   error?: string;
 }
 
+/**
+ * How long a run may sit in "running" before it is treated as abandoned.
+ *
+ * A run cannot outlive the invocation executing it, and every route that starts
+ * one caps at maxDuration = 300s. So anything still "running" well past that is
+ * not slow, it is gone: the process was killed mid-flight and the code that
+ * settles the row never got to run. Three times the ceiling leaves room for a
+ * platform that is more generous than ours without ever racing a live run.
+ */
+export const ABANDONED_RUN_MS = 15 * 60 * 1000;
+
+/** True when a "running" row has outlived any invocation that could still be
+ *  working on it. Exported for tests and for callers that only want to report. */
+export function isAbandoned(run: { status: string; started_at: string | null }, now = Date.now()): boolean {
+  if (run.status !== "running") return false;
+  // No started_at is itself a broken row; created_at is not read here because
+  // the only writer of "running" sets started_at in the same insert.
+  if (!run.started_at) return false;
+  return now - new Date(run.started_at).getTime() > ABANDONED_RUN_MS;
+}
+
+/**
+ * Settle a run that will never finish itself.
+ *
+ * Every path that executes a run settles its own row on the way out — unless the
+ * process dies first, which is exactly what happens to a background run that
+ * outlives its serverless invocation. The row then reads "running" forever, and
+ * a client polling GET /v1/runs/:id/status polls forever with it: the status
+ * endpoint is a promise that the state is eventually terminal, and nothing was
+ * keeping that promise.
+ *
+ * Guarded on status = 'running' so it is idempotent and cannot race a run that
+ * settled itself between the read and this write — the loser of that race
+ * updates nothing rather than overwriting a real result with a failure.
+ * `completed_count` is deliberately left alone: answers stored before the
+ * interruption are real, and the run row should say how far it got.
+ */
+export async function settleAbandonedRun(
+  supabase: SupabaseClient,
+  runId: string,
+  reason: string,
+): Promise<boolean> {
+  const { data } = await supabase
+    .from("runs")
+    .update({
+      status: "failed",
+      finished_at: new Date().toISOString(),
+      error: reason,
+    })
+    .eq("id", runId)
+    .eq("status", "running")
+    .select("id");
+  return (data ?? []).length > 0;
+}
+
+/** What an interrupted run says for itself. Shared so the sweeper, the status
+ *  endpoint and the background catch can't describe it three different ways. */
+export const INTERRUPTED_RUN_ERROR =
+  "The run was interrupted before it finished — the server stopped executing it. Answers stored before that point were kept. Run it again to collect the rest.";
+
 export interface ExecuteRunParams {
   supabase: SupabaseClient;
   project: Project;


### PR DESCRIPTION
Follow-up to #46. A run row is written `"running"` up front and settled by whatever is executing it — so if that process dies first, **nothing ever settles it**. The row reads `"running"` forever, and `GET /v1/runs/:id/status`, the polling companion #46 introduced, reports that to a client forever with it. The status endpoint's whole promise is that the state eventually becomes terminal; nothing was keeping it.

### Why this is reachable in ordinary operation

`waitUntil` outlives the response but **not the invocation**, and every route that starts a run caps at `maxDuration = 300`. So a background run whose queries exceed ~5 minutes is killed mid-flight by design, and the code that settles the row never runs.

That isn't a pathological size. At `CONCURRENCY = 4` with web-search answers taking 10–30s each, forty answers is already ~200s — and a deliberately shaped probe portfolio (mention / citation / target / page probes, × replicates) clears forty answers easily. A well-behaved client polls the status endpoint until it sees a terminal state, so the visible symptom is a client that never stops polling and a dashboard row stuck on "running".

There was a second, smaller hole on the same path: the background `.catch()` swallowed a throw from `resumeRun` without settling anything, so an error inside the settle itself also stranded the row *and* discarded the reason.

### The fix

One primitive, three callers.

`settleAbandonedRun()` performs a `status = 'running'` **guarded** update, which makes it idempotent and makes the loser of a race change nothing rather than overwrite a real result with a failure. `completed_count` is deliberately untouched — answers stored before the interruption are real, and the row should say how far it got.

| Caller | Covers |
|---|---|
| background `.catch()` | a throw inside `resumeRun` (previously swallowed) |
| cron tick | rows whose executor is already gone — the only place that can fix these |
| `getRunStatus` | settles a provably-dead run as it reads it, so a poller learns it is over now rather than at the next scheduled tick |

The cron sweep runs **unconditionally**, before the due-project loop: a stranded row is stranded whether or not any project happens to be due this tick. It reports what it settled in the response (`sweptRuns`) so an operator sees it there rather than inferring it from a client complaint.

### Choices worth reviewing

- **15-minute threshold** — three times the 300s platform ceiling every run route caps at, so the sweeper can never race a run that is merely slow. A test pins `ABANDONED_RUN_MS > 300_000` so the two can't drift apart silently.
- **A `running` row with no `started_at` is left alone.** Nothing can be concluded about its age, and the alternative is failing runs at random on a row shape no writer produces.
- **Lazy settle inside a GET.** It is a write on a read path, which I'd normally avoid — but it is guarded, idempotent, and self-healing, and the alternative is telling a poller "running" about a run that is provably over.

### Testing

`451 tests, typecheck, lint, build` all clean. New coverage: the threshold boundary, the status-only filter, the missing-`started_at` case, the guard's filter set, the false return when nothing changed, and `getRunStatus` both leaving a live run untouched and settling a dead one.

Also verified against a real database rather than only the fakes — a stranded row settles with `completed_count` intact, an in-flight row beside it is untouched, a second settle returns `false`, and a late sweep against a run that completed in the meantime leaves it `completed`:

```
isAbandoned(stranded)  = true
isAbandoned(in-flight) = false
settle(stranded)       -> true
settle(stranded) again -> false (idempotent)
  stranded:  status=failed    completed_count=4  finished=yes
  in-flight: status=running   completed_count=1  finished=no
late sweep on a completed run -> changed=false, status still completed
```

### Not addressed here

Nothing resumes an interrupted run — it is marked failed and the operator re-runs it. Partial resumption would need per-prompt state the schema doesn't carry, and marking it honestly is the smaller correct step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
