### PR TITLE
Read every row, not the first thousand of them

### DIFF
--- a/lib/api-service.test.ts
+++ b/lib/api-service.test.ts
@@ -80,6 +80,13 @@ function fakeDb(handlers: Record<string, Handler>) {
           q.modifiers.push(["limit", ...args]);
           return proxy;
         },
+        // Paged reads ask for an inclusive range and stop on a short page. The
+        // handlers here return a single page's worth, which is what ends the
+        // loop — see lib/paging.
+        range: (...args: unknown[]) => {
+          q.modifiers.push(["range", ...args]);
+          return proxy;
+        },
         single: async () => result(),
         maybeSingle: async () => result(),
         then: (resolve: (v: unknown) => unknown, reject?: (e: unknown) => unknown) =>

--- a/lib/api-service.ts
+++ b/lib/api-service.ts
@@ -28,6 +28,7 @@ import {
 } from "@/lib/metrics";
 import { waitUntil } from "@vercel/functions";
 import { normalizeCompetitorList } from "@/lib/competitors";
+import { selectAll } from "@/lib/paging";
 import { discoverCompanies, type DiscoveredCompany } from "@/lib/discover";
 import {
   executeRun,
@@ -888,22 +889,33 @@ export async function getRunReport(
       .from("responses")
       .select("id", { count: "exact", head: true })
       .eq("run_id", runId),
-    mentions: supabase.from("mentions").select("*").eq("run_id", runId),
-    sources: supabase.from("sources").select("response_id, url, is_owned").eq("run_id", runId),
-    responseTopics: supabase.from("responses").select("id, topic_id, prompt_id").eq("run_id", runId),
+    // These four grow with answers, prompts and entities, so they page rather
+    // than trusting a single unpaginated read — see lib/paging. They hand back
+    // rows directly; only the un-paged queries carry a { data } envelope.
+    mentions: selectAll<Mention>((f, t) =>
+      supabase.from("mentions").select("*").eq("run_id", runId).range(f, t),
+    ),
+    sources: selectAll<Pick<Source, "response_id" | "url" | "is_owned">>((f, t) =>
+      supabase.from("sources").select("response_id, url, is_owned").eq("run_id", runId).range(f, t),
+    ),
+    responseTopics: selectAll<{ id: string; topic_id: string | null; prompt_id: string | null }>(
+      (f, t) => supabase.from("responses").select("id, topic_id, prompt_id").eq("run_id", runId).range(f, t),
+    ),
     topics: supabase.from("topics").select("id, name").eq("project_id", run.project_id),
-    promptTargets: supabase.from("prompts").select("id, target_url").eq("project_id", run.project_id),
+    promptTargets: selectAll<{ id: string; target_url: string | null }>((f, t) =>
+      supabase.from("prompts").select("id, target_url").eq("project_id", run.project_id).range(f, t),
+    ),
     competitors: supabase
       .from("competitors")
       .select("id", { count: "exact", head: true })
       .eq("project_id", run.project_id),
   });
   const { count } = results.responseCount;
-  const { data: mentionRows } = results.mentions;
-  const { data: sourceRows } = results.sources;
-  const { data: responseTopicRows } = results.responseTopics;
+  const mentionRows = results.mentions;
+  const sourceRows = results.sources;
+  const responseTopicRows = results.responseTopics;
   const { data: topicRows } = results.topics;
-  const { data: promptTargetRows } = results.promptTargets;
+  const promptTargetRows = results.promptTargets;
   const { count: competitorCount } = results.competitors;
 
   const mentions = (mentionRows ?? []) as Mention[];
@@ -1023,19 +1035,29 @@ export async function getRunResponses(
   if (!project) return null;
 
   const results = await allOf({
-    responses: supabase
-      .from("responses")
-      .select("*")
-      .eq("run_id", runId)
-      .order("created_at", { ascending: true }),
-    sources: supabase.from("sources").select("*").eq("run_id", runId),
-    mentions: supabase.from("mentions").select("*").eq("run_id", runId),
-    prompts: supabase.from("prompts").select("id, text").eq("project_id", run.project_id),
+    // Every one of these grows with the size of the run — see lib/paging.
+    responses: selectAll<Response>((f, t) =>
+      supabase
+        .from("responses")
+        .select("*")
+        .eq("run_id", runId)
+        .order("created_at", { ascending: true })
+        .range(f, t),
+    ),
+    sources: selectAll<Source>((f, t) =>
+      supabase.from("sources").select("*").eq("run_id", runId).range(f, t),
+    ),
+    mentions: selectAll<Mention>((f, t) =>
+      supabase.from("mentions").select("*").eq("run_id", runId).range(f, t),
+    ),
+    prompts: selectAll<Pick<Prompt, "id" | "text">>((f, t) =>
+      supabase.from("prompts").select("id, text").eq("project_id", run.project_id).range(f, t),
+    ),
   });
-  const { data: responseRows } = results.responses;
-  const { data: sourceRows } = results.sources;
-  const { data: mentionRows } = results.mentions;
-  const { data: promptRows } = results.prompts;
+  const responseRows = results.responses;
+  const sourceRows = results.sources;
+  const mentionRows = results.mentions;
+  const promptRows = results.prompts;
 
   const promptTextById = new Map(
     ((promptRows ?? []) as Pick<Prompt, "id" | "text">[]).map((p) => [p.id, p.text]),

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1,6 +1,7 @@
 import { cache } from "react";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { decryptSecret } from "@/lib/crypto";
+import { selectAll } from "@/lib/paging";
 import type {
   Project,
   Provider,
@@ -19,12 +20,19 @@ export const getProjects = cache(async function getProjects(
   supabase: SupabaseClient,
   userId: string,
 ): Promise<Project[]> {
-  const { data } = await supabase
-    .from("projects")
-    .select("*")
-    .eq("user_id", userId)
-    .order("created_at", { ascending: true });
-  return (data as Project[] | null) ?? [];
+  // Paged, because an account can hold more projects than a single PostgREST
+  // read returns. One account per customer-fleet is a supported shape — every
+  // client is a project on it — and the 1001st would otherwise vanish from the
+  // org switcher, from `lettertrace projects`, and from the CLI's name lookup,
+  // which would then report a real project as "no project called that".
+  return selectAll<Project>((from, to) =>
+    supabase
+      .from("projects")
+      .select("*")
+      .eq("user_id", userId)
+      .order("created_at", { ascending: true })
+      .range(from, to),
+  );
 });
 
 /**

--- a/lib/engine.ts
+++ b/lib/engine.ts
@@ -13,6 +13,7 @@ import { detectMention, brandTerms } from "@/lib/mentions";
 import { pageKey } from "@/lib/metrics";
 import { modelLabel } from "@/lib/models";
 import { logActivity } from "@/lib/activity";
+import { selectAll } from "@/lib/paging";
 
 /**
  * Who/what asked for a run, forwarded to the activity log so every run — from
@@ -201,18 +202,21 @@ export async function prepareRun(params: ExecuteRunParams): Promise<PreparedRun>
     targetType: "run",
   };
 
-  const { data: promptRows } = await supabase
-    .from("prompts")
-    .select("*")
-    .eq("project_id", project.id)
-    .eq("is_active", true);
-  const prompts = (promptRows ?? []) as Prompt[];
+  // Paged: a run must ask the WHOLE portfolio. A silently truncated prompt list
+  // would just look like a smaller run, and the mention rate it produced would
+  // be over a different set of questions than the one before it.
+  const prompts = await selectAll<Prompt>((from, to) =>
+    supabase
+      .from("prompts")
+      .select("*")
+      .eq("project_id", project.id)
+      .eq("is_active", true)
+      .range(from, to),
+  );
 
-  const { data: competitorRows } = await supabase
-    .from("competitors")
-    .select("*")
-    .eq("project_id", project.id);
-  const competitors = (competitorRows ?? []) as Competitor[];
+  const competitors = await selectAll<Competitor>((from, to) =>
+    supabase.from("competitors").select("*").eq("project_id", project.id).range(from, to),
+  );
 
   // Ask each prompt `replicates` times. Provider answers vary between identical
   // calls, so one ask can't tell "not mentioned" from "mentioned, unlucky" — at

--- a/lib/paging.test.ts
+++ b/lib/paging.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { selectAll } from "@/lib/paging";
+
+/** A fake table of `total` rows that honours an inclusive range, the way
+ *  PostgREST does, and records the ranges it was asked for. */
+function fakeTable(total: number, pageSize = 1000) {
+  const asked: [number, number][] = [];
+  const page = async (from: number, to: number) => {
+    asked.push([from, to]);
+    const rows = [];
+    for (let i = from; i <= Math.min(to, total - 1); i++) rows.push({ i });
+    return { data: rows, error: null };
+  };
+  return { page, asked, pageSize };
+}
+
+describe("selectAll", () => {
+  it("returns everything past the server's row cap", async () => {
+    const t = fakeTable(2500);
+    const rows = await selectAll(t.page);
+    expect(rows).toHaveLength(2500);
+    // and in order, so callers that assume ordering still can
+    expect(rows[0]).toEqual({ i: 0 });
+    expect(rows[2499]).toEqual({ i: 2499 });
+  });
+
+  it("stops on a short page rather than probing forever", async () => {
+    const t = fakeTable(1500);
+    await selectAll(t.page);
+    expect(t.asked).toEqual([
+      [0, 999],
+      [1000, 1999],
+    ]);
+  });
+
+  // The boundary that would otherwise loop one extra time or, worse, stop early.
+  it("handles an exact multiple of the page size", async () => {
+    const t = fakeTable(2000);
+    const rows = await selectAll(t.page);
+    expect(rows).toHaveLength(2000);
+    expect(t.asked).toHaveLength(3); // 0-999, 1000-1999, then the empty probe
+  });
+
+  it("handles empty and single-page results in one round trip", async () => {
+    const empty = fakeTable(0);
+    expect(await selectAll(empty.page)).toEqual([]);
+    expect(empty.asked).toHaveLength(1);
+
+    const small = fakeTable(3);
+    expect(await selectAll(small.page)).toHaveLength(3);
+    expect(small.asked).toHaveLength(1);
+  });
+
+  // Returning what arrived before the failure would be a partial result that
+  // looks complete — precisely the bug this module exists to prevent.
+  it("throws on a query error instead of returning a partial set", async () => {
+    const page = async (from: number) =>
+      from === 0
+        ? { data: Array.from({ length: 1000 }, (_, i) => ({ i })), error: null }
+        : { data: null, error: { message: "boom" } as never };
+    await expect(selectAll(page)).rejects.toMatchObject({ message: "boom" });
+  });
+
+  it("respects a caller-chosen page size", async () => {
+    const t = fakeTable(250);
+    const rows = await selectAll(t.page, 100);
+    expect(rows).toHaveLength(250);
+    expect(t.asked).toEqual([
+      [0, 99],
+      [100, 199],
+      [200, 299],
+    ]);
+  });
+});

--- a/lib/paging.ts
+++ b/lib/paging.ts
@@ -1,0 +1,36 @@
+import type { PostgrestError } from "@supabase/supabase-js";
+
+/**
+ * Read every row of a query, not the first page of it.
+ *
+ * PostgREST caps an unpaginated select at a server-configured maximum (1000 rows
+ * on Supabase's default) and says nothing about it: no error, no flag, just a
+ * short array. Measured on this deployment — a `select` over a 7,173-row table
+ * returned exactly 1000.
+ *
+ * That silence is the danger. A truncated read of `runs` is a missing row in a
+ * list; a truncated read of `sources` or `mentions` is a share-of-voice number
+ * computed over part of the evidence and presented as if it were whole. The
+ * failure has no symptom until someone reconciles a report by hand.
+ *
+ * So anything whose row count grows with answers, prompts or projects reads
+ * through here. `range` is inclusive on both ends, and a short page means the
+ * end — asking for one page beyond the data returns empty rather than erroring,
+ * so the loop terminates on its own.
+ */
+export async function selectAll<T>(
+  page: (from: number, to: number) => PromiseLike<{ data: T[] | null; error: PostgrestError | null }>,
+  pageSize = 1000,
+): Promise<T[]> {
+  const rows: T[] = [];
+  for (let from = 0; ; from += pageSize) {
+    const { data, error } = await page(from, from + pageSize - 1);
+    // Surface the failure rather than returning a partial set that looks
+    // complete — reporting half the evidence as all of it is the thing this
+    // module exists to prevent.
+    if (error) throw error;
+    const batch = data ?? [];
+    rows.push(...batch);
+    if (batch.length < pageSize) return rows;
+  }
+}


### PR DESCRIPTION
PostgREST caps an unpaginated select at a server-configured maximum — **1000 rows** on Supabase's default — and says nothing about it. No error, no flag, just a short array. Measured on the shared deployment:

```
unlimited select returned: 1000 rows
actual row count:          7173
```

Found while looking at something else: with one account per customer-fleet (each client a project on it), `getProjects` would stop seeing the 1001st project. Auditing for that turned up the sharper version of the same bug.

## Why the silence is the problem

A truncated read of `runs` is a missing row in a list — someone notices. A truncated read of `sources` or `mentions` is **a share-of-voice number computed over part of the evidence and presented as whole**, and nobody notices, because there is no symptom until a report is reconciled by hand.

**This is not hypothetical.** The largest run on the shared account already carries **535 sources for 100 answers**, so roughly 190 answers crosses the line — and probe-heavy portfolios (mention / citation / target / page probes × replicates) clear that easily.

Demonstrated end to end on a seeded run of 1,201 sources, where the only citation of a tracked page sat past the cut:

```
sources on the run:            1201
an unpaginated read returns:   1000
...and contains the citation of the tracked page? NO

report (paged) says for https://acme.com/guides/soc2:
  responsesCiting = 1, citedRate = 1
```

Before this change that page read as **never cited — citedRate 0** — with nothing to indicate the evidence had been cut off. That is the per-URL tracking from #49 quietly reporting the opposite of the truth.

## The fix

`lib/paging` exports `selectAll`, which walks `range` until a short page. It **throws** on a query error rather than returning what arrived first, because a partial set that looks complete is precisely the failure being fixed.

Applied to every read whose row count grows with answers, prompts, entities or projects:

| where | why |
|---|---|
| `getRunReport` — mentions, sources, response topics, prompt targets | the report's numbers are computed from these |
| `getRunResponses` — responses, sources, mentions, prompts | one row per answer, plus its evidence |
| `getProjects` | the 1001st project would vanish from the org switcher, from `lettertrace projects`, and from the CLI's name lookup — which would then report a real project as *"no project called that"* |
| the engine's prompt and competitor lists | a run must ask the **whole** portfolio, or its mention rate is over a different set of questions than the run before it |

Fixed-size reads (a project's topics, a per-run head count) are left alone.

## Testing

6 unit tests for the helper — past the cap, short-page termination, the exact-multiple boundary, empty and single-page, error propagation, custom page size — plus the seeded live-database demonstration above.

`508 tests, typecheck, lint, build` clean.

## Note for review

`selectAll` returns rows directly, so inside `allOf` the paged entries are arrays while the un-paged ones still carry a `{ data }` envelope. That asymmetry is visible at the destructure and is deliberate: wrapping the paged results back into `{ data }` cost the type inference and read worse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
