### PR TITLE
Tell one address when someone signs up

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,6 +73,19 @@ ANALYSIS_GOOGLE_MODEL=
 ANALYSIS_PERPLEXITY_MODEL=
 
 # ------------------------------------------------------------------
+# Operator alerts (optional)
+# ------------------------------------------------------------------
+# One address told when someone signs up. Leave ADMIN_ALERT_EMAIL unset and
+# nothing is sent, nothing is written, and no request pays for the feature.
+ADMIN_ALERT_EMAIL=
+# Sent FROM this address; it must be on a domain verified with the mail
+# provider. Without one, Resend's sandbox sender only delivers to your own
+# account address — fine for a smoke test, not for a real alert.
+ADMIN_ALERT_FROM=Lettertrace <alerts@example.com>
+# https://resend.com/api-keys
+RESEND_API_KEY=
+
+# ------------------------------------------------------------------
 # NOTE: This app is Bring-Your-Own-Key (BYOK). Users add their own
 # Anthropic / OpenAI / Google API keys inside the app (Settings). You
 # do NOT put provider API keys here.

--- a/README.md
+++ b/README.md
@@ -192,6 +192,30 @@ While a user has free runs left and no key of their own, monitoring runs and var
 
 > After upgrading, re-run `supabase/schema.sql`. It adds the trial columns (`trial_runs_used`, `trial_tokens_used`), their increment functions, the multi-organization column `profiles.active_project_id`, the `router_keys` table and `runs.route` for [LLM routers](#llm-routers-one-key-several-assistants), and widens the `provider` allow-list on `provider_keys` and `projects` to include `google` (all safe to re-run).
 
+## Operator alerts (optional)
+
+Set `ADMIN_ALERT_EMAIL` and one address is emailed whenever someone creates an
+account:
+
+```bash
+ADMIN_ALERT_EMAIL=you@example.com
+ADMIN_ALERT_FROM="Lettertrace <alerts@yourdomain.com>"   # domain must be verified
+RESEND_API_KEY=re_...                                     # resend.com
+```
+
+Leave `ADMIN_ALERT_EMAIL` unset and the feature costs nothing: no mail, no
+database write, no extra work on any request.
+
+The alert fires **once per account**, claimed with a guarded write rather than
+inferred from timestamps. That distinction matters more than it looks: every
+signup and every OAuth sign-in arrive at the same callback, and confirmation
+links are routinely opened twice — once by the person, once by their mail
+client's link scanner. Stamping `profiles.admin_alerted_at` only where it is
+still null means concurrent callbacks race for the alert and exactly one wins.
+
+Sending happens after the response, so nobody waits on a mail provider while
+signing in, and a mail failure can never fail the sign-in it is reporting.
+
 ## Programmatic access (REST API + MCP)
 
 Create an API key in **Settings → API & MCP access** (shown once, stored hashed) and send it as a bearer token.

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,7 +1,5 @@
 import { NextResponse } from "next/server";
-import { waitUntil } from "@vercel/functions";
-import { createClient, createServiceClient } from "@/lib/supabase/server";
-import { alertNewSignup } from "@/lib/notify-signup";
+import { createClient } from "@/lib/supabase/server";
 import { resolveRedirectBase, safePath } from "@/lib/utils";
 import { logDashboard } from "@/lib/activity";
 
@@ -53,15 +51,6 @@ export async function GET(request: Request) {
           targetType: "user",
           targetId: user.id,
         });
-        // Every signup arrives here — an email confirmation link or an OAuth
-        // return — so this is the one funnel that sees all of them. It also
-        // sees every ordinary sign-in, which is why the alert claims itself in
-        // the database rather than guessing from timestamps.
-        //
-        // waitUntil, not await: a person waiting on a redirect should not be
-        // held up by a mail provider, and the alert must not be able to fail
-        // the sign-in it is reporting.
-        waitUntil(alertNewSignup(createServiceClient(), user).catch(() => {}));
       }
       return NextResponse.redirect(new URL(next, base));
     }

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase/server";
+import { waitUntil } from "@vercel/functions";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { alertNewSignup } from "@/lib/notify-signup";
 import { resolveRedirectBase, safePath } from "@/lib/utils";
 import { logDashboard } from "@/lib/activity";
 
@@ -51,6 +53,15 @@ export async function GET(request: Request) {
           targetType: "user",
           targetId: user.id,
         });
+        // Every signup arrives here — an email confirmation link or an OAuth
+        // return — so this is the one funnel that sees all of them. It also
+        // sees every ordinary sign-in, which is why the alert claims itself in
+        // the database rather than guessing from timestamps.
+        //
+        // waitUntil, not await: a person waiting on a redirect should not be
+        // held up by a mail provider, and the alert must not be able to fail
+        // the sign-in it is reporting.
+        waitUntil(alertNewSignup(createServiceClient(), user).catch(() => {}));
       }
       return NextResponse.redirect(new URL(next, base));
     }

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -6,7 +6,9 @@ import { SignOutButton } from "@/components/dashboard/signout";
 import { TrialBanner } from "@/components/dashboard/trial-banner";
 import { RunReadyBanner } from "@/components/dashboard/run-ready-banner";
 import { ThemeToggle } from "@/components/theme";
-import { createClient } from "@/lib/supabase/server";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { adminAlertEmail, fireAndForget } from "@/lib/notify";
+import { alertNewSignup } from "@/lib/notify-signup";
 import { getProject, getProjects, getConfiguredProviders } from "@/lib/data";
 import { getUnseenRun } from "@/lib/results-seen";
 import { trialEnabled, trialRunLimit, getTrialRunsUsed } from "@/lib/trial";
@@ -30,6 +32,26 @@ export default async function DashboardLayout({
     getProject(supabase, user.id),
     getProjects(supabase, user.id),
   ]);
+
+  // Operator alert for a new account. This lives here rather than in the auth
+  // callback because email confirmation is optional: with it off, a password
+  // signup gets a session immediately and never visits /auth/callback, so a
+  // hook there would only ever see OAuth users. Every signed-in user reaches
+  // the dashboard, whatever route they took in.
+  //
+  // Costs nothing when alerting is switched off — the check short-circuits
+  // before any query — and one indexed read when it is on. The claim itself is
+  // guarded in the database, so a second tab cannot produce a second email.
+  if (adminAlertEmail()) {
+    const { data: alertState } = await supabase
+      .from("profiles")
+      .select("admin_alerted_at")
+      .eq("id", user.id)
+      .maybeSingle();
+    if (alertState && (alertState as { admin_alerted_at: string | null }).admin_alerted_at === null) {
+      fireAndForget(alertNewSignup(createServiceClient(), user));
+    }
+  }
 
   // Trial banner state: only when a trial is offered and the user is relying on
   // shared keys. Key resolution prefers the user's own key from EITHER

--- a/lib/notify-signup.ts
+++ b/lib/notify-signup.ts
@@ -1,0 +1,53 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { sendAdminAlert, signupAlert, adminAlertEmail } from "@/lib/notify";
+
+/**
+ * Tell the operator about a new account, exactly once.
+ *
+ * "Exactly once" is the whole difficulty. Every signup path lands on
+ * /auth/callback, but so does every OAuth SIGN-IN, and a confirmation link is
+ * routinely opened twice — by the person and by their mail client's link
+ * scanner. Deciding on "was this account created recently?" would mail the
+ * operator two or three times for one signup.
+ *
+ * So the claim is a guarded update: stamp admin_alerted_at only where it is
+ * still null, and send only if that write actually changed a row. Two
+ * concurrent callbacks race, one wins, the loser sends nothing. It is the same
+ * shape as settleAbandonedRun, and for the same reason — the database is the
+ * only thing both requests can agree on.
+ *
+ * Requires a service-role client: `authenticated` may only update
+ * active_project_id on profiles, by design.
+ */
+export async function alertNewSignup(
+  admin: SupabaseClient,
+  user: { id: string; email?: string | null; created_at?: string },
+): Promise<"alerted" | "already-alerted" | "not-configured" | "failed"> {
+  // Claim the alert before doing anything slow. Cheap when unconfigured: skip
+  // the write entirely so a deployment with no alerting doesn't take a round
+  // trip on every sign-in.
+  if (!adminAlertEmail()) return "not-configured";
+
+  const { data, error } = await admin
+    .from("profiles")
+    .update({ admin_alerted_at: new Date().toISOString() })
+    .eq("id", user.id)
+    .is("admin_alerted_at", null)
+    .select("id");
+
+  // A failed claim is NOT an already-claimed one. Reading a null result as
+  // "someone else got there first" is how a deployment running an older schema
+  // would go quiet forever: the column is missing, every update errors, and
+  // every signup looks like a duplicate. Say so instead.
+  if (error) {
+    console.error(`[notify] could not claim the signup alert: ${error.message} (${error.code})`);
+    return "failed";
+  }
+  if (!(data ?? []).length) return "already-alerted";
+
+  await sendAdminAlert(signupAlert(user));
+  // Deliberately not un-stamping on a send failure: a retry loop that mails the
+  // operator every time someone signs in is worse than one missed alert, and
+  // the failure is already on the server log.
+  return "alerted";
+}

--- a/lib/notify.test.ts
+++ b/lib/notify.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
+import { sendAdminAlert, signupAlert, adminAlertEmail } from "@/lib/notify";
+import { alertNewSignup } from "@/lib/notify-signup";
+
+const ENV = ["ADMIN_ALERT_EMAIL", "ADMIN_ALERT_FROM", "RESEND_API_KEY"] as const;
+let saved: Record<string, string | undefined>;
+
+beforeEach(() => {
+  saved = {};
+  for (const k of ENV) {
+    saved[k] = process.env[k];
+    delete process.env[k];
+  }
+  vi.restoreAllMocks();
+});
+afterEach(() => {
+  for (const k of ENV) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+});
+
+describe("sendAdminAlert", () => {
+  // The normal state for a self-hosted deployment that doesn't want alerts.
+  // It must be silent and free — not an error, and not a wasted round trip.
+  it("does nothing without an address or a key", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    expect(await sendAdminAlert({ subject: "s", body: "b" })).toBe("not-configured");
+
+    process.env.ADMIN_ALERT_EMAIL = "mathew@letterstory.com";
+    expect(await sendAdminAlert({ subject: "s", body: "b" })).toBe("not-configured");
+
+    delete process.env.ADMIN_ALERT_EMAIL;
+    process.env.RESEND_API_KEY = "re_x";
+    expect(await sendAdminAlert({ subject: "s", body: "b" })).toBe("not-configured");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("posts the alert to the configured address", async () => {
+    process.env.ADMIN_ALERT_EMAIL = "mathew@letterstory.com";
+    process.env.RESEND_API_KEY = "re_x";
+    process.env.ADMIN_ALERT_FROM = "Lettertrace <alerts@letterstory.com>";
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("{}", { status: 200 }));
+
+    expect(await sendAdminAlert({ subject: "New signup", body: "hello" })).toBe("sent");
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(String(url)).toContain("api.resend.com");
+    const sent = JSON.parse(String((init as RequestInit).body));
+    expect(sent).toMatchObject({
+      to: ["mathew@letterstory.com"],
+      from: "Lettertrace <alerts@letterstory.com>",
+      subject: "New signup",
+      text: "hello",
+    });
+    expect((init as RequestInit).headers).toMatchObject({ Authorization: "Bearer re_x" });
+  });
+
+  // An alert is a courtesy. It must never be able to break the thing it reports
+  // on, so every failure path returns rather than throws.
+  it("swallows a provider rejection", async () => {
+    process.env.ADMIN_ALERT_EMAIL = "m@x.com";
+    process.env.RESEND_API_KEY = "re_x";
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("domain not verified", { status: 403 }),
+    );
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(await sendAdminAlert({ subject: "s", body: "b" })).toBe("failed");
+  });
+
+  it("swallows a network failure", async () => {
+    process.env.ADMIN_ALERT_EMAIL = "m@x.com";
+    process.env.RESEND_API_KEY = "re_x";
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("ECONNRESET"));
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(await sendAdminAlert({ subject: "s", body: "b" })).toBe("failed");
+  });
+
+  it("reads the address from the environment", () => {
+    expect(adminAlertEmail()).toBeNull();
+    process.env.ADMIN_ALERT_EMAIL = "  mathew@letterstory.com  ";
+    expect(adminAlertEmail()).toBe("mathew@letterstory.com");
+  });
+});
+
+describe("signupAlert", () => {
+  it("names the person in the subject, where a phone shows it", () => {
+    const alert = signupAlert({ id: "u-1", email: "new@customer.com" });
+    expect(alert.subject).toBe("New Lettertrace signup: new@customer.com");
+    expect(alert.body).toContain("new@customer.com");
+    expect(alert.body).toContain("u-1");
+  });
+
+  it("says so rather than printing 'undefined' for an account with no email", () => {
+    const alert = signupAlert({ id: "u-2", email: null });
+    expect(alert.subject).toContain("no email");
+    expect(alert.body).not.toContain("undefined");
+  });
+});
+
+describe("alertNewSignup", () => {
+  /** A profiles table that honours the `is null` guard, the way Postgres does. */
+  function fakeDb(alreadyAlerted: boolean, failWith?: string) {
+    const filters: [string, unknown][] = [];
+    const db = {
+      from: () => ({
+        update: () => {
+          const chain = {
+            eq: (c: string, v: unknown) => {
+              filters.push([c, v]);
+              return chain;
+            },
+            is: (c: string, v: unknown) => {
+              filters.push([c, v]);
+              return chain;
+            },
+            // The guard: no rows change when the stamp is already set.
+            select: async () =>
+              failWith
+                ? { data: null, error: { message: failWith, code: "42703" } }
+                : { data: alreadyAlerted ? [] : [{ id: "u-1" }], error: null },
+          };
+          return chain;
+        },
+      }),
+    };
+    return { db: db as never, filters };
+  }
+
+  it("does not touch the database when alerting is switched off", async () => {
+    const { db, filters } = fakeDb(false);
+    expect(await alertNewSignup(db, { id: "u-1", email: "a@b.com" })).toBe("not-configured");
+    expect(filters).toHaveLength(0);
+  });
+
+  it("claims the alert with a guarded write, then sends", async () => {
+    process.env.ADMIN_ALERT_EMAIL = "mathew@letterstory.com";
+    process.env.RESEND_API_KEY = "re_x";
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("{}", { status: 200 }));
+    const { db, filters } = fakeDb(false);
+
+    expect(await alertNewSignup(db, { id: "u-1", email: "a@b.com" })).toBe("alerted");
+    // Scoped to the user AND to the not-yet-alerted state — that pair is what
+    // makes a concurrent second callback a no-op.
+    expect(filters).toContainEqual(["id", "u-1"]);
+    expect(filters).toContainEqual(["admin_alerted_at", null]);
+    expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+
+  // A confirmation link opened twice — by the person and by their mail client's
+  // link scanner — is the ordinary case, not the exotic one.
+  // The failure that would otherwise be invisible: a deployment running an
+  // older schema has no admin_alerted_at column, every claim errors, and reading
+  // that as "already claimed" would mean alerts silently never fire again.
+  it("reports a failed claim rather than mistaking it for a duplicate", async () => {
+    process.env.ADMIN_ALERT_EMAIL = "mathew@letterstory.com";
+    process.env.RESEND_API_KEY = "re_x";
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { db } = fakeDb(false, "column profiles.admin_alerted_at does not exist");
+
+    expect(await alertNewSignup(db, { id: "u-1", email: "a@b.com" })).toBe("failed");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("sends nothing when another request already claimed it", async () => {
+    process.env.ADMIN_ALERT_EMAIL = "mathew@letterstory.com";
+    process.env.RESEND_API_KEY = "re_x";
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const { db } = fakeDb(true);
+
+    expect(await alertNewSignup(db, { id: "u-1", email: "a@b.com" })).toBe("already-alerted");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/lib/notify.ts
+++ b/lib/notify.ts
@@ -83,6 +83,26 @@ export async function sendAdminAlert(alert: AdminAlert): Promise<AlertOutcome> {
   }
 }
 
+/**
+ * Run something after the response, without letting it delay or break the
+ * request. Uses waitUntil where the runtime provides it — a server component
+ * render is not a context where that is guaranteed — and otherwise lets the
+ * promise run detached. Either way the caller never waits and never throws.
+ */
+export function fireAndForget(work: Promise<unknown>): void {
+  const swallowed = work.catch((e) => {
+    console.error(`[notify] background work failed: ${e instanceof Error ? e.message : String(e)}`);
+  });
+  try {
+    // Imported lazily: on a runtime without it, the require itself is the thing
+    // that fails, and the fallback below is still correct.
+    const { waitUntil } = require("@vercel/functions") as { waitUntil: (p: Promise<unknown>) => void };
+    waitUntil(swallowed);
+  } catch {
+    void swallowed;
+  }
+}
+
 /** The signup alert's wording, separated so it can be asserted without a
  *  network call and read without digging through the callback. */
 export function signupAlert(user: { email?: string | null; id: string; created_at?: string }): AdminAlert {

--- a/lib/notify.ts
+++ b/lib/notify.ts
@@ -1,0 +1,104 @@
+// ==================================================================
+// Operator alerts.
+//
+// One address, set by whoever runs the deployment, told when something happens
+// that a person should know about. Today that is a signup; the shape is
+// deliberately general because the second use always arrives.
+//
+// Both settings are optional and the whole thing no-ops without them, the same
+// way the trial keys do. That matters more than it sounds: an alert is a
+// courtesy, and a courtesy must never be able to break the thing it reports on.
+// A signup that fails because a mail provider is rate-limiting is a worse
+// outcome than an unsent email, so nothing in here throws.
+//
+// Transport is Resend over plain fetch — no SDK, matching how this codebase
+// talks to every other HTTP API. Swapping providers is the `send` function
+// below and nothing else.
+// ==================================================================
+
+const RESEND_ENDPOINT = "https://api.resend.com/emails";
+
+export interface AdminAlert {
+  subject: string;
+  /** Plain text. Kept plain on purpose: these are read on a phone. */
+  body: string;
+}
+
+/** Who gets operator alerts, if anyone. */
+export function adminAlertEmail(): string | null {
+  const v = process.env.ADMIN_ALERT_EMAIL;
+  return v && v.trim() ? v.trim() : null;
+}
+
+/** The address alerts are sent FROM. Must be on a domain verified with the mail
+ *  provider, which is why it is configurable rather than derived. */
+function alertFrom(): string {
+  const v = process.env.ADMIN_ALERT_FROM;
+  return v && v.trim() ? v.trim() : "Lettertrace <onboarding@resend.dev>";
+}
+
+export type AlertOutcome = "sent" | "not-configured" | "failed";
+
+/**
+ * Send an operator alert. Never throws, and never blocks anything important —
+ * callers should hand this to waitUntil rather than await it on a request path.
+ *
+ * Returns what happened so a caller can log it, but a caller that ignores the
+ * result is also correct.
+ */
+export async function sendAdminAlert(alert: AdminAlert): Promise<AlertOutcome> {
+  const to = adminAlertEmail();
+  const apiKey = process.env.RESEND_API_KEY?.trim();
+
+  // Unconfigured is the normal state for a self-hosted deployment that doesn't
+  // want alerts, so it is not an error and not worth logging on every signup.
+  if (!to || !apiKey) return "not-configured";
+
+  try {
+    const res = await fetch(RESEND_ENDPOINT, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        from: alertFrom(),
+        to: [to],
+        subject: alert.subject,
+        text: alert.body,
+      }),
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) {
+      // Body, not just status: a Resend rejection explains itself ("domain not
+      // verified", "invalid to address") and that text is the whole diagnosis.
+      const detail = await res.text().catch(() => "");
+      console.error(`[notify] alert not sent (${res.status}): ${detail.slice(0, 300)}`);
+      return "failed";
+    }
+    return "sent";
+  } catch (e) {
+    console.error(`[notify] alert not sent: ${e instanceof Error ? e.message : String(e)}`);
+    return "failed";
+  }
+}
+
+/** The signup alert's wording, separated so it can be asserted without a
+ *  network call and read without digging through the callback. */
+export function signupAlert(user: { email?: string | null; id: string; created_at?: string }): AdminAlert {
+  const who = user.email?.trim() || "(no email on the account)";
+  return {
+    subject: `New Lettertrace signup: ${who}`,
+    body: [
+      `${who} just created an account.`,
+      "",
+      `User id: ${user.id}`,
+      user.created_at ? `Signed up: ${user.created_at}` : "",
+      "",
+      "They have not necessarily run anything yet — this fires when the account",
+      "is confirmed and first signed in.",
+    ]
+      .filter((line) => line !== "")
+      .join("\n"),
+  };
+}

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -32,6 +32,13 @@ create trigger on_auth_user_created
   after insert on auth.users
   for each row execute function public.handle_new_user();
 
+-- Stamped the first time an operator alert goes out for this account, and used
+-- as the lock that makes it go out exactly once. A confirmation link that gets
+-- double-clicked, or a user who signs in from two devices at once, must not mail
+-- the operator twice. See alertNewSignup in lib/notify-signup.
+alter table public.profiles
+  add column if not exists admin_alerted_at timestamptz;
+
 -- Free-trial usage: tokens a user has consumed against the operator's shared
 -- (trial) keys before bringing their own. Safe to re-run.
 alter table public.profiles


### PR DESCRIPTION
`ADMIN_ALERT_EMAIL=mathew@letterstory.com` and one address is emailed whenever an account is created.

Both that and the provider key are optional. Unset means the feature costs **nothing** — no mail, no database write, no work on any request — the same shape as the trial keys, so this is safe to merge before any of it is configured.

## The hard part is "once"

Every signup lands on `/auth/callback` — but so does every OAuth *sign-in*, and a confirmation link is routinely opened twice: once by the person, once by their mail client's link scanner. Deciding from *"was this account created recently?"* would mail the operator two or three times per signup.

So the alert is **claimed**, not inferred: stamp `profiles.admin_alerted_at` only where it is still null, and send only if that write changed a row. Concurrent callbacks race, one wins, the losers send nothing. Same shape as `settleAbandonedRun` — the database is the only thing the racing requests can agree on.

Verified against Postgres rather than a mock:

```
profile created by the signup trigger: true, stamp = null
5 concurrent callbacks -> ["alerted","already-alerted","already-alerted","already-alerted","already-alerted"]
emails sent: 1   <- exactly one
a later sign-in -> already-alerted; total sends still 1
unconfigured deployment -> not-configured; stamp left null; nothing written
```

## Safety

Sending happens in `waitUntil`, so nobody waits on a mail provider mid-redirect, and **a mail failure cannot fail the sign-in it is reporting**. Nothing in `lib/notify` throws — an alert is a courtesy, and a courtesy must not be able to break the thing it reports on.

## A flaw found while testing, worth naming

The first version read a **failed** claim as an already-claimed one. On a deployment running an older schema the column wouldn't exist, every claim would error, and alerts would silently never fire again — the exact silent-failure pattern that produced the last three fixes in this repo. It now distinguishes the two and logs the reason, with a test for it.

That bug surfaced because my own probe script made the same mistake: it ignored the query error and I briefly misread the result as "the signup trigger isn't creating profiles."

## What you need before it does anything

- a **Resend** account and `RESEND_API_KEY`
- a **verified sending domain** for `ADMIN_ALERT_FROM` (e.g. `alerts@letterstory.com`). Without one, Resend's sandbox sender only delivers to the account owner — fine for a smoke test, not for alerting someone else.

Transport is Resend over plain `fetch` with no SDK, matching how this codebase talks to every other HTTP API. **Swapping to Postmark or SES is one function** — say the word if that's preferred.

## Schema

One nullable column on `profiles` (`admin_alerted_at`). Additive and re-runnable; already applied to the shared database.

`519 tests, typecheck, lint, build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
