### PR TITLE
Give the loading state a circle, and stop the button resizing under it

### DIFF
--- a/app/dashboard/competitors/competitors-client.tsx
+++ b/app/dashboard/competitors/competitors-client.tsx
@@ -247,8 +247,12 @@ export function CompetitorsClient({
               />
             </div>
             <div className="flex items-center gap-3 sm:col-span-3">
-              <Button type="submit" disabled={submitting || !name.trim()}>
-                {submitting && <Spinner />}
+              <Button
+                type="submit"
+                loading={submitting}
+                loadingText="Adding…"
+                disabled={!name.trim()}
+              >
                 Add competitor
               </Button>
               {error && <p className="text-sm text-terracotta-dark">{error}</p>}

--- a/app/dashboard/onboarding.tsx
+++ b/app/dashboard/onboarding.tsx
@@ -253,7 +253,9 @@ export function Onboarding() {
           This usually takes a minute or two.
         </p>
         <div className="mt-5">
-          <Spinner className="text-terracotta" />
+          {/* Page-level, not inline next to a label, so it carries the wait on
+              its own and is sized to be seen. */}
+          <Spinner className="h-6 w-6 text-terracotta" />
         </div>
       </div>
     );

--- a/app/dashboard/runs/run-now.tsx
+++ b/app/dashboard/runs/run-now.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Play } from "lucide-react";
-import { Button, Spinner } from "@/components/ui";
+import { Button } from "@/components/ui";
 
 export function RunNow({
   canRun,
@@ -45,16 +45,11 @@ export function RunNow({
 
   return (
     <div className="flex flex-col items-start gap-1.5 sm:items-end">
-      <Button onClick={run} disabled={disabled}>
-        {loading ? (
-          <>
-            <Spinner /> Running… this can take a minute
-          </>
-        ) : (
-          <>
-            <Play className="h-4 w-4" /> Run monitor now
-          </>
-        )}
+      {/* Just "Running…". The label used to read "Running… this can take a
+          minute", which roughly doubled the button's width the moment it was
+          clicked — the spinner already says a wait is underway. */}
+      <Button onClick={run} loading={loading} loadingText="Running…" disabled={disabled}>
+        <Play className="h-4 w-4" /> Run monitor now
       </Button>
 
       {keySource === "exhausted" && (

--- a/app/dashboard/settings/api-keys-manager.tsx
+++ b/app/dashboard/settings/api-keys-manager.tsx
@@ -138,9 +138,8 @@ export default function ApiKeysManager({ keys }: { keys: ApiKeyPublic[] }) {
           aria-label="API key name"
           className="max-w-xs"
         />
-        <Button type="submit" size="sm" disabled={creating}>
-          {creating ? <Spinner /> : <Plus className="h-3.5 w-3.5" />}
-          Create key
+        <Button type="submit" size="sm" loading={creating} loadingText="Creating…">
+          <Plus className="h-3.5 w-3.5" /> Create key
         </Button>
       </form>
 

--- a/app/dashboard/settings/keys-manager.tsx
+++ b/app/dashboard/settings/keys-manager.tsx
@@ -206,9 +206,14 @@ function ProviderCard({
               </button>
             </div>
             <div className="flex flex-wrap items-center gap-2">
-              <Button type="submit" size="sm" disabled={verifying || !apiKey.trim()}>
-                {verifying && <Spinner />}
-                {verifying ? "Verifying..." : "Save key"}
+              <Button
+                type="submit"
+                size="sm"
+                loading={verifying}
+                loadingText="Verifying…"
+                disabled={!apiKey.trim()}
+              >
+                Save key
               </Button>
               {editing && (
                 <Button

--- a/app/dashboard/settings/project-form.tsx
+++ b/app/dashboard/settings/project-form.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Check } from "lucide-react";
-import { Button, Input, Textarea, Select, Label, Spinner } from "@/components/ui";
+import { Button, Input, Textarea, Select, Label } from "@/components/ui";
 import { PROVIDER_LIST, PROVIDERS } from "@/lib/models";
 import { article } from "@/lib/utils";
 import type { Project, Provider, Schedule } from "@/lib/types";
@@ -285,9 +285,8 @@ export default function ProjectForm({
       {error && <p className="text-sm text-terracotta">{error}</p>}
 
       <div className="flex items-center gap-3">
-        <Button type="submit" disabled={saving}>
-          {saving && <Spinner />}
-          {saving ? "Saving..." : "Save changes"}
+        <Button type="submit" loading={saving} loadingText="Saving…">
+          Save changes
         </Button>
         {saved && !saving && (
           // A bare "Saved" was the whole complaint: an engine with no key

--- a/app/dashboard/topics/topics-client.tsx
+++ b/app/dashboard/topics/topics-client.tsx
@@ -88,9 +88,13 @@ export function TopicsClient({ topics, prompts, hasKey, providerLabel }: Props) 
               </div>
             </div>
             <div className="flex items-center gap-3">
-              <Button type="submit" disabled={creating || !name.trim()}>
-                {creating ? <Spinner /> : <Plus className="h-4 w-4" />}
-                {creating ? "Adding…" : "Add topic"}
+              <Button
+                type="submit"
+                loading={creating}
+                loadingText="Adding…"
+                disabled={!name.trim()}
+              >
+                <Plus className="h-4 w-4" /> Add topic
               </Button>
               {createError && <p className="text-sm text-terracotta-dark">{createError}</p>}
             </div>

--- a/components/ui.tsx
+++ b/components/ui.tsx
@@ -11,8 +11,13 @@ import { cn } from "@/lib/utils";
 type ButtonVariant = "primary" | "secondary" | "ghost" | "danger";
 type ButtonSize = "sm" | "md" | "lg";
 
+// `transition-colors`, not `transition-all`. A button's label changes width when
+// it swaps to a loading state ("Save changes" -> "Saving..."), and `all` animates
+// the resulting width and height too: the button crawls to its new size, and
+// mid-transition it reads as two overlapping buttons with two overlapping labels.
+// Nothing here needs a layout property animated — only the hover/focus colours do.
 const buttonBase =
-  "inline-flex items-center justify-center gap-2 rounded font-medium tracking-tight transition-all disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus-visible:ring-2 focus-visible:ring-terracotta/40 focus-visible:ring-offset-2 focus-visible:ring-offset-paper";
+  "inline-flex items-center justify-center gap-2 rounded font-medium tracking-tight transition-colors disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus-visible:ring-2 focus-visible:ring-terracotta/40 focus-visible:ring-offset-2 focus-visible:ring-offset-paper";
 
 const buttonVariants: Record<ButtonVariant, string> = {
   primary: "bg-ink text-paper hover:bg-ink/90 shadow-sm",
@@ -31,6 +36,10 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: ButtonVariant;
   size?: ButtonSize;
   href?: string;
+  /** In flight: shows a spinner and blocks input. */
+  loading?: boolean;
+  /** What to say while loading. Defaults to the idle label. */
+  loadingText?: ReactNode;
 }
 
 export function Button({
@@ -39,6 +48,9 @@ export function Button({
   href,
   className,
   children,
+  loading,
+  loadingText,
+  disabled,
   ...props
 }: ButtonProps) {
   const classes = cn(buttonBase, buttonVariants[variant], buttonSizes[size], className);
@@ -50,9 +62,60 @@ export function Button({
     );
   }
   return (
-    <button className={classes} {...props}>
-      {children}
+    <button
+      className={classes}
+      disabled={disabled || loading}
+      aria-busy={loading || undefined}
+      {...props}
+    >
+      {loading === undefined ? children : <ButtonLabel loading={loading} loadingText={loadingText}>{children}</ButtonLabel>}
     </button>
+  );
+}
+
+/**
+ * Both labels, stacked in one grid cell, with the inactive one hidden by
+ * `visibility` rather than unmounted.
+ *
+ * The button is therefore always as wide as its widest state, so entering and
+ * leaving the loading state moves nothing — no reflow of the row it sits in, no
+ * width for a transition to animate, and no window in which two labels can be
+ * painted at once. Rendering only the active label would be simpler and is what
+ * the call sites used to do by hand; it is also what made the button resize
+ * under the user's cursor every time they saved.
+ */
+function ButtonLabel({
+  loading,
+  loadingText,
+  children,
+}: {
+  loading: boolean;
+  loadingText?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <span className="grid place-items-center">
+      <span
+        className={cn(
+          "col-start-1 row-start-1 inline-flex items-center gap-2",
+          loading && "invisible",
+        )}
+      >
+        {children}
+      </span>
+      <span
+        className={cn(
+          "col-start-1 row-start-1 inline-flex items-center gap-2",
+          !loading && "invisible",
+        )}
+        // Hidden from assistive tech when idle; when loading, aria-busy on the
+        // button plus this text is what announces the state.
+        aria-hidden={!loading}
+      >
+        <Spinner />
+        {loadingText ?? children}
+      </span>
+    </span>
   );
 }
 
@@ -223,14 +286,42 @@ export function EmptyState({
   );
 }
 
+/**
+ * Indeterminate loading indicator: a circular track with a rotating arc.
+ *
+ * Was a `rounded-sm` bordered box with a transparent top edge, which is the
+ * cheap CSS trick for a spinner and looks like exactly what it is — a square
+ * corner tumbling end over end. Two things fix that. An actual circle, so the
+ * silhouette doesn't change as it turns, and a low-opacity full ring behind the
+ * arc, which gives the arc a path to travel along: without it the eye reads a
+ * shape flickering, with it the eye reads rotation.
+ *
+ * `shrink-0` because this is nearly always a flex child next to a label, and a
+ * shrinkable circle becomes an oval on a narrow button.
+ *
+ * Sized and coloured through `className` (height/width and text colour), since
+ * it draws with currentColor and inherits from whatever it sits inside.
+ */
 export function Spinner({ className }: { className?: string }) {
   return (
-    <span
+    <svg
+      viewBox="0 0 16 16"
+      fill="none"
+      // Slower rather than stopped under reduced motion: a frozen spinner is
+      // indistinguishable from a hung request, which is worse than the motion.
       className={cn(
-        "inline-block h-4 w-4 animate-spin rounded-sm border-2 border-current border-t-transparent",
+        "h-4 w-4 shrink-0 animate-spin [animation-duration:0.7s] motion-reduce:[animation-duration:2.4s]",
         className,
       )}
       aria-hidden
-    />
+    >
+      <circle cx="8" cy="8" r="6.5" stroke="currentColor" strokeOpacity="0.25" strokeWidth="2" />
+      <path
+        d="M14.5 8A6.5 6.5 0 0 0 8 1.5"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+    </svg>
   );
 }


### PR DESCRIPTION
Two faults were visible in one screenshot of Settings: the spinner was a square, and the save button was painting two labels on top of each other. Different causes, so different fixes.


### The square

The old indicator was the cheap CSS trick — a `rounded-sm` box with a border, its top edge transparent, rotating. Rotate a square and its silhouette changes every frame, so the eye reads a corner tumbling rather than something turning.

It is now a circular arc over a low-opacity ring. The ring matters: it gives the arc a path to travel along, so the motion reads as rotation instead of a shape flickering. It draws in `currentColor` and takes its size from the class it is given, so it inherits from whatever it sits in. Under `prefers-reduced-motion` it slows to 2.4s rather than stopping — a frozen spinner is indistinguishable from a hung request.

### The overlap

Every button carried `transition-all`. When a label swapped to its loading text, the button's **width** was in that transition too, so it crawled to its new size — and mid-crawl that is two boxes with two labels.

Only colours transition now. The label swap moved into `Button` itself as `loading` / `loadingText`, which stacks both labels in one grid cell and hides the inactive one with `visibility`. The button is therefore always as wide as its widest state: there is no width for a transition to animate, and no window in which both labels can paint. It also sets `disabled` and `aria-busy` while in flight, so double-submit protection and the announcement stop being decisions each call site makes for itself.

### Call sites

Six buttons dropped their hand-rolled `{saving && <Spinner />}{saving ? … : …}`. Icon-only ones (trash, refresh) kept theirs — they never shifted, and they pick up the new circle for free.

`Run monitor now` gave up its `…this can take a minute` loading label, which had roughly doubled the button's width the moment it was clicked. The spinner already says a wait is underway.

### Testing

`451 tests, typecheck, lint, build` all clean.

The change is visual, and this repo has no browser driver, so it was checked by rendering both states side by side in the app's own palette rather than by asserting on markup: before/after at 16px and 24px, and a toggle that flips every converted button between idle and loading to confirm nothing shifts against a ruler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
