### PR TITLE
Count a brand named in a link, and stop aligning queries by position

### DIFF
--- a/lib/api-service.ts
+++ b/lib/api-service.ts
@@ -47,6 +47,35 @@ import { isProvider, resolveEngine, PROVIDERS } from "@/lib/models";
 // Lettertrace API key, so `supabase` is the service-role client: RLS is
 // bypassed and every query here scopes by userId explicitly.
 
+/**
+ * Run queries concurrently and get the results back BY NAME.
+ *
+ * `Promise.all` over a list of queries hands back a positional array, and a
+ * positional destructure of seven heterogeneous queries is a trap the type
+ * system cannot spring: every PostgREST response carries both `data` and
+ * `count`, so pulling `{ count }` out of a `select()` type-checks perfectly.
+ * That is how getRunReport once read its competitor head-count out of the
+ * prompts query and its prompt targets out of the competitors query — pages[]
+ * came back empty and every report read no-competitors, through a typed
+ * codebase, past review, all the way to staging.
+ *
+ * Keying the queries removes the failure mode rather than fixing one instance
+ * of it: inserting, removing or reordering a query here cannot misalign
+ * anything, because nothing is aligned by position. Concurrency is unchanged —
+ * the builders are lazy and all start together inside the Promise.all.
+ */
+async function allOf<T extends Record<string, PromiseLike<unknown>>>(
+  queries: T,
+): Promise<{ [K in keyof T]: Awaited<T[K]> }> {
+  const keys = Object.keys(queries) as (keyof T)[];
+  const settled = await Promise.all(keys.map((k) => queries[k]));
+  const out = {} as { [K in keyof T]: Awaited<T[K]> };
+  keys.forEach((key, i) => {
+    out[key] = settled[i] as Awaited<T[typeof key]>;
+  });
+  return out;
+}
+
 /** A project row trimmed to what the API exposes. */
 export function projectSummary(p: Project) {
   return {
@@ -854,29 +883,28 @@ export async function getRunReport(
   const project = await getOwnedProject(supabase, userId, run.project_id);
   if (!project) return null;
 
-  const [
-    { count },
-    { data: mentionRows },
-    { data: sourceRows },
-    { data: responseTopicRows },
-    { data: topicRows },
-    { data: promptTargetRows },
-    { count: competitorCount },
-  ] = await Promise.all([
-    supabase
+  const results = await allOf({
+    responseCount: supabase
       .from("responses")
       .select("id", { count: "exact", head: true })
       .eq("run_id", runId),
-    supabase.from("mentions").select("*").eq("run_id", runId),
-    supabase.from("sources").select("response_id, url, is_owned").eq("run_id", runId),
-    supabase.from("responses").select("id, topic_id, prompt_id").eq("run_id", runId),
-    supabase.from("topics").select("id, name").eq("project_id", run.project_id),
-    supabase.from("prompts").select("id, target_url").eq("project_id", run.project_id),
-    supabase
+    mentions: supabase.from("mentions").select("*").eq("run_id", runId),
+    sources: supabase.from("sources").select("response_id, url, is_owned").eq("run_id", runId),
+    responseTopics: supabase.from("responses").select("id, topic_id, prompt_id").eq("run_id", runId),
+    topics: supabase.from("topics").select("id, name").eq("project_id", run.project_id),
+    promptTargets: supabase.from("prompts").select("id, target_url").eq("project_id", run.project_id),
+    competitors: supabase
       .from("competitors")
       .select("id", { count: "exact", head: true })
       .eq("project_id", run.project_id),
-  ]);
+  });
+  const { count } = results.responseCount;
+  const { data: mentionRows } = results.mentions;
+  const { data: sourceRows } = results.sources;
+  const { data: responseTopicRows } = results.responseTopics;
+  const { data: topicRows } = results.topics;
+  const { data: promptTargetRows } = results.promptTargets;
+  const { count: competitorCount } = results.competitors;
 
   const mentions = (mentionRows ?? []) as Mention[];
   const sources = (sourceRows ?? []) as Pick<Source, "response_id" | "url" | "is_owned">[];
@@ -994,21 +1022,20 @@ export async function getRunResponses(
   const project = await getOwnedProject(supabase, userId, run.project_id);
   if (!project) return null;
 
-  const [
-    { data: responseRows },
-    { data: sourceRows },
-    { data: mentionRows },
-    { data: promptRows },
-  ] = await Promise.all([
-    supabase
+  const results = await allOf({
+    responses: supabase
       .from("responses")
       .select("*")
       .eq("run_id", runId)
       .order("created_at", { ascending: true }),
-    supabase.from("sources").select("*").eq("run_id", runId),
-    supabase.from("mentions").select("*").eq("run_id", runId),
-    supabase.from("prompts").select("id, text").eq("project_id", run.project_id),
-  ]);
+    sources: supabase.from("sources").select("*").eq("run_id", runId),
+    mentions: supabase.from("mentions").select("*").eq("run_id", runId),
+    prompts: supabase.from("prompts").select("id, text").eq("project_id", run.project_id),
+  });
+  const { data: responseRows } = results.responses;
+  const { data: sourceRows } = results.sources;
+  const { data: mentionRows } = results.mentions;
+  const { data: promptRows } = results.prompts;
 
   const promptTextById = new Map(
     ((promptRows ?? []) as Pick<Prompt, "id" | "text">[]).map((p) => [p.id, p.text]),

--- a/lib/mentions.test.ts
+++ b/lib/mentions.test.ts
@@ -46,3 +46,50 @@ describe("common-word domain labels never become terms", () => {
     expect(detectMention("You.com is a solid AI search pick.", terms).mentioned).toBe(true);
   });
 });
+
+describe("markdown link labels", () => {
+  const terms = brandTerms("Vercel", [], "vercel.com");
+
+  // The shape this exists for: a ranked list where every brand name is a link.
+  // To the reader the brand is named — the label IS the prose.
+  it("counts the brand when it is the visible label", () => {
+    expect(detectMention("Try [Vercel](https://vercel.com) for Next.js.", terms).mentioned).toBe(true);
+    expect(detectMention("1. **[Vercel](https://vercel.com)** — best for Next.js.", terms).mentioned).toBe(true);
+  });
+
+  // ...but a label that reads as an address is a citation, which is what keeps
+  // a link from minting a first-mention milestone.
+  it("still ignores a label that is itself an address", () => {
+    expect(detectMention("See [vercel.com](https://vercel.com).", terms).mentioned).toBe(false);
+    expect(detectMention("See [vercel.com/docs](https://vercel.com/docs).", terms).mentioned).toBe(false);
+    expect(detectMention("See [https://vercel.com](https://vercel.com).", terms).mentioned).toBe(false);
+    expect(detectMention("See [www.vercel.com](https://vercel.com).", terms).mentioned).toBe(false);
+  });
+
+  it("never counts the link target, only the label", () => {
+    // One mention: the label. The target names the brand twice more.
+    const hit = detectMention("[Vercel](https://vercel.com/vercel-docs) is good.", terms);
+    expect(hit.count).toBe(1);
+  });
+
+  it("treats a label with prose around it as prose", () => {
+    expect(
+      detectMention("[Vercel — the hosting platform](https://vercel.com) is good.", terms).mentioned,
+    ).toBe(true);
+  });
+
+  // firstPosition drives prominence, so every transform here has to leave the
+  // surviving characters exactly where they were.
+  it("preserves length and label offsets", () => {
+    const text = "Try [Vercel](https://vercel.com) today.";
+    const stripped = stripLinkSurfaces(text);
+    expect(stripped.length).toBe(text.length);
+    expect(stripped.indexOf("Vercel")).toBe(text.indexOf("Vercel"));
+  });
+
+  it("handles an empty label without shifting anything", () => {
+    const text = "See [](https://vercel.com) here.";
+    expect(stripLinkSurfaces(text).length).toBe(text.length);
+    expect(detectMention(text, terms).mentioned).toBe(false);
+  });
+});

--- a/lib/mentions.ts
+++ b/lib/mentions.ts
@@ -39,9 +39,53 @@ function buildRegex(terms: string[]): RegExp | null {
 export function stripLinkSurfaces(text: string): string {
   const blank = (m: string) => " ".repeat(m.length);
   return text
-    .replace(/\[([^\]]*)\]\(([^)]*)\)/g, blank) // whole markdown links
+    .replace(/\[([^\]]*)\]\(([^)]*)\)/g, markdownLink)
     .replace(/\bhttps?:\/\/[^\s<>"')\]]+/gi, blank) // bare URLs
     .replace(/\bwww\.[^\s<>"')\]]+/gi, blank); // scheme-less www hosts
+}
+
+/**
+ * A markdown link keeps its LABEL and loses its target — unless the label is
+ * itself an address.
+ *
+ * Blanking the whole link was too broad. "[Vercel](https://vercel.com)" is the
+ * single most common way an assistant names a brand in a ranked list, and to
+ * the person reading the answer the brand is named: the label is the prose.
+ * Dropping it means a brand that assistants always link reads as never
+ * mentioned, which is the same class of error as counting a URL, pointing the
+ * other way — and the silent direction, because nobody notices a zero that
+ * looks plausible.
+ *
+ * "[vercel.com](https://vercel.com)" is different: what the reader sees is an
+ * address, so the answer cited a page rather than naming a company. Those are
+ * still blanked, which is what keeps a link from minting a first-mention.
+ *
+ * Length-preserving, and the label keeps its exact original offsets — the label
+ * starts one character into the match either way — so `firstPosition` and the
+ * prominence built on it stay valid.
+ */
+function markdownLink(match: string, label: string): string {
+  const keep = isAddress(label) ? "" : label;
+  return " " + keep + " ".repeat(match.length - keep.length - 1);
+}
+
+/**
+ * Does this link label read as an address rather than as words?
+ *
+ * A scheme or www prefix, or a bare dotted token with an optional path and
+ * nothing else around it. "Vercel" keeps its dots-free spelling and stays;
+ * "vercel.com" and "vercel.com/docs" go. A label with any surrounding prose
+ * ("Vercel — the hosting platform") is words, whatever else it contains.
+ *
+ * A brand whose NAME is a domain (You.com) is the residual cost: its label is
+ * indistinguishable from a citation of the same domain, so it is treated as
+ * one. That was the behaviour for every label before this change; it now
+ * applies only to the labels that genuinely look like addresses.
+ */
+function isAddress(label: string): boolean {
+  const trimmed = label.trim();
+  if (/^(?:https?:\/\/|www\.)/i.test(trimmed)) return true;
+  return /^[\w-]+(?:\.[\w-]+)+(?:\/\S*)?$/.test(trimmed);
 }
 
 export function detectMention(text: string, terms: string[]): MentionHit {


### PR DESCRIPTION
Two follow-ups from reviewing #46–#54. Independent, but both small and both in the measurement path, so they're together — happy to split if you'd rather.

---

## 1. A brand named inside a link is a mention again

#53 was right that a link is a citation rather than naming, but it blanks the **whole** markdown link — including the visible label. So `[Vercel](https://vercel.com)` counted as zero mentions, and that is the commonest way an assistant names a brand in a ranked list:

```
1. **[Vercel](https://vercel.com)** — best for Next.js apps.
```

To the person reading the answer, the brand is named; the label *is* the prose. Dropping it means a brand that assistants habitually link reads as never mentioned — the same class of error as counting a URL, pointing the other way, and the more dangerous direction because nobody questions a zero that looks plausible.

**Now:** the label survives, the target is blanked, and a label that reads as an address is still blanked:

| label | treated as |
|---|---|
| `[Vercel](…)` | prose — counts |
| `[Vercel — the hosting platform](…)` | prose — counts |
| `[vercel.com](…)` | address — ignored |
| `[vercel.com/docs](…)` | address — ignored |
| `[https://vercel.com](…)` | address — ignored |
| `[www.vercel.com](…)` | address — ignored |

Still length-preserving, and the label keeps its exact original offsets, so `firstPosition` and the prominence built on it stay valid.

### What it changes on real data: nothing, yet

Measured over 1000 stored answers before opening this:

```
answers containing markdown links: 264 / 1000
  labels that are addresses:       1836   (blanked, before and after)
  labels that are words:            200   (were thrown away; now kept)
  stored verdicts that change:        0   in either direction
```

Those 200 prose labels are headlines and titles — none happened to name a tracked brand, which is why no verdict moves. **So this is insurance, not a repair**: it costs nothing measurable today and closes the case the moment an engine formats a list differently, which they do often. Mentions are computed at run time and stored, so nothing is backfilled either way.

**Residual, stated plainly:** a brand whose *name* is a domain (You.com) has a label indistinguishable from a citation of the same domain, so it is still treated as one. That was true of every label before this change; it now applies only to labels that genuinely look like addresses.

---

## 2. The trap behind #51, not just the instance

#51 fixed a swapped destructure. The shape that produced it is untouched: a 7-element positional destructure over `Promise.all` of heterogeneous queries.

The type system **cannot** catch this. Every PostgREST response carries both `data` and `count`, so pulling `{ count }` out of a `select()` type-checks perfectly — which is how the report came to read its competitor head-count from the prompts query and its prompt targets from the competitors query, through a typed codebase, past review, all the way to staging, with `pages[]` empty and every verdict `no-competitors`.

`allOf` keys the queries instead of ordering them:

```ts
const results = await allOf({
  responseCount: supabase.from("responses").select("id", { count: "exact", head: true }).eq("run_id", runId),
  mentions:      supabase.from("mentions").select("*").eq("run_id", runId),
  promptTargets: supabase.from("prompts").select("id, target_url").eq("project_id", run.project_id),
  competitors:   supabase.from("competitors").select("id", { count: "exact", head: true }).eq("project_id", run.project_id),
  …
});
```

Inserting, removing or reordering a query cannot misalign anything, because nothing is aligned by position. Concurrency is unchanged — the builders are lazy and all start together inside the `Promise.all`.

Applied to the two long call sites (`getRunReport`, `getRunResponses`). The two-element destructures elsewhere are left alone deliberately: they're readable at a glance, and converting them would grow the diff without reducing risk.

---

## Testing

`457 tests, typecheck, lint, build` all clean — including #51's own regression test, which is the one that would catch a mistake in part 2.

Six new cases cover the label rule: brand as label, brand as label inside bold, each address-shaped label form, a label with prose around it, the target never being counted, offsets and length preserved, and an empty label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
