### PR TITLE
Publish the CLI to npm as a standalone lettertrace package

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,6 +15,7 @@ import {
 import { Badge, Button, Card } from "@/components/ui";
 import { Logo } from "@/components/logo";
 import { ThemeToggle } from "@/components/theme";
+import { InstallCli } from "@/components/install-cli";
 
 const GITHUB_URL = "https://github.com/letterstory/lettertrace";
 
@@ -161,6 +162,16 @@ export default function LandingPage() {
             <a href="#open-source" className="transition hover:text-ink">Open source</a>
           </nav>
           <div className="flex items-center gap-2">
+            <a
+              href={GITHUB_URL}
+              target="_blank"
+              rel="noreferrer"
+              aria-label="Lettertrace on GitHub"
+              title="Lettertrace on GitHub"
+              className="inline-flex h-9 w-9 items-center justify-center rounded border border-ink/15 text-ink-soft transition hover:border-ink/35 hover:text-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-terracotta/40"
+            >
+              <Github className="h-4 w-4" aria-hidden />
+            </a>
             <ThemeToggle />
             <Button href="/login" variant="ghost" size="sm">Sign in</Button>
             <Button href="/login" size="sm">Initialize</Button>
@@ -189,10 +200,7 @@ export default function LandingPage() {
                 Start monitoring: it&apos;s free
                 <ArrowRight className="h-4 w-4" />
               </Button>
-              <Button href={GITHUB_URL} variant="secondary" size="lg">
-                <Github className="h-4 w-4" />
-                Star on GitHub
-              </Button>
+              <InstallCli />
             </div>
             <p className="mt-4 font-mono text-xs text-ink-faint">
               works with ChatGPT, Claude &amp; Gemini · self-host in minutes

--- a/cli/LICENSE
+++ b/cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 The Letter Company
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,62 @@
+# lettertrace
+
+Command-line client for a [Lettertrace](https://github.com/letterstory/lettertrace) deployment: monitor how your brand shows up in AI assistant answers.
+
+Sign-in is OAuth 2.1 only (no API keys): the first command that needs access opens your browser to approve a scoped, expiring token, stored under `~/.lettertrace/config.json` and refreshed automatically. Data commands use the REST v1 API; the `mcp` commands speak the Model Context Protocol directly to `/api/mcp`, exactly as an AI assistant would.
+
+## Install
+
+```bash
+npm install -g lettertrace
+```
+
+Or run it without installing:
+
+```bash
+npx lettertrace help
+```
+
+Also published under the `@letterstory` org scope as `@letterstory/lettertrace` (same package). Both install a `lettertrace` command on your `PATH`.
+
+Requires Node.js 20 or newer.
+
+## Quick start
+
+```bash
+lettertrace login --url https://your-app.com   # browser sign-in / create account
+lettertrace whoami --json                       # machine-readable auth status
+
+# Bring your own provider key (verified on save, encrypted at rest)
+lettertrace keys set anthropic                   # hidden prompt
+
+# Build a project and start measuring
+lettertrace projects create --name "Acme" --brand "Acme" --domains acme.io
+lettertrace prompts add <project> --text "best crm for startups" --topic CRM
+lettertrace competitors add <project> Vanta Drata Secureframe
+lettertrace runs trigger <project>
+lettertrace runs get <runId>                     # share-of-voice report (--json for full)
+
+# Talk to the MCP endpoint directly
+lettertrace mcp tools
+lettertrace mcp call get_share_of_voice_report --project_id <project>
+```
+
+Every command accepts `--json` for machine-readable output and `--url <base>` to target a deployment.
+
+## Base URL
+
+Resolved in order: `--url`, then `$LETTERTRACE_URL`, then the URL saved at login, then the hosted default `https://lettertrace.com`.
+
+## Commands
+
+Run `lettertrace help` for the full list. Highlights:
+
+- **Auth** — `login`, `logout`, `whoami`
+- **Provider keys (BYOK)** — `keys`, `keys set <provider>`, `keys remove <provider>`
+- **Router keys** — `routers`, `routers set <router>`, `routers remove <router>`
+- **Data** — `projects`, `prompts`, `competitors`, `runs`, `history`, `logs`
+- **MCP** — `mcp tools`, `mcp call <tool>`
+
+## License
+
+MIT

--- a/cli/brand.mjs
+++ b/cli/brand.mjs
@@ -155,7 +155,7 @@ function renderGrid(level, grid, indent = 0) {
 
 function version() {
   try {
-    const pkgPath = fileURLToPath(new URL("../package.json", import.meta.url));
+    const pkgPath = fileURLToPath(new URL("./package.json", import.meta.url));
     return JSON.parse(readFileSync(pkgPath, "utf8")).version || "";
   } catch {
     return "";

--- a/cli/config.mjs
+++ b/cli/config.mjs
@@ -31,9 +31,9 @@ export function saveConfig(cfg) {
 }
 
 // Base URL precedence: explicit --url, then $LETTERTRACE_URL, then the base
-// saved at login, then localhost.
+// saved at login, then the hosted default at https://lettertrace.com.
 export function resolveBase(cliUrl) {
   const stored = loadConfig().base;
-  const base = cliUrl || process.env.LETTERTRACE_URL || stored || "http://localhost:3000";
+  const base = cliUrl || process.env.LETTERTRACE_URL || stored || "https://lettertrace.com";
   return base.replace(/\/+$/, "");
 }

--- a/cli/lettertrace.mjs
+++ b/cli/lettertrace.mjs
@@ -9,7 +9,7 @@
  * to /api/mcp, exactly as an AI assistant would.
  *
  * Run `lettertrace help` for the command list. Base URL comes from --url, then
- * $LETTERTRACE_URL, then the URL saved at login, then http://localhost:3000.
+ * $LETTERTRACE_URL, then the URL saved at login, then https://lettertrace.com.
  */
 
 import { resolveBase, loadConfig } from "./config.mjs";
@@ -804,7 +804,7 @@ function printHelp() {
     "  mcp call <tool> [--arg value ...]      Call an MCP tool",
     "",
     c.dim("Tokens live in ~/.lettertrace/config.json. Base URL: --url, then"),
-    c.dim("$LETTERTRACE_URL, then the login URL, then http://localhost:3000."),
+    c.dim("$LETTERTRACE_URL, then the login URL, then https://lettertrace.com."),
   ];
   process.stdout.write(lines.join("\n") + "\n");
 }

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "lettertrace",
+  "version": "0.1.1",
+  "description": "Command-line client for a Lettertrace deployment: monitor how your brand shows up in AI assistant answers.",
+  "license": "MIT",
+  "author": "The Letter Company",
+  "type": "module",
+  "bin": {
+    "lettertrace": "lettertrace.mjs"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "files": [
+    "*.mjs",
+    "README.md",
+    "LICENSE"
+  ],
+  "keywords": [
+    "lettertrace",
+    "cli",
+    "ai",
+    "share-of-voice",
+    "brand-monitoring",
+    "mcp",
+    "llm"
+  ],
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.26.0"
+  }
+}

--- a/components/install-cli.tsx
+++ b/components/install-cli.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { useEffect, useState, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+import { Check, Copy, Sparkles, Terminal, X } from "lucide-react";
+import { Button } from "@/components/ui";
+import { cn } from "@/lib/utils";
+
+// The "Install the CLI" hero action. Opens a small dialog with two ways to get
+// the CLI: a prompt to hand a coding agent, or the plain npm one-liner. Its own
+// "use client" island so the server-rendered landing page stays static.
+
+const NPM_COMMAND = "npm install -g lettertrace";
+
+const AGENT_PROMPT =
+  "Install and set up the Lettertrace CLI for me. Run `npm install -g lettertrace`, " +
+  "then `lettertrace login` to authenticate in the browser. Once I'm signed in, create a " +
+  "project for my brand and trigger a first monitoring run so I can see how AI assistants describe us.";
+
+type Tab = "agent" | "npm";
+
+export function InstallCli({ className }: { className?: string }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Button
+        variant="secondary"
+        size="lg"
+        className={className}
+        onClick={() => setOpen(true)}
+      >
+        <Terminal className="h-4 w-4" />
+        Install the CLI
+      </Button>
+      {open && <InstallDialog onClose={() => setOpen(false)} />}
+    </>
+  );
+}
+
+function InstallDialog({ onClose }: { onClose: () => void }) {
+  const [mounted, setMounted] = useState(false);
+  const [tab, setTab] = useState<Tab>("agent");
+
+  useEffect(() => setMounted(true), []);
+
+  // Escape to close; lock body scroll while the dialog is up.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prev;
+    };
+  }, [onClose]);
+
+  if (!mounted) return null;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="install-cli-title"
+    >
+      <div
+        className="absolute inset-0 bg-ink/40 backdrop-blur-sm animate-fade-up"
+        onClick={onClose}
+      />
+      <div className="relative w-full max-w-lg overflow-hidden rounded border border-ink/10 bg-paper shadow-lift animate-fade-up">
+        <div className="flex items-center justify-between border-b border-ink/10 px-5 py-4">
+          <h2 id="install-cli-title" className="text-lg font-semibold tracking-tight text-ink">
+            Install the CLI
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="inline-flex h-8 w-8 items-center justify-center rounded-[2px] text-ink-soft transition hover:bg-ink/[0.05] hover:text-ink"
+          >
+            <X className="h-4 w-4" aria-hidden />
+          </button>
+        </div>
+
+        <div className="flex gap-1 border-b border-ink/10 px-5 pt-3">
+          <TabButton active={tab === "agent"} onClick={() => setTab("agent")} icon={Sparkles}>
+            Coding Agent
+          </TabButton>
+          <TabButton active={tab === "npm"} onClick={() => setTab("npm")} icon={Terminal}>
+            Install via npm
+          </TabButton>
+        </div>
+
+        <div className="p-5">
+          {tab === "agent" ? (
+            <div>
+              <p className="mb-3 text-sm text-ink-soft">
+                Paste this prompt into your coding agent (Claude Code, Cursor, and the like).
+              </p>
+              <CopyBlock text={AGENT_PROMPT} multiline />
+            </div>
+          ) : (
+            <div>
+              <p className="mb-3 text-sm text-ink-soft">
+                Requires Node.js 20 or newer. Then run <span className="font-mono text-ink">lettertrace login</span>.
+              </p>
+              <CopyBlock text={NPM_COMMAND} />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+function TabButton({
+  active,
+  onClick,
+  icon: Icon,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  icon: typeof Sparkles;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "-mb-px inline-flex items-center gap-2 border-b-2 px-3 py-2.5 text-sm font-medium transition-colors",
+        active
+          ? "border-ink text-ink"
+          : "border-transparent text-ink-soft hover:text-ink",
+      )}
+    >
+      <Icon className="h-4 w-4" aria-hidden />
+      {children}
+    </button>
+  );
+}
+
+function CopyBlock({ text, multiline = false }: { text: string; multiline?: boolean }) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      /* clipboard blocked; the text is still selectable */
+    }
+  };
+
+  return (
+    <div className="relative rounded border border-white/10 bg-terminal text-terminal-ink">
+      <pre
+        className={cn(
+          "overflow-x-auto p-4 pr-12 font-mono text-[13px] leading-relaxed",
+          multiline ? "whitespace-pre-wrap" : "whitespace-pre",
+        )}
+      >
+        {!multiline && <span className="text-mint-bright">$ </span>}
+        {text}
+      </pre>
+      <button
+        type="button"
+        onClick={copy}
+        aria-label={copied ? "Copied" : "Copy to clipboard"}
+        title={copied ? "Copied" : "Copy"}
+        className="absolute right-2 top-2 inline-flex h-8 w-8 items-center justify-center rounded-[2px] text-white/50 transition hover:bg-white/10 hover:text-white"
+      >
+        {copied ? <Check className="h-4 w-4" aria-hidden /> : <Copy className="h-4 w-4" aria-hidden />}
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
Makes `cli/` a standalone, publishable npm package: a dedicated `cli/package.json` (name `lettertrace`, `bin` `lettertrace`, sole runtime dependency `@modelcontextprotocol/sdk`, `files` scoped to the CLI), plus a package README and LICENSE. Fixes `version()` in `brand.mjs` to read the CLI's own `package.json` instead of the private root app's. Changes the CLI's default base URL from `http://localhost:3000` to `https://lettertrace.com` (still overridable via `--url`, `$LETTERTRACE_URL`, or a saved login). Published to npm as both `lettertrace` and `@letterstory/lettertrace` at 0.1.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)