### PR TITLE
Set competitors from the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ npm run cli -- keys set anthropic                    # hidden prompt, key verifi
 # Set up an account over the API — the agent-drivable part:
 npm run cli -- projects create --name "Acme" --brand "Acme" --domains acme.io
 npm run cli -- prompts add <projectId> --text "best crm for startups" --topic CRM
-npm run cli -- competitors add <projectId> Drata Secureframe   # who you're measured against
+npm run cli -- competitors add Vanta Drata Secureframe          # who you're measured against
 npm run cli -- runs trigger <projectId>
 npm run cli -- runs get <runId>          # share-of-voice report (--json for full)
 
@@ -373,11 +373,17 @@ of standing a brand up rather than a later refinement — monitoring Vanta means
 tracking Drata and Secureframe, and that should be one command:
 
 ```bash
-npm run cli -- competitors add <projectId> Drata Secureframe   # several at once
-npm run cli -- competitors add <projectId> --name Sprinto --domain sprinto.com --aliases "Sprinto Inc"
-npm run cli -- competitors <projectId>                         # what's tracked, with ids
+npm run cli -- competitors add Vanta Drata Secureframe   # several at once
+npm run cli -- competitors add Vanta --name Sprinto --domain sprinto.com --aliases "Sprinto Inc"
+npm run cli -- competitors Vanta                         # what's tracked, with ids
 npm run cli -- competitors remove <competitorId>
 ```
+
+Anywhere a command takes a project, it accepts the **project name**, the **brand
+name**, a full id, or an unambiguous id prefix — the last because a shortened id
+is what you copy out of a table. Ids still work unchanged, so nothing an agent
+does needs to know about this; it exists so a person can say what they mean. An
+ambiguous name is refused with the ids listed rather than guessed at.
 
 Names the project already tracks are reported as skipped rather than failing, so
 re-running the same setup command is safe. The brand itself is refused — it

--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ npm run cli -- keys set anthropic                    # hidden prompt, key verifi
 # Set up an account over the API — the agent-drivable part:
 npm run cli -- projects create --name "Acme" --brand "Acme" --domains acme.io
 npm run cli -- prompts add <projectId> --text "best crm for startups" --topic CRM
+npm run cli -- competitors add <projectId> Drata Secureframe   # who you're measured against
 npm run cli -- runs trigger <projectId>
 npm run cli -- runs get <runId>          # share-of-voice report (--json for full)
 
@@ -364,6 +365,27 @@ resolves the deployment from `--url`, then `$LETTERTRACE_URL`, then the URL save
 at login. Tokens live in `~/.lettertrace/config.json` (one per audience). The
 data commands use REST v1; the `mcp` commands speak the Model Context Protocol
 directly. The mechanism underneath is:
+
+#### Competitors from the CLI (`competitors`)
+
+Share of voice needs something to compare against, so setting competitors is part
+of standing a brand up rather than a later refinement — monitoring Vanta means
+tracking Drata and Secureframe, and that should be one command:
+
+```bash
+npm run cli -- competitors add <projectId> Drata Secureframe   # several at once
+npm run cli -- competitors add <projectId> --name Sprinto --domain sprinto.com --aliases "Sprinto Inc"
+npm run cli -- competitors <projectId>                         # what's tracked, with ids
+npm run cli -- competitors remove <competitorId>
+```
+
+Names the project already tracks are reported as skipped rather than failing, so
+re-running the same setup command is safe. The brand itself is refused — it
+cannot be its own competitor.
+
+`competitors discovered <projectId>` is the other direction: companies this
+project's own answers have already named that nobody is tracking. It is evidence
+from runs you have already paid for, not a guess.
 
 #### Setting your provider key from the CLI (`keys`)
 

--- a/cli/lettertrace.mjs
+++ b/cli/lettertrace.mjs
@@ -108,6 +108,50 @@ async function withAutoLogin(fn) {
 }
 
 // --- commands -------------------------------------------------------
+
+// A project can be named on the command line instead of pointed at by uuid.
+// Nothing about the API changes — an agent keeps passing ids — but a person
+// demoing this should be able to say what they mean:
+//
+//   lettertrace competitors add Vanta Drata Secureframe
+//
+// Accepts, in order: a full uuid (used as-is, no lookup), the project name, the
+// brand name, or an unambiguous id prefix — the last because a shortened id is
+// exactly what someone copies out of a table or a screen recording.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+async function resolveProject(ref) {
+  if (UUID_RE.test(ref)) return ref;
+
+  const out = await withAutoLogin(() => rest(base, "GET", "/projects"));
+  const projects = out.projects ?? [];
+  const needle = ref.trim().toLowerCase();
+
+  const byName = projects.filter((p) => (p.name ?? "").toLowerCase() === needle);
+  const byBrand = projects.filter((p) => (p.brand_name ?? "").toLowerCase() === needle);
+  // A prefix only counts when it could plausibly be one — four hex characters or
+  // more — so a brand called "Ada" never gets read as an id.
+  const byPrefix = /^[0-9a-f]{4,}$/i.test(ref)
+    ? projects.filter((p) => p.id.startsWith(ref.toLowerCase()))
+    : [];
+
+  const matches = byName.length ? byName : byBrand.length ? byBrand : byPrefix;
+
+  if (matches.length === 1) return matches[0].id;
+
+  if (matches.length > 1) {
+    throw new UsageError(
+      `"${ref}" matches ${matches.length} projects. Use the id instead:\n` +
+        matches.map((p) => `  ${p.id}  ${p.name}${p.brand_name && p.brand_name !== p.name ? ` (${p.brand_name})` : ""}`).join("\n"),
+    );
+  }
+
+  const known = projects.length
+    ? projects.map((p) => `  ${p.name}${p.brand_name && p.brand_name !== p.name ? ` (${p.brand_name})` : ""}`).join("\n")
+    : "  (none yet — create one with `lettertrace projects create`)";
+  throw new UsageError(`No project called "${ref}". Yours:\n${known}`);
+}
+
 const commands = {
   async login() {
     const opts = { scope: scopeFlag(), ipv6: IPV6 };
@@ -348,7 +392,7 @@ const commands = {
     const sub = rest_[0];
 
     if (sub === "add") {
-      const projectId = need(rest_[1], "competitors add needs a <projectId>");
+      const projectId = await resolveProject(need(rest_[1], "competitors add needs a <project> (name or id)"));
       // Two shapes, because both are natural. Several names positionally for the
       // common case, or one competitor with its aliases and domain spelled out.
       //   competitors add <id> Drata Secureframe
@@ -407,7 +451,7 @@ const commands = {
     if (sub === "discovered") {
       // Not a guess: companies THIS project's own answers already named, which
       // nobody is tracking. The evidence is the answers you paid for.
-      const projectId = need(rest_[1], "competitors discovered needs a <projectId>");
+      const projectId = await resolveProject(need(rest_[1], "competitors discovered needs a <project>"));
       const out = await withAutoLogin(() =>
         rest(base, "GET", `/projects/${projectId}/competitors/discovered`),
       );
@@ -434,7 +478,9 @@ const commands = {
     }
 
     // list: competitors <projectId>
-    const projectId = need(sub, "competitors needs a <projectId> (or a subcommand: add, remove, discovered)");
+    const projectId = await resolveProject(
+      need(sub, "competitors needs a <project> (or a subcommand: add, remove, discovered)"),
+    );
     const out = await withAutoLogin(() => rest(base, "GET", `/projects/${projectId}/competitors`));
     if (JSON_OUT) return printJson(out);
     const rows = out.competitors ?? [];
@@ -489,7 +535,7 @@ const commands = {
   async prompts() {
     const sub = rest_[0];
     if (sub === "add") {
-      const projectId = need(rest_[1], "prompts add needs a <projectId>");
+      const projectId = await resolveProject(need(rest_[1], "prompts add needs a <project>"));
       const body = {
         prompts: [
           {
@@ -516,7 +562,7 @@ const commands = {
       return;
     }
     // list: prompts <projectId>
-    const projectId = need(sub, "prompts needs a <projectId>");
+    const projectId = await resolveProject(need(sub, "prompts needs a <project>"));
     const out = await withAutoLogin(() => rest(base, "GET", `/projects/${projectId}/prompts`));
     if (JSON_OUT) return printJson(out.prompts);
     table(out.prompts, [
@@ -530,7 +576,7 @@ const commands = {
   async runs() {
     const sub = rest_[0];
     if (sub === "trigger") {
-      const projectId = need(rest_[1], "runs trigger needs a <projectId>");
+      const projectId = await resolveProject(need(rest_[1], "runs trigger needs a <project>"));
       const body = {};
       if (flags.provider) body.provider = flags.provider;
       if (flags.model) body.model = flags.model;
@@ -583,7 +629,7 @@ const commands = {
       return;
     }
     // list: runs <projectId>
-    const projectId = need(sub, "runs needs a <projectId>");
+    const projectId = await resolveProject(need(sub, "runs needs a <project>"));
     const query = flags.limit ? { limit: Number(flags.limit) } : undefined;
     const out = await withAutoLogin(() => rest(base, "GET", `/projects/${projectId}/runs`, { query }));
     if (JSON_OUT) return printJson(out.runs);
@@ -597,7 +643,7 @@ const commands = {
   },
 
   async history() {
-    const projectId = need(rest_[0], "history needs a <projectId>");
+    const projectId = await resolveProject(need(rest_[0], "history needs a <project>"));
     const query = flags.limit ? { limit: Number(flags.limit) } : undefined;
     const out = await withAutoLogin(() =>
       rest(base, "GET", `/projects/${projectId}/history`, { query }),
@@ -734,21 +780,22 @@ function printHelp() {
     "  routers remove <router>                Forget the stored key for a router",
     "",
     c.bold("DATA (REST v1)"),
+    c.dim("  <project> is a project name, a brand name, or an id (full or a unique prefix)"),
     "  projects                               List organizations",
     "  projects create --name <n> --brand <b> [--domains a,b] [--description <d>]",
-    "  prompts <projectId>                    List a project's prompts",
-    "  prompts add <projectId> --text <t> --topic <top>",
+    "  prompts <project>                      List a project's prompts",
+    "  prompts add <project> --text <t> --topic <top>",
     "  prompts toggle <promptId> --on|--off",
-    "  competitors <projectId>                Competitors tracked for a project",
-    "  competitors add <projectId> <name...>  Track competitors by name",
-    "  competitors add <projectId> --name <n> [--domain <d>] [--aliases a,b]",
+    "  competitors <project>                  Competitors tracked for a project",
+    "  competitors add <project> <name...>    Track competitors by name",
+    "  competitors add <project> --name <n> [--domain <d>] [--aliases a,b]",
     "  competitors remove <competitorId>      Stop tracking one",
-    "  competitors discovered <projectId>     Companies the answers named but nobody tracks",
-    "  runs <projectId> [--limit <n>]         List runs",
-    "  runs trigger <projectId> [--provider <p>] [--model <m>]",
+    "  competitors discovered <project>       Companies the answers named but nobody tracks",
+    "  runs <project> [--limit <n>]           List runs",
+    "  runs trigger <project> [--provider <p>] [--model <m>]",
     "  runs get <runId>                       Share-of-voice report",
     "  runs responses <runId>                 Raw answers, sources, mentions",
-    "  history <projectId> [--limit <n>]      Brand visibility over time",
+    "  history <project> [--limit <n>]        Brand visibility over time",
     "  logs [--channel c] [--category c] [--status s] [--days n] [--q text] [--limit n]",
     "                                         Account activity feed (users, agents, cron)",
     "",

--- a/cli/lettertrace.mjs
+++ b/cli/lettertrace.mjs
@@ -21,6 +21,12 @@ import { c, printJson, table, kv, ok, info, fail } from "./output.mjs";
 import { banner, withSpinner } from "./brand.mjs";
 
 // --- arg parsing ----------------------------------------------------
+// Flags that are switches, not settings. Without this list a flag swallows the
+// following word as its value, so `--json competitors <id>` set json to
+// "competitors" and then failed with "Unknown command: <id>" — the documented
+// "every command takes --json" only worked if you put it last.
+const BOOLEAN_FLAGS = new Set(["json", "on", "off", "mcp", "both", "ipv6", "help"]);
+
 function parseArgs(argv) {
   const positionals = [];
   const flags = {};
@@ -29,7 +35,7 @@ function parseArgs(argv) {
     if (a.startsWith("--")) {
       const key = a.slice(2);
       const next = argv[i + 1];
-      if (next !== undefined && !next.startsWith("--")) {
+      if (!BOOLEAN_FLAGS.has(key) && next !== undefined && !next.startsWith("--")) {
         flags[key] = next;
         i++;
       } else {
@@ -334,6 +340,125 @@ const commands = {
     info(c.dim("Set one with: lettertrace routers set <router>  (the key is never typed as an argument)"));
   },
 
+  // Competitors. Share of voice is meaningless without something to compare
+  // against, so this is part of setting a brand up rather than a later refinement
+  // — "monitoring Vanta, track Drata and Secureframe" should be one command, not
+  // a trip to the dashboard.
+  async competitors() {
+    const sub = rest_[0];
+
+    if (sub === "add") {
+      const projectId = need(rest_[1], "competitors add needs a <projectId>");
+      // Two shapes, because both are natural. Several names positionally for the
+      // common case, or one competitor with its aliases and domain spelled out.
+      //   competitors add <id> Drata Secureframe
+      //   competitors add <id> --name Drata --domain drata.com --aliases "Drata Inc"
+      const positional = rest_.slice(2);
+      const entries = positional.length
+        ? positional.map((name) => ({ name }))
+        : [
+            {
+              name: need(flags.name, "competitors add needs names, or --name"),
+              ...(flags.domain ? { domain: String(flags.domain) } : {}),
+              ...(flags.aliases
+                ? {
+                    aliases: String(flags.aliases)
+                      .split(",")
+                      .map((a) => a.trim())
+                      .filter(Boolean),
+                  }
+                : {}),
+            },
+          ];
+      if (positional.length && (flags.domain || flags.aliases)) {
+        throw new UsageError(
+          "--domain and --aliases describe ONE competitor, so they can't be combined with a list of names. " +
+            "Add the detailed one on its own, or list the names and set details later.",
+        );
+      }
+
+      const out = await withAutoLogin(() =>
+        rest(base, "POST", `/projects/${projectId}/competitors`, { body: { competitors: entries } }),
+      );
+      if (JSON_OUT) return printJson(out);
+      // This endpoint answers { competitors, skipped } where prompts answers
+      // { created, skipped }. Read the one this route actually sends.
+      const added = out.competitors ?? out.created ?? [];
+      const names = added.map((c) => c.name).join(", ");
+      // "skipped" means already tracked — worth saying out loud, because a user
+      // re-running the same command should be told nothing was lost.
+      ok(
+        `Tracking ${added.length} new competitor${added.length === 1 ? "" : "s"}` +
+          (names ? `: ${names}` : "") +
+          (out.skipped ? ` (${out.skipped} already tracked)` : "") +
+          ".",
+      );
+      return;
+    }
+
+    if (sub === "remove" || sub === "rm") {
+      const competitorId = need(rest_[1], "competitors remove needs a <competitorId>");
+      const out = await withAutoLogin(() => rest(base, "DELETE", `/competitors/${competitorId}`));
+      if (JSON_OUT) return printJson(out);
+      ok(`Stopped tracking ${out.removed?.name ?? competitorId}.`);
+      return;
+    }
+
+    if (sub === "discovered") {
+      // Not a guess: companies THIS project's own answers already named, which
+      // nobody is tracking. The evidence is the answers you paid for.
+      const projectId = need(rest_[1], "competitors discovered needs a <projectId>");
+      const out = await withAutoLogin(() =>
+        rest(base, "GET", `/projects/${projectId}/competitors/discovered`),
+      );
+      if (JSON_OUT) return printJson(out);
+      const rows = out.discovered ?? out.companies ?? [];
+      if (!rows.length) {
+        info("No untracked companies have shown up in this project's answers yet.");
+        return;
+      }
+      table(
+        rows.map((d) => ({
+          name: d.name,
+          answers: d.responses ?? d.count ?? "",
+          example: (d.example ?? d.snippet ?? "").slice(0, 60),
+        })),
+        [
+          { key: "name", label: "COMPANY" },
+          { key: "answers", label: "ANSWERS" },
+          { key: "example", label: "SEEN IN" },
+        ],
+      );
+      info(c.dim("\nTrack one with: lettertrace competitors add <projectId> <name>"));
+      return;
+    }
+
+    // list: competitors <projectId>
+    const projectId = need(sub, "competitors needs a <projectId> (or a subcommand: add, remove, discovered)");
+    const out = await withAutoLogin(() => rest(base, "GET", `/projects/${projectId}/competitors`));
+    if (JSON_OUT) return printJson(out);
+    const rows = out.competitors ?? [];
+    if (!rows.length) {
+      info("No competitors tracked yet. Share of voice needs something to compare against —");
+      info(c.dim("add some with: lettertrace competitors add <projectId> Drata Secureframe"));
+      return;
+    }
+    table(
+      rows.map((x) => ({
+        id: x.id,
+        name: x.name,
+        domain: x.domain ?? "",
+        aliases: (x.aliases ?? []).join(", "),
+      })),
+      [
+        { key: "id", label: "ID" },
+        { key: "name", label: "NAME" },
+        { key: "domain", label: "DOMAIN" },
+        { key: "aliases", label: "ALIASES" },
+      ],
+    );
+  },
+
   async projects() {
     const sub = rest_[0] ?? "list";
     if (sub === "create") {
@@ -614,6 +739,11 @@ function printHelp() {
     "  prompts <projectId>                    List a project's prompts",
     "  prompts add <projectId> --text <t> --topic <top>",
     "  prompts toggle <promptId> --on|--off",
+    "  competitors <projectId>                Competitors tracked for a project",
+    "  competitors add <projectId> <name...>  Track competitors by name",
+    "  competitors add <projectId> --name <n> [--domain <d>] [--aliases a,b]",
+    "  competitors remove <competitorId>      Stop tracking one",
+    "  competitors discovered <projectId>     Companies the answers named but nobody tracks",
     "  runs <projectId> [--limit <n>]         List runs",
     "  runs trigger <projectId> [--provider <p>] [--model <m>]",
     "  runs get <runId>                       Share-of-voice report",

--- a/cli/lettertrace.mjs
+++ b/cli/lettertrace.mjs
@@ -473,7 +473,7 @@ const commands = {
           { key: "example", label: "SEEN IN" },
         ],
       );
-      info(c.dim("\nTrack one with: lettertrace competitors add <projectId> <name>"));
+      info(c.dim("\nTrack one with: lettertrace competitors add <project> <name>"));
       return;
     }
 
@@ -486,7 +486,7 @@ const commands = {
     const rows = out.competitors ?? [];
     if (!rows.length) {
       info("No competitors tracked yet. Share of voice needs something to compare against —");
-      info(c.dim("add some with: lettertrace competitors add <projectId> Drata Secureframe"));
+      info(c.dim("add some with: lettertrace competitors add <project> Drata Secureframe"));
       return;
     }
     table(


### PR DESCRIPTION
Answers Mathew's ask directly: *"setting up Lettertrace for Vanta, I should be able to set Drata, Secureframe etc as competitors"* — from the CLI, naming the project rather than pasting a uuid.

```
$ lettertrace competitors add Vanta Drata Secureframe
✓ Tracking 2 new competitors: Drata, Secureframe.
```

Two files: the CLI and the README. No server change — the v1 API already had all of this from #47, nothing exposed it.

## 1 · The `competitors` command

| command | |
|---|---|
| `competitors <project>` | what's tracked, with ids |
| `competitors add <project> Drata Secureframe` | several by name |
| `competitors add <project> --name Sprinto --domain sprinto.com --aliases "Sprinto Inc"` | one, in detail |
| `competitors remove <competitorId>` | stop tracking |
| `competitors discovered <project>` | companies your answers named that nobody tracks |

Two shapes for `add` because both are natural, and **mixing them is refused** rather than silently applying one competitor's domain to a whole list of names. Already-tracked names come back as skipped rather than as an error, so re-running a setup script is safe; the brand itself is refused as its own competitor.

## 2 · A project can be named, not just pointed at

Every command that took a `<projectId>` now takes a `<project>`, resolved in order: **project name → brand name → full uuid → unambiguous id prefix**. A uuid short-circuits with no lookup at all, so **nothing an agent does changes** — this exists so a person can say what they mean.

The prefix case is there because a shortened id is what you copy out of a table or a screen recording. It only applies to strings that could plausibly be one (four hex characters or more), so a brand called "Ada" is never read as an id.

**An ambiguous name is refused with the matching ids listed, never guessed at.** Silently writing competitors to the wrong project is the failure worth designing against — it would surface weeks later in a client report, if at all.

```
$ lettertrace competitors Twins
✗ "Twins" matches 2 projects. Use the id instead:
    9f3c…  Twins (TwinsOne)
    2b71…  Twins (TwinsTwo)
```

## Three bugs found by testing against a live server

None of these were visible from reading the code:

- **The response shape differs between endpoints.** Competitors answers `{ competitors, skipped }` where prompts answers `{ created, skipped }`. The first version read the prompts shape and **crashed on success** — after the write had landed, so the user saw a stack trace for an operation that worked.
- **Every `--flag` swallowed the next word as its value.** `--json competitors <id>` set `json` to `"competitors"` and then failed with `Unknown command: <id>`. The documented "every command takes `--json`" only held if you put it last. Switch flags are a known set now — this affected every command, not just the new one.
- **The CLI's own hints still said `<projectId>`** one commit after names started working. A hint that contradicts the help text is worse than no hint.

## Testing

**25 checks across two suites**, both driving `cli/lettertrace.mjs` as a child process against a live server on throwaway accounts with scoped OAuth tokens, asserting against the **database** rather than the CLI's own output.

The command itself (14): empty state, bulk add, detailed add, duplicates, brand-as-competitor refusal, mixed-form refusal, listing, rows really in the database, domain and aliases stored, removal, removal really happened, discovered, `--json`, usage error.

Name resolution (11): by project name, by brand name, case-insensitive, short id prefix, full uuid, writes landing on the *right* project in each case, ambiguous name refusing with ids, unknown name listing what exists, and the same resolution working on `runs` and `history`.

`502 tests, typecheck, lint, build` clean.

## Demo

A replay of a real session (actual captured output and timings) is published as an artifact — private until shared from its own share menu, so it's a teammate link rather than a public one.

## Not in this PR

**AI competitor research over the API.** `discovered` is evidence-based — companies this project's own answers already named. The other kind, Claude *proposing* competitors from the brand description, lives only behind the dashboard's cookie session (`/api/competitors/suggest`); there's no v1 route, so no CLI or agent can reach it.

Worth doing next, with one decision attached: that dashboard route runs on the trial-key ladder, while every v1 write is strictly BYOK so API-triggered work never spends the operator's allowance. I'd keep the BYOK rule and have a trial-only user get a clear refusal rather than silently burning free runs from a script — but that's a product call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
