### PR TITLE
Say why pageKey lowercases a path, and drop a vendor name from library docs

### DIFF
--- a/lib/api-service.ts
+++ b/lib/api-service.ts
@@ -847,7 +847,7 @@ export interface RunReport {
   /** Per-URL cited-hit rates for prompts mapped to a target page: when the
    *  question a page was built for gets asked, is THAT page the one cited? */
   pages: PageStat[];
-  /** Per-topic brand visibility. Letterstory plans by topic, so this is the
+  /** Per-topic brand visibility. Content is usually planned by topic, so this is the
    *  join between "we published about X" and "are we surfacing for X". */
   topics: (TopicStat & { topic: string | null })[];
 }
@@ -1252,7 +1252,7 @@ export interface ProjectHistory {
   brandName: string;
   points: HistoryPoint[];
   /** When the brand was first mentioned in any run, or null if never. This is
-   *  the event Letterstory is waiting on: publish, re-run, watch for it to flip. */
+   *  the event a content team is waiting on: publish, re-run, watch it flip. */
   firstMentionAt: string | null;
   /** True once any run has recorded a brand mention. */
   everMentioned: boolean;

--- a/lib/metrics.ts
+++ b/lib/metrics.ts
@@ -312,6 +312,12 @@ export function pageKey(url: string): string | null {
   try {
     const u = new URL(/^https?:\/\//i.test(url) ? url : `https://${url}`);
     const host = u.hostname.toLowerCase().replace(/^www\./, "");
+    // Lowercasing the path is deliberate and technically wrong: paths are
+    // case-sensitive per RFC 3986, so /Blog/Post and /blog/post collide here.
+    // The trade favours recall, which is the right side for citation matching —
+    // an engine that reformats a URL's casing should not read as "your page
+    // wasn't cited". Revisit only if a real site serves different content at
+    // two casings of one path.
     const path = u.pathname.replace(/\/+$/, "").toLowerCase();
     return `${host}${path}`;
   } catch {


### PR DESCRIPTION
Two comment-only follow-ups from the #46–#54 review. No behaviour changes; `457 tests, typecheck, lint, build` clean.

**`pageKey` lowercases the path.** That is technically wrong — paths are case-sensitive per RFC 3986, so `/Blog/Post` and `/blog/post` collide. It is still the right trade for citation matching: an engine that reformats a URL's casing should not read as "your page wasn't cited". Deliberate choices that look like bugs need to say so, or the next reader "fixes" them.

**Two comments explained features in terms of Letterstory's planning process.** The repo is published and the reasoning holds for any content team, so they now read that way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
