### PR TITLE
Add OpenRouter, on what it does rather than what it documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,11 +131,12 @@ Open [http://localhost:3000](http://localhost:3000), create an account, and you'
 
 ## LLM routers (one key, several assistants)
 
-Instead of a key per provider, you can connect a single **LLM router** (gateway) credential and reach several assistants through it. One router ships today — the bar for adding another is a live probe, not a docs page, for the reason spelled out below:
+Instead of a key per provider, you can connect a single **LLM router** (gateway) credential and reach several assistants through it. The bar for adding one is a live probe, not a docs page — both entries below were corrected by probing:
 
 | Router | Engines it serves | Notes |
 |---|---|---|
-| **[Concentrate](https://concentrate.ai/)** | Claude, ChatGPT | No markup on tokens, which matters when the key is yours. Mirrors both providers' native APIs, so a routed answer is the same request a direct key sends — forced browse included. |
+| **[Concentrate](https://concentrate.ai/)** | Claude, ChatGPT — both grounded | No markup on tokens, which matters when the key is yours. Mirrors both providers' native APIs, so a routed answer is the same request a direct key sends — forced browse included. |
+| **[OpenRouter](https://openrouter.ai/)** | Claude grounded; ChatGPT **ungrounded only** | 400+ models behind one key. Its Anthropic endpoint carries Claude's forced web search intact, but it cannot ask an OpenAI model for its *own* search — the alternatives route through Exa, a third-party service — so GPT here serves projects with web search off. Requests pin the upstream (`allow_fallbacks: false`) so routing changes can't move a trend line. |
 
 Settings → **Or use one router key**, or from the terminal:
 
@@ -152,7 +153,8 @@ Three things are worth understanding before you rely on one.
 **Grounding is verified, not assumed.** Every monitored answer is supposed to come from the provider's *native* web search, forced. A gateway that normalizes requests can accept those parameters and quietly drop them, and an ungrounded answer is not a cheaper version of a grounded one — it is a different measurement that still looks like data. So saving a router key runs a real forced search per engine and stores which ones actually returned sources (`router_keys.search_verified`). An engine that didn't is allowed to serve projects with web search **off**, and refused for projects with it on, with a message naming the fix. Operators can run the same check without an account:
 
 ```bash
-ROUTER_API_KEY=... npx tsx scripts/probe-router.ts concentrate
+ROUTER_API_KEY_CONCENTRATE=... npx tsx scripts/probe-router.ts concentrate
+ROUTER_API_KEY_OPENROUTER=...  npx tsx scripts/probe-router.ts openrouter
 ```
 
 The distinction that matters is **forced** versus merely enabled, and it is worth testing rather than reading off a gateway's docs. Probed against Concentrate on 2026-07-30: asked "what is the capital of France?" — a question the model answers from memory — its Responses endpoint with a forced `tool_choice` still returned two cited sources, while the same request with the tool only offered returned none, and so did chat-completions with `web_search_options`. A router that permits searching but can't be made to search will drift against a direct key, since the model answers familiar questions from recall and cites nothing.

--- a/app/dashboard/settings/routers-manager.tsx
+++ b/app/dashboard/settings/routers-manager.tsx
@@ -25,6 +25,7 @@ import type { Provider, RouterId, RouterKeyPublic } from "@/lib/types";
 
 const ROUTER_MARK: Record<RouterId, { mark: string; markClass: string }> = {
   concentrate: { mark: "◎", markClass: "bg-teal/15 text-teal-dark" },
+  openrouter: { mark: "⇄", markClass: "bg-butter-tint text-butter-ink" },
 };
 
 /** One engine's verdict on a saved credential, as returned by the save call. */

--- a/lib/llm/analysis.test.ts
+++ b/lib/llm/analysis.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseAnalysis, type AnalyzeEntity } from "@/lib/llm";
+import { parseAnalysis, humanError, type AnalyzeEntity } from "@/lib/llm";
 
 const entities: AnalyzeEntity[] = [
   { key: "brand", name: "Cloudflare" },
@@ -91,5 +91,25 @@ describe("parseAnalysis", () => {
     expect(parseAnalysis(entities, "nope")).toEqual([]);
     expect(parseAnalysis(entities, { results: "nope" })).toEqual([]);
     expect(parseAnalysis(entities, [null, 42, "x"])).toEqual([]);
+  });
+});
+
+describe("humanError on non-Error failures", () => {
+  // Supabase hands back a plain object, not an Error. It used to fall through
+  // to "Unknown error." — which is what a check-constraint violation reported
+  // while a deployment ran an older schema, turning a one-line fix into a
+  // debugging session.
+  it("keeps the message and code from a database error", () => {
+    const message = humanError({
+      code: "23514",
+      message: 'new row for relation "router_keys" violates check constraint',
+    });
+    expect(message).toContain("violates check constraint");
+    expect(message).toContain("23514");
+  });
+
+  it("still says something when there is nothing to say", () => {
+    expect(humanError({})).toBe("Unknown error.");
+    expect(humanError(null)).toBe("Unknown error.");
   });
 });

--- a/lib/llm/index.ts
+++ b/lib/llm/index.ts
@@ -109,6 +109,7 @@ interface RoutePlan {
   search: SearchSupport;
   /** Which header carries the key on the Anthropic surface — see the registry. */
   anthropicAuth: "x-api-key" | "bearer";
+  extraBody: Record<string, unknown>;
 }
 
 /**
@@ -163,6 +164,7 @@ function planRoute(
     baseUrl,
     search: support.search,
     anthropicAuth: info.anthropicAuth,
+    extraBody: info.extraBody?.(provider, { webSearch: opts.webSearch }) ?? {},
   };
 }
 
@@ -206,6 +208,7 @@ async function anthropicChat(
     max_tokens: maxTokens,
     ...(system ? { system } : {}),
     messages: [{ role: "user", content: user }],
+    ...(plan?.extraBody ?? {}),
   };
   const msg = await client.messages.create(
     params as unknown as Anthropic.MessageCreateParamsNonStreaming,
@@ -241,6 +244,7 @@ async function openaiChat(
     max_tokens: maxTokens,
     messages,
     ...(json ? { response_format: { type: "json_object" } } : {}),
+    ...(plan?.extraBody ?? {}),
   };
   const res = await client.chat.completions.create(
     params as unknown as OpenAI.Chat.ChatCompletionCreateParamsNonStreaming,
@@ -564,6 +568,7 @@ async function gatewayQuery(
     model: plan.slug,
     max_tokens: ANSWER_MAX_TOKENS,
     messages: [{ role: "user", content: prompt }],
+    ...plan.extraBody,
   };
   const res = (await client.chat.completions.create(
     params as unknown as OpenAI.Chat.ChatCompletionCreateParamsNonStreaming,
@@ -641,6 +646,7 @@ async function anthropicWebSearch(
     // us to check the live web. Costs roughly 4x the tokens of a memory answer.
     tool_choice: { type: "tool", name: "web_search" },
     messages: [{ role: "user", content: prompt }],
+    ...(plan?.extraBody ?? {}),
   };
   const msg = await client.messages.create(
     params as unknown as Anthropic.MessageCreateParamsNonStreaming,
@@ -712,6 +718,7 @@ async function openaiWebSearch(
           tool_choice: { type: "web_search_preview" },
           input: prompt,
           max_output_tokens: ANSWER_MAX_TOKENS,
+          ...plan?.extraBody,
         }),
       });
       if (!res.ok) {
@@ -1724,6 +1731,17 @@ export function humanError(err: unknown): string {
       return "Couldn't reach the AI provider (connection dropped). Please try again.";
     }
     return err.message;
+  }
+  // A Supabase/PostgREST error is a plain object, not an Error, so it used to
+  // fall through to "Unknown error." — which is what a check-constraint
+  // violation reported while a deployment was running an older schema. The
+  // message and code are the entire diagnosis; throwing them away turned a
+  // one-line fix into a debugging session.
+  if (err && typeof err === "object") {
+    const e = err as { message?: unknown; code?: unknown };
+    if (typeof e.message === "string" && e.message.trim()) {
+      return typeof e.code === "string" && e.code ? `${e.message} (${e.code})` : e.message;
+    }
   }
   return "Unknown error.";
 }

--- a/lib/routers.test.ts
+++ b/lib/routers.test.ts
@@ -15,10 +15,7 @@ import type { Provider } from "@/lib/types";
 describe("router registry", () => {
   it("narrows only known routers", () => {
     expect(isRouterId("concentrate")).toBe(true);
-    // OpenRouter was built and then dropped before shipping: its entries rested
-    // on documentation where Concentrate's rest on a live probe. Nothing should
-    // accept the identifier while the registry has no entry for it.
-    expect(isRouterId("openrouter")).toBe(false);
+    expect(isRouterId("openrouter")).toBe(true);
     expect(isRouterId("litellm")).toBe(false);
     expect(parseRouterId(42)).toBeNull();
     expect(parseRouterId("concentrate")).toBe("concentrate");
@@ -36,6 +33,7 @@ describe("router registry", () => {
 
   it("serves only the engines whose measurement survives a gateway", () => {
     expect(routerProviders("concentrate")).toEqual(["anthropic", "openai"]);
+    expect(routerProviders("openrouter")).toEqual(["anthropic", "openai"]);
     // Gemini's grounding chunks, the AI Overviews pseudo-model and Perplexity's
     // always-on search are all provider-shaped; routed, they'd answer with a
     // different measurement under the same label.
@@ -54,9 +52,51 @@ describe("router registry", () => {
   });
 
   // The Anthropic SDK sends one auth header, not both, so the entry has to match
-  // what the router documents or every routed Claude call 401s.
-  it("records the auth header for the Anthropic surface", () => {
+  // what the router accepts or every routed Claude call 401s. Both probed live.
+  it("records the auth header for each Anthropic surface", () => {
     expect(ROUTERS.concentrate.anthropicAuth).toBe("bearer");
+    expect(ROUTERS.openrouter.anthropicAuth).toBe("x-api-key");
+  });
+
+  // Probed 2026-07-31 against a live key. OpenRouter carries Claude's forced
+  // web_search (13 sources on a question answerable from memory) but cannot ask
+  // an OpenAI model for its OWN search — "does not support native web search,
+  // use engine auto or exa" — and Exa is a third-party service that measures
+  // something different. So GPT through OpenRouter is ungrounded-only.
+  it("records what each router can actually ground", () => {
+    expect(routerSupport("openrouter", "anthropic")?.search).toBe("passthrough");
+    expect(routerSupport("openrouter", "openai")?.search).toBe("none");
+    expect(routerSupport("concentrate", "anthropic")?.search).toBe("passthrough");
+    expect(routerSupport("concentrate", "openai")?.search).toBe("passthrough");
+  });
+
+  it("still serves ungrounded work on the engine it cannot ground", () => {
+    // A refusal would be wrong: nothing is being claimed about the live web.
+    expect(routerCanMeasure("openrouter", "openai", { webSearch: false, verified: [] })).toBe(true);
+    expect(routerCanMeasure("openrouter", "openai", { webSearch: true, verified: ["openai"] })).toBe(false);
+  });
+});
+
+describe("OpenRouter request body", () => {
+  it("pins the upstream and forbids fallbacks", () => {
+    // Unpinned, OpenRouter price-load-balances across upstreams that can serve
+    // different quantizations, so a trend line moves when routing moves.
+    // Verified accepted: a pinned request came back "served by: OpenAI".
+    const body = ROUTERS.openrouter.extraBody!("anthropic", { webSearch: true }) as {
+      provider: { order: string[]; allow_fallbacks: boolean };
+    };
+    expect(body.provider).toEqual({ order: ["anthropic"], allow_fallbacks: false });
+  });
+
+  it("never asks for a web plugin", () => {
+    // The plugin would route through Exa for OpenAI models, which is a
+    // third-party search service and a different measurement.
+    const body = ROUTERS.openrouter.extraBody!("openai", { webSearch: true }) as Record<string, unknown>;
+    expect(body.plugins).toBeUndefined();
+  });
+
+  it("Concentrate needs no extra body", () => {
+    expect(ROUTERS.concentrate.extraBody).toBeUndefined();
   });
 });
 
@@ -113,26 +153,6 @@ describe("routerCanMeasure", () => {
   });
 });
 
-/**
- * Temporarily mark one engine as unsearchable and ask for the refusal.
- *
- * routerRefusalMessage reads the registry rather than taking support as an
- * argument, so the only way to reach the 'none' branch is to put a router in
- * that state — and no shipped router is in it, now that Concentrate's Responses
- * endpoint turned out to honour a forced browse. Restored in a finally, so a
- * failing assertion can't leave the registry lying to every other test.
- */
-function refusalForSearchless(): string {
-  const support = ROUTERS.concentrate.providers.openai!;
-  const original = support.search;
-  support.search = "none";
-  try {
-    return routerRefusalMessage("concentrate", "openai", { webSearch: true, verified: [] });
-  } finally {
-    support.search = original;
-  }
-}
-
 describe("routerRefusalMessage", () => {
   it("names the alternative engines when the router can't serve one", () => {
     const message = routerRefusalMessage("concentrate", "google", {
@@ -143,10 +163,16 @@ describe("routerRefusalMessage", () => {
     expect(message).toContain("Anthropic (Claude) and OpenAI (ChatGPT)");
   });
 
-  // The branch stays because it is the guard for the next router added, so
-  // exercise it against a stub rather than deleting the coverage with the case.
+  // OpenRouter cannot ask an OpenAI model for its own web search — its only
+  // options route through Exa — so this is the real case, not a stub.
   it("offers turning grounding off when search can't be requested", () => {
-    expect(refusalForSearchless()).toContain("Turn off web search");
+    const message = routerRefusalMessage("openrouter", "openai", {
+      webSearch: true,
+      verified: [],
+    });
+    expect(message).toContain("Turn off web search");
+    expect(message).toContain("OpenRouter");
+    expect(message).toContain("OpenAI (ChatGPT)");
   });
 
   it("points at a re-check when only the probe is missing", () => {

--- a/lib/routers.ts
+++ b/lib/routers.ts
@@ -47,12 +47,13 @@ export type { RouterId };
  * endpoint with a forced `tool_choice` still returned two cited sources, while
  * the same request with the tool merely offered returned none, and so did
  * chat-completions with `web_search_options`. Forcing is honoured; the
- * alternatives only permit. That difference is why the OpenAI path names the
- * Responses API specifically rather than treating any OpenAI-compatible
- * endpoint as interchangeable: chat-completions is still used for routed calls
- * that aren't grounded, where there is nothing to force.
+ * alternatives only permit. That difference is why 'openai-responses' names the
+ * Responses API specifically rather than treating any OpenAI-compatible endpoint
+ * as interchangeable. 'openai-chat' is the plain chat-completions surface, used
+ * for routed calls that aren't grounded — where there is nothing to force — and
+ * for a router that has no Responses API at all.
  */
-export type RouteShape = "anthropic" | "openai-responses";
+export type RouteShape = "anthropic" | "openai-chat" | "openai-responses";
 
 /**
  * How native web search is expressed through a router for one provider.
@@ -114,10 +115,12 @@ export interface RouterInfo {
    * verification uses this same path.
    */
   anthropicAuth: "x-api-key" | "bearer";
+  /** Extra top-level body fields for a call through this router. */
+  extraBody?: (provider: Provider, opts: { webSearch: boolean }) => Record<string, unknown>;
   providers: Partial<Record<Provider, RouterProviderSupport>>;
 }
 
-// Google and Perplexity are deliberately absent from the router below.
+// Google and Perplexity are deliberately absent from the routers below.
 //
 // Not because the models are unreachable — they are — but because their
 // measurement paths don't survive normalization. Gemini's answers are grounded
@@ -162,12 +165,65 @@ export const ROUTERS: Record<RouterId, RouterInfo> = {
       },
     },
   },
+  openrouter: {
+    id: "openrouter",
+    label: "OpenRouter",
+    blurb: "400+ models behind one key. Claude is measurable; GPT is not.",
+    keyUrl: "https://openrouter.ai/keys",
+    docsUrl: "https://openrouter.ai/docs",
+    keyPrefix: "sk-or-v1-",
+    openaiBaseUrl: "https://openrouter.ai/api/v1",
+    anthropicBaseUrl: "https://openrouter.ai/api",
+    // Both x-api-key and bearer were accepted when probed; x-api-key is what the
+    // Anthropic SDK sends unprompted, so it is the one with fewer moving parts.
+    anthropicAuth: "x-api-key",
+    extraBody: (provider) => ({
+      // Pin the upstream and refuse fallbacks. OpenRouter price-load-balances a
+      // model across upstream hosts that can serve different quantizations, and
+      // moves between them silently. For a product whose output is a trend line
+      // that is a measurement change disguised as a visibility change: the
+      // mention rate shifts because routing shifted. Verified accepted — a
+      // pinned request came back "served by: OpenAI".
+      provider: { order: [OPENROUTER_UPSTREAM[provider]], allow_fallbacks: false },
+    }),
+    providers: {
+      anthropic: {
+        // The Anthropic skin forwards the forced web_search tool intact. Probed
+        // 2026-07-31 with a live key: asked for the capital of France — a
+        // question answerable from memory — it still returned 13 cited sources.
+        shape: "anthropic",
+        search: "passthrough",
+        slugPrefix: "anthropic",
+      },
+      openai: {
+        // OpenRouter cannot ask an OpenAI model for its OWN web search:
+        // "The requested model does not support native web search. Use engine
+        // 'auto' or 'exa' instead." Both of those route the search through Exa,
+        // a third-party service — which measures something different from the
+        // provider's own browsing and breaks the README's claim that Lettertrace
+        // uses no search service beyond the provider's. So GPT through this
+        // router serves ungrounded projects and utility work only, and a
+        // grounded project is refused with a message naming the fix.
+        shape: "openai-chat",
+        search: "none",
+        slugPrefix: "openai",
+      },
+    },
+  },
+};
+
+/** OpenRouter's upstream-provider names, for the pinning above. */
+const OPENROUTER_UPSTREAM: Record<Provider, string> = {
+  anthropic: "anthropic",
+  openai: "openai",
+  google: "google-vertex",
+  perplexity: "perplexity",
 };
 
 export const ROUTER_LIST: RouterInfo[] = Object.values(ROUTERS);
 
 export function isRouterId(value: string): value is RouterId {
-  return value === "concentrate";
+  return value === "concentrate" || value === "openrouter";
 }
 
 /** Narrow an untrusted router value, or null. */

--- a/lib/trial.test.ts
+++ b/lib/trial.test.ts
@@ -452,16 +452,19 @@ describe("the exhausted message offers the router", () => {
     expect(k.source).toBe("exhausted");
     expect(message).toContain("Anthropic (Claude) key");
     expect(message).toContain("Concentrate");
+    expect(message).toContain("OpenRouter");
   });
 
   // The engines come from the registry, so the pitch can't outlive the support
   // entry that backs it.
-  it("names the engines that router actually covers", async () => {
+  // No per-engine promise in this line. Routers differ in what they can
+  // MEASURE — Concentrate carries both engines' native search, OpenRouter only
+  // Claude's — so naming engines here would over-promise for one of them. The
+  // settings card states coverage per router, where it can be accurate.
+  it("promises no engine it might not be able to measure", async () => {
     process.env.TRIAL_ANTHROPIC_API_KEY = "sk-ant-trial";
-    const k = await runKeyFor(db(5), "user-1", "anthropic");
-    const message = engineKeyMessage(k);
-    expect(message).toContain("Anthropic (Claude) and OpenAI (ChatGPT)");
-    // Never promises an engine a router can't measure.
+    const message = engineKeyMessage(await runKeyFor(db(5), "user-1", "anthropic"));
+    expect(message).toContain("router key");
     expect(message).not.toContain("Perplexity");
     expect(message).not.toContain("Gemini");
   });

--- a/lib/trial.ts
+++ b/lib/trial.ts
@@ -338,13 +338,20 @@ export async function resolveRunKey(
   });
 }
 
-/** The engines the shipped router covers, as prose. Read from the registry so
- *  the sales line in the exhausted message can't outlive the support entry. */
-function routerCoverage(): string {
-  const names = routerProviders(ROUTER_LIST[0].id).map((p) => PROVIDERS[p].label);
+/**
+ * The routers on offer, by name, read from the registry.
+ *
+ * Deliberately no per-engine promise here. Routers differ in what they can
+ * actually MEASURE — one carries both engines' native search, another only
+ * Claude's — so a single line naming engines would over-promise for one of them
+ * the moment a second router exists. The settings card states coverage per
+ * router, where it can be accurate.
+ */
+function routerNames(): string {
+  const names = ROUTER_LIST.map((r) => r.label);
   return names.length <= 1
-    ? names[0] ?? "your engines"
-    : `${names.slice(0, -1).join(", ")} and ${names[names.length - 1]}`;
+    ? names[0] ?? "a gateway"
+    : `${names.slice(0, -1).join(", ")} or ${names[names.length - 1]}`;
 }
 
 /** The RouteInfo for a stored router credential. */
@@ -376,7 +383,7 @@ export function engineKeyMessage(key: ResolvedKey): string {
     return (
       `You've used all ${key.limit ?? 0} free runs on ${engine}. ` +
       `Add your own ${providerLabel} key in Settings to keep monitoring, ` +
-      `or one ${ROUTER_LIST[0].label} key that covers ${routerCoverage()}.`
+      `or one router key (${routerNames()}) that covers several assistants at once.`
     );
   }
   if (key.source === "mismatch") {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -6,7 +6,7 @@ export type Provider = "anthropic" | "openai" | "google" | "perplexity";
 // LLM routers are credentials, not providers, so they get their own union and
 // stay out of `Provider` — which is what keeps `runs.provider` meaning "whose
 // answer was this" rather than "who billed us". See lib/routers.ts.
-export type RouterId = "concentrate";
+export type RouterId = "concentrate" | "openrouter";
 
 export type RunStatus = "pending" | "running" | "completed" | "failed";
 

--- a/scripts/harness-router-keys.ts
+++ b/scripts/harness-router-keys.ts
@@ -34,7 +34,8 @@ import { createRequire } from "node:module";
 import crypto from "node:crypto";
 import { createClient } from "@supabase/supabase-js";
 import { decryptSecret } from "../lib/crypto";
-import type { Project } from "../lib/types";
+import { routerProviders, routerSupport } from "../lib/routers";
+import type { Project, Provider } from "../lib/types";
 
 // lib/data wraps its readers in React's cache(), which only exists inside
 // Next's runtime — importing it from a plain Node script throws before any
@@ -86,10 +87,17 @@ const SUPABASE_URL = requireEnv("NEXT_PUBLIC_SUPABASE_URL");
 const SERVICE_ROLE = requireEnv("SUPABASE_SERVICE_ROLE_KEY");
 requireEnv("ENCRYPTION_KEY"); // used by decryptSecret below
 
+const ROUTER = (flag("router") ?? "concentrate") as "concentrate" | "openrouter";
 const keyFile = flag("key-file");
-const ROUTER_KEY = (keyFile ? readFileSync(keyFile, "utf8") : process.env.ROUTER_API_KEY ?? "").trim();
+const ROUTER_KEY = (
+  keyFile
+    ? readFileSync(keyFile, "utf8")
+    : process.env[`ROUTER_API_KEY_${ROUTER.toUpperCase()}`] ?? process.env.ROUTER_API_KEY ?? ""
+).trim();
 if (!ROUTER_KEY) {
-  console.error("No router key. Set $ROUTER_API_KEY or pass --key-file <path>.");
+  console.error(
+    `No router key. Set $ROUTER_API_KEY_${ROUTER.toUpperCase()} (or $ROUTER_API_KEY), or pass --key-file <path>.`,
+  );
   process.exit(2);
 }
 
@@ -121,6 +129,16 @@ function check(name: string, ok: boolean, detail = ""): void {
 
 function section(title: string): void {
   say(`\n\x1b[1m${title}\x1b[0m`);
+}
+
+/**
+ * The engines THIS router is expected to ground — per router, not blanket.
+ * OpenRouter carries Claude's native search but cannot ask an OpenAI model for
+ * its own, so demanding both would assert something untrue of a
+ * correctly-working credential.
+ */
+function groundable(): Provider[] {
+  return routerProviders(ROUTER).filter((p) => routerSupport(ROUTER, p)?.search === "passthrough");
 }
 
 async function main() {
@@ -161,14 +179,14 @@ async function main() {
       // stored as if it were real.
       const { error: badRouter } = await admin.from("router_keys").insert({
         user_id: userId,
-        router: "openrouter",
+        router: "litellm",
         encrypted_key: "x",
         key_hint: "x",
       });
       check(
         "an unshipped router id is rejected by the check constraint",
         Boolean(badRouter),
-        "openrouter was accepted",
+        "litellm was accepted",
       );
     }
 
@@ -177,17 +195,17 @@ async function main() {
     // ------------------------------------------------------------------
     {
       const outcome = await setRouterKey(admin, userId, {
-        router: "concentrate",
+        router: ROUTER,
         apiKey: ROUTER_KEY,
         label: "harness",
       });
       check("the save path accepted a real key", outcome.ok, outcome.ok ? "" : outcome.message);
       if (!outcome.ok) throw new Error(`cannot continue: ${outcome.message}`);
 
+      const mustGround = groundable();
       check(
-        "grounding was confirmed for both engines it serves",
-        outcome.verification.searchVerified.includes("anthropic") &&
-          outcome.verification.searchVerified.includes("openai"),
+        `grounding confirmed for every engine this router can ground (${mustGround.join(", ")})`,
+        mustGround.every((p) => outcome.verification.searchVerified.includes(p)),
         `searchVerified=[${outcome.verification.searchVerified}]`,
       );
 
@@ -222,7 +240,7 @@ async function main() {
       check(
         "search_verified persisted",
         Array.isArray(stored?.search_verified) &&
-          (stored!.search_verified as string[]).length === 2,
+          (stored!.search_verified as string[]).length === mustGround.length,
         JSON.stringify(stored?.search_verified),
       );
 
@@ -244,7 +262,8 @@ async function main() {
       check("the credential round-trips through the decrypt helper", keys[0]?.apiKey === ROUTER_KEY);
       check(
         "its verified engines came with it",
-        keys[0]?.searchVerified.includes("anthropic") && keys[0]?.searchVerified.includes("openai"),
+        groundable().every((p) => keys[0]?.searchVerified.includes(p)),
+        `searchVerified=[${keys[0]?.searchVerified}]`,
       );
 
       // The resolver is what decides a run may use this credential at all.
@@ -253,7 +272,7 @@ async function main() {
       });
       check(
         "a grounded run resolves to the router",
-        grounded.source === "own" && grounded.route?.router === "concentrate",
+        grounded.source === "own" && grounded.route?.router === ROUTER,
         `source=${grounded.source} route=${grounded.route?.router}`,
       );
       check(
@@ -336,7 +355,7 @@ async function main() {
       );
       check(
         "the gateway is recorded alongside it",
-        run.route === "concentrate",
+        run.route === ROUTER,
         `route=${run.route}`,
       );
 
@@ -360,11 +379,11 @@ async function main() {
     section("Revoking it");
     // ------------------------------------------------------------------
     {
-      const removed = await removeRouterKey(admin, userId, "concentrate");
+      const removed = await removeRouterKey(admin, userId, ROUTER);
       check("remove returns the row it deleted", removed !== null);
       const after = await listRouterKeys(admin, userId);
       check("nothing is left behind", after.length === 0);
-      const again = await removeRouterKey(admin, userId, "concentrate");
+      const again = await removeRouterKey(admin, userId, ROUTER);
       check("removing a second time reports nothing stored", again === null);
     }
 

--- a/scripts/probe-router.ts
+++ b/scripts/probe-router.ts
@@ -22,10 +22,31 @@
  */
 
 import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { PROVIDERS, analysisModelFor } from "../lib/models";
 import { ROUTERS, isRouterId, routerProviders, routerSupport } from "../lib/routers";
 import { probeRouterSearch, humanError } from "../lib/llm";
 import type { Provider, RouterId } from "../lib/types";
+
+/** Read .env.local into the environment, so a key set there is found without
+ *  being exported by hand. Existing variables always win. */
+function loadEnvLocal(): void {
+  const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+  let raw = "";
+  try {
+    raw = readFileSync(resolve(repoRoot, ".env.local"), "utf8");
+  } catch {
+    return;
+  }
+  for (const line of raw.split("\n")) {
+    const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*)$/);
+    if (!m) continue;
+    const value = m[2].trim().replace(/^["']|["']$/g, "");
+    if (value && !process.env[m[1]]) process.env[m[1]] = value;
+  }
+}
+loadEnvLocal();
 
 function parseArgs(argv: string[]) {
   const positional: string[] = [];
@@ -42,16 +63,27 @@ function parseArgs(argv: string[]) {
   return { positional, flags };
 }
 
-function readKey(flags: Record<string, string>): string {
+/**
+ * The key, from a file or the environment — never from an argument, which would
+ * land in shell history and in `ps`.
+ *
+ * $ROUTER_API_KEY_<ROUTER> is checked before the generic $ROUTER_API_KEY so a
+ * machine configured for several gateways doesn't need the variable rewritten
+ * between probes.
+ */
+function readKey(router: string, flags: Record<string, string>): string {
   if (flags["key-file"]) {
     const key = readFileSync(flags["key-file"], "utf8").trim();
     if (key) return key;
     throw new Error(`--key-file ${flags["key-file"]} is empty.`);
   }
-  const env = process.env.ROUTER_API_KEY?.trim();
-  if (env) return env;
+  const specific = process.env[`ROUTER_API_KEY_${router.toUpperCase()}`]?.trim();
+  if (specific) return specific;
+  const generic = process.env.ROUTER_API_KEY?.trim();
+  if (generic) return generic;
   throw new Error(
-    "No key. Set $ROUTER_API_KEY or pass --key-file <path>. A key given as an argument would land in your shell history.",
+    `No key. Set $ROUTER_API_KEY_${router.toUpperCase()} (or $ROUTER_API_KEY), or pass --key-file <path>. ` +
+      "A key given as an argument would land in your shell history.",
   );
 }
 
@@ -66,7 +98,7 @@ async function main() {
     process.exit(2);
   }
   const router: RouterId = routerArg;
-  const apiKey = readKey(flags);
+  const apiKey = readKey(router, flags);
   const baseUrl = flags["base-url"] || null;
 
   // Default to every engine the registry says this router serves; --provider

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -118,7 +118,7 @@ alter table public.provider_keys
 create table if not exists public.router_keys (
   id uuid primary key default gen_random_uuid(),
   user_id uuid not null references auth.users (id) on delete cascade,
-  router text not null check (router in ('concentrate')),
+  router text not null check (router in ('concentrate', 'openrouter')),
   label text,
   -- Only for a self-hosted deployment of a router; null uses the registry's URL.
   base_url text,
@@ -133,7 +133,7 @@ create table if not exists public.router_keys (
 -- no-op once the table exists). Safe to re-run.
 alter table public.router_keys drop constraint if exists router_keys_router_check;
 alter table public.router_keys
-  add constraint router_keys_router_check check (router in ('concentrate'));
+  add constraint router_keys_router_check check (router in ('concentrate', 'openrouter'));
 
 -- ---------- projects -------------------------------------------------
 create table if not exists public.projects (
@@ -320,7 +320,7 @@ alter table public.runs
 alter table public.runs add column if not exists route text;
 alter table public.runs drop constraint if exists runs_route_check;
 alter table public.runs
-  add constraint runs_route_check check (route is null or route in ('concentrate'));
+  add constraint runs_route_check check (route is null or route in ('concentrate', 'openrouter'));
 
 -- ---------- responses ------------------------------------------------
 create table if not exists public.responses (


### PR DESCRIPTION
Adds OpenRouter as a second router. It was built once before and **cut for resting on documentation**; with a live key it comes back — and probing changed the entry it would otherwise have had, in both directions.

## What the probe found

| question | answer |
|---|---|
| Anthropic endpoint forwards the forced `web_search`? | **Yes** — 13 cited sources on *"what is the capital of France?"*, a question answerable from memory |
| OpenAI native web search? | **No** — `404: does not support native web search. Use engine "auto" or "exa" instead` |
| Upstream pinning accepted? | Yes — a pinned request came back `served by: OpenAI` |
| Our catalog slugs resolve? | Yes, both `claude-haiku-4-5` and `claude-haiku-4.5` |
| Auth on the Anthropic surface | both `x-api-key` and bearer work; entry uses `x-api-key`, which the SDK sends unprompted |

So the coverage is asymmetric, and the registry says so:

| | Claude | ChatGPT |
|---|---|---|
| **Concentrate** | grounded | grounded |
| **OpenRouter** | grounded | **ungrounded only** |

Both of OpenRouter's OpenAI search options route through **Exa**, a third-party service. That measures something other than the provider's own browsing and breaks the README's claim that Lettertrace uses no search service beyond the provider's, so GPT here is `search: "none"`: it serves projects with web search **off** and utility work, and a grounded project is refused with a message naming the fix.

That `"none"` branch previously existed only as a guard, exercised by a stubbed registry entry. It has a real one now, and the stub is gone.

Upstream pinning (`provider: { order, allow_fallbacks: false }`) is kept because unpinned routing price-load-balances across upstreams that can serve different quantizations — a measurement change disguised as a visibility change.

## Two bugs fixed on the way

- **`humanError` returned "Unknown error." for any Supabase failure**, because a PostgREST error is a plain object rather than an `Error`. A check-constraint violation therefore reported nothing usable — which is exactly what hid an outdated schema behind a shrug while testing this. It keeps the message and code now.
- **The harness asserted both engines ground**, which is untrue of a correctly-working OpenRouter key. It now asks each router only for what that router claims it can ground.

## Verified against live keys

- **probe:** Claude grounded; GPT correctly refused with the reason
- **save path:** `searchVerified=[anthropic]` for OpenRouter, `[anthropic, openai]` for Concentrate — the settings card states it per engine
- **database harness:** 26/26 for **both** routers, including a real monitored run that recorded `route=openrouter` with live sources cited
- `502 tests, typecheck, lint, build` clean

## Schema

The `router_keys.router` and `runs.route` allow-lists widen to include `openrouter`. **Re-run `supabase/schema.sql`** — additive and re-runnable. (Already applied to the shared database.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
