### PR TITLE
Cap what one free account can spend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,23 @@ TRIAL_PERPLEXITY_API_KEY=
 # Free monitoring runs per user before they must add their own key (default 5).
 # THIS is the configurable trial threshold. Consumed atomically at run start.
 TRIAL_RUN_LIMIT=5
+# The ceiling that actually bounds your bill, in dollars per user.
+#
+# TRIAL_RUN_LIMIT counts how OFTEN a free user may start a run; it does not
+# bound what a run costs — a run is prompts x replicates provider calls, and
+# nothing caps prompts. This does. A run stops itself partway when the ceiling
+# is reached, and the three suggest/generate endpoints (which spend your key
+# without consuming a run) are metered against it too.
+#
+# 0 turns the free tier off entirely. Unset defaults to 5.
+TRIAL_SPEND_LIMIT_USD=5
+
+# Optional: correct the rates that ceiling is measured with (lib/pricing.ts).
+# The built-in table deliberately errs high, so the cap can only trigger early.
+# RATE_SEARCH_USD is the per-search price and is the figure most worth setting:
+# on a cheap model the searches, not the tokens, are the bill.
+# RATE_SEARCH_USD=0.01
+# RATE_ANTHROPIC_USD_PER_MTOK=25
 # Optional: force a cheaper model during the trial to cap your cost.
 # Defaults to the project's selected model when unset.
 TRIAL_ANTHROPIC_MODEL=claude-haiku-4-5

--- a/app/api/competitors/suggest/route.ts
+++ b/app/api/competitors/suggest/route.ts
@@ -3,7 +3,8 @@ import { createClient } from "@/lib/supabase/server";
 import { getProject } from "@/lib/data";
 import { suggestCompetitors, humanError } from "@/lib/llm";
 import { PROVIDERS } from "@/lib/models";
-import { resolveKey, recordTrialUsage } from "@/lib/trial";
+import { resolveKey, recordTrialUsage, recordTrialSpend } from "@/lib/trial";
+import { spendMicros } from "@/lib/pricing";
 import { logDashboard } from "@/lib/activity";
 import type { Competitor, Topic } from "@/lib/types";
 
@@ -67,7 +68,15 @@ export async function POST(request: Request) {
       count: 6,
     });
 
-    if (key.source === "trial") await recordTrialUsage(supabase, tokens);
+    // Metered even though no free RUN is consumed: these endpoints spend the
+    // operator's key, so without this a script could call them forever.
+    if (key.source === "trial") {
+      await recordTrialUsage(supabase, tokens);
+      await recordTrialSpend(
+        supabase,
+        spendMicros({ provider: key.provider, model: key.model, tokens }),
+      );
+    }
 
     // Belt-and-braces: drop the brand itself and anything already tracked,
     // including tracked competitors' aliases (e.g. "Monday" vs "Monday.com").

--- a/app/api/onboarding/complete/route.ts
+++ b/app/api/onboarding/complete/route.ts
@@ -7,6 +7,8 @@ import {
   resolveRunKey,
   consumeTrialRun,
   recordTrialUsage,
+  recordTrialSpend,
+  runBudgetMicros,
   pickDefaultProvider,
   engineKeyMessage,
 } from "@/lib/trial";
@@ -231,6 +233,7 @@ export async function POST(request: Request) {
       model: key.model,
       apiKey: key.apiKey,
       route: key.route,
+      budgetMicros: runBudgetMicros(key),
       context: {
         channel: "dashboard",
         actorType: "user",
@@ -240,6 +243,7 @@ export async function POST(request: Request) {
     });
     if (key.source === "trial") {
       await recordTrialUsage(supabase, result.tokensUsed);
+      await recordTrialSpend(supabase, result.spendMicros);
     }
     return NextResponse.json({
       projectId: project.id,

--- a/app/api/onboarding/suggest/route.ts
+++ b/app/api/onboarding/suggest/route.ts
@@ -2,7 +2,13 @@ import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { scrapeDomain } from "@/lib/scrape";
 import { suggestFromSite, humanError } from "@/lib/llm";
-import { resolveKey, recordTrialUsage, pickDefaultProvider } from "@/lib/trial";
+import {
+  resolveKey,
+  recordTrialUsage,
+  recordTrialSpend,
+  pickDefaultProvider,
+} from "@/lib/trial";
+import { spendMicros } from "@/lib/pricing";
 import { logDashboard } from "@/lib/activity";
 
 export const maxDuration = 60;
@@ -65,7 +71,15 @@ export async function POST(request: Request) {
       brandName,
       siteText: scrape.text,
     });
-    if (key.source === "trial") await recordTrialUsage(supabase, suggestion.tokens);
+    // Metered even though no free RUN is consumed: these endpoints spend the
+    // operator's key, so without this a script could call them forever.
+    if (key.source === "trial") {
+      await recordTrialUsage(supabase, suggestion.tokens);
+      await recordTrialSpend(
+        supabase,
+        spendMicros({ provider: key.provider, model: key.model, tokens: suggestion.tokens }),
+      );
+    }
     await logDashboard(user, request, {
       category: "onboarding",
       action: "onboarding.suggested",

--- a/app/api/runs/route.ts
+++ b/app/api/runs/route.ts
@@ -4,7 +4,14 @@ import { getProject } from "@/lib/data";
 import { executeRun } from "@/lib/engine";
 import { humanError } from "@/lib/llm";
 import { PROVIDERS } from "@/lib/models";
-import { resolveRunKey, consumeTrialRun, recordTrialUsage, engineKeyMessage } from "@/lib/trial";
+import {
+  resolveRunKey,
+  consumeTrialRun,
+  recordTrialUsage,
+  recordTrialSpend,
+  runBudgetMicros,
+  engineKeyMessage,
+} from "@/lib/trial";
 
 export const maxDuration = 300;
 export const dynamic = "force-dynamic";
@@ -73,6 +80,7 @@ export async function POST() {
       model: key.model,
       apiKey: key.apiKey!,
       route: key.route,
+      budgetMicros: runBudgetMicros(key),
       context: {
         channel: "dashboard",
         actorType: "user",
@@ -81,9 +89,12 @@ export async function POST() {
       },
     });
 
-    // Record token spend against the operator's shared key for cost visibility.
+    // Bill the operator's shared key. Tokens for visibility, dollars for the
+    // ceiling — the run may already have stopped itself on that ceiling, but it
+    // still has to be recorded or the next run starts from a stale total.
     if (key.source === "trial") {
       await recordTrialUsage(supabase, result.tokensUsed);
+      await recordTrialSpend(supabase, result.spendMicros);
     }
 
     // Echo the engine that actually answered. The caller asked for

--- a/app/api/topics/[id]/generate/route.ts
+++ b/app/api/topics/[id]/generate/route.ts
@@ -3,7 +3,8 @@ import { createClient } from "@/lib/supabase/server";
 import { getProject } from "@/lib/data";
 import { generateVariations, humanError } from "@/lib/llm";
 import { PROVIDERS } from "@/lib/models";
-import { resolveKey, recordTrialUsage } from "@/lib/trial";
+import { resolveKey, recordTrialUsage, recordTrialSpend } from "@/lib/trial";
+import { spendMicros } from "@/lib/pricing";
 import { logDashboard } from "@/lib/activity";
 import type { Topic } from "@/lib/types";
 
@@ -81,7 +82,13 @@ export async function POST(
     });
 
     if (key.source === "trial") {
+      // Metered even though no free RUN is consumed: these endpoints spend the
+      // operator's key, so without this a script could call them forever.
       await recordTrialUsage(supabase, tokens);
+      await recordTrialSpend(
+        supabase,
+        spendMicros({ provider: key.provider, model: key.model, tokens }),
+      );
     }
 
     if (!variations.length) {

--- a/app/api/v1/v1-routes.test.ts
+++ b/app/api/v1/v1-routes.test.ts
@@ -401,7 +401,7 @@ describe("POST /api/v1/projects/:id/runs", () => {
   it("returns the run result on success", async () => {
     vi.mocked(triggerRunForProject).mockResolvedValue({
       ok: true,
-      result: { runId: "r1", status: "completed", totalResponses: 3, tokensUsed: 10 },
+      result: { runId: "r1", status: "completed", totalResponses: 3, tokensUsed: 10 , spendMicros: 0},
     });
     const res = await postRunRoute(
       req("/api/v1/projects/p1/runs", { method: "POST" }),
@@ -444,7 +444,7 @@ describe("POST /api/v1/projects/:id/runs", () => {
   it("ignores a non-boolean background value", async () => {
     vi.mocked(triggerRunForProject).mockResolvedValue({
       ok: true,
-      result: { runId: "r1", status: "completed", totalResponses: 3, tokensUsed: 10 },
+      result: { runId: "r1", status: "completed", totalResponses: 3, tokensUsed: 10 , spendMicros: 0},
     });
     const res = await postRunRoute(
       req("/api/v1/projects/p1/runs", {
@@ -474,7 +474,7 @@ describe("POST /api/v1/projects/:id/runs", () => {
   it("passes a google provider override through", async () => {
     vi.mocked(triggerRunForProject).mockResolvedValue({
       ok: true,
-      result: { runId: "r3", status: "completed", totalResponses: 3, tokensUsed: 10 },
+      result: { runId: "r3", status: "completed", totalResponses: 3, tokensUsed: 10 , spendMicros: 0},
     });
     const res = await postRunRoute(
       req("/api/v1/projects/p1/runs", {
@@ -495,7 +495,7 @@ describe("POST /api/v1/projects/:id/runs", () => {
   it("passes a provider/model override through", async () => {
     vi.mocked(triggerRunForProject).mockResolvedValue({
       ok: true,
-      result: { runId: "r2", status: "completed", totalResponses: 3, tokensUsed: 10 },
+      result: { runId: "r2", status: "completed", totalResponses: 3, tokensUsed: 10 , spendMicros: 0},
     });
     const res = await postRunRoute(
       req("/api/v1/projects/p1/runs", {

--- a/lib/api-service.test.ts
+++ b/lib/api-service.test.ts
@@ -408,6 +408,7 @@ describe("triggerRunForProject", () => {
       status: "completed",
       totalResponses: 4,
       tokensUsed: 1234,
+      spendMicros: 0,
     });
 
     const outcome = await triggerRunForProject(db as never, "user-1", "proj-1");
@@ -435,6 +436,7 @@ describe("triggerRunForProject", () => {
       status: "completed",
       totalResponses: 4,
       tokensUsed: 1234,
+      spendMicros: 0,
     });
 
     const outcome = await triggerRunForProject(db as never, "user-1", "proj-1", {
@@ -474,6 +476,7 @@ describe("triggerRunForProject", () => {
       status: "completed",
       totalResponses: 1,
       tokensUsed: 10,
+      spendMicros: 0,
     });
 
     await triggerRunForProject(db as never, "user-1", "proj-1", { provider: "openai" });

--- a/lib/engine-budget.test.ts
+++ b/lib/engine-budget.test.ts
@@ -1,0 +1,176 @@
+// ---------------------------------------------------------------------------
+// The per-run spend ceiling.
+//
+// The free tier used to be gated on the NUMBER of runs, which bounds nothing:
+// a run is prompts x replicates provider calls and nothing caps prompts, so a
+// single free run could be arbitrarily expensive. These cases pin the fix — a
+// run stops itself partway when the operator's money runs out, keeps what it
+// already paid for, and says plainly that it stopped short.
+// ---------------------------------------------------------------------------
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/llm", () => ({
+  runQuery: vi.fn(),
+  analyzeResponse: vi.fn(),
+  humanError: (e: unknown) => (e instanceof Error ? e.message : String(e)),
+}));
+vi.mock("@/lib/activity", () => ({ logActivity: vi.fn() }));
+vi.mock("@/lib/data", () => ({
+  getDecryptedKey: vi.fn(),
+  getConfiguredProviders: vi.fn(),
+  getDecryptedRouterKeys: vi.fn(),
+}));
+
+import { runQuery, analyzeResponse } from "@/lib/llm";
+import { logActivity } from "@/lib/activity";
+import { resumeRun, type PreparedRun } from "@/lib/engine";
+import { spendMicros } from "@/lib/pricing";
+
+/** Records what the run wrote, and answers the reads resumeRun makes. */
+function makeDb() {
+  const runUpdates: Record<string, unknown>[] = [];
+  const responses: Record<string, unknown>[] = [];
+  let responseId = 0;
+
+  const db = {
+    from(table: string) {
+      return {
+        insert(rows: unknown) {
+          if (table === "responses") responses.push(rows as Record<string, unknown>);
+          return {
+            select: () => ({
+              single: async () => ({ data: { id: `resp-${++responseId}` } }),
+            }),
+            then: (res: (v: unknown) => unknown) => res({ data: null, error: null }),
+          };
+        },
+        update(patch: Record<string, unknown>) {
+          if (table === "runs") runUpdates.push(patch);
+          return {
+            eq: () => ({
+              eq: () => ({ select: async () => ({ data: [] }) }),
+              then: (res: (v: unknown) => unknown) => res({ data: null, error: null }),
+            }),
+          };
+        },
+      };
+    },
+  };
+  return { db: db as never, runUpdates, responses };
+}
+
+const project = {
+  id: "p1",
+  user_id: "u1",
+  brand_name: "Acme",
+  brand_aliases: [],
+  brand_domains: ["acme.com"],
+  use_web_search: true,
+  replicates: 1,
+} as never;
+
+function prepared(jobCount: number): PreparedRun {
+  return {
+    runId: "run-1",
+    jobs: Array.from({ length: jobCount }, (_, i) => ({
+      id: `prompt-${i}`,
+      text: `question ${i}`,
+      topic_id: null,
+    })) as never,
+    competitors: [],
+    attribution: {
+      userId: "u1",
+      projectId: "p1",
+      actorType: "user",
+      actorId: "u1",
+      actorLabel: "You",
+      channel: "dashboard",
+      category: "run",
+      targetType: "run",
+    } as never,
+    startedMs: Date.now(),
+  };
+}
+
+/** What one answer costs under the rules the engine prices with. */
+const PER_ANSWER = spendMicros({
+  provider: "anthropic",
+  model: "claude-haiku-4-5",
+  tokens: 1000,
+  webSearch: true,
+});
+
+beforeEach(() => {
+  vi.mocked(runQuery)
+    .mockReset()
+    .mockResolvedValue({ text: "an answer with no brand in it", tokens: 1000, sources: [] } as never);
+  vi.mocked(analyzeResponse).mockReset().mockResolvedValue({ results: [], tokens: 0 } as never);
+  vi.mocked(logActivity).mockReset().mockResolvedValue(undefined as never);
+});
+
+function run(jobs: number, budgetMicros: number | null) {
+  const { db, runUpdates, responses } = makeDb();
+  return resumeRun(prepared(jobs), {
+    supabase: db,
+    project,
+    provider: "anthropic",
+    model: "claude-haiku-4-5",
+    apiKey: "sk-ant-operator",
+    budgetMicros,
+  } as never).then((result) => ({ result, runUpdates, responses }));
+}
+
+describe("a run on the operator's money", () => {
+  it("stops once the budget is gone instead of asking every prompt", async () => {
+    // Budget for ~3 answers, 50 prompts queued. Without the ceiling this run
+    // would make 50 paid calls.
+    const { result } = await run(50, PER_ANSWER * 3);
+    expect(vi.mocked(runQuery).mock.calls.length).toBeLessThan(50);
+    expect(result.budgetStopped).toBe(true);
+  });
+
+  it("keeps the answers it already paid for", async () => {
+    const { result, responses } = await run(50, PER_ANSWER * 3);
+    // Discarding them would waste money already spent; a stored answer is real
+    // data whatever stopped the run.
+    expect(result.totalResponses).toBeGreaterThan(0);
+    expect(responses.length).toBe(result.totalResponses);
+    expect(result.status).toBe("completed");
+  });
+
+  it("reports the shortfall on the run itself, not as a failure", async () => {
+    const { result, runUpdates } = await run(50, PER_ANSWER * 3);
+    const settle = runUpdates.find((u) => "status" in u)!;
+    expect(settle.status).toBe("completed");
+    // A run that silently returns 4 of 50 answers looks like the prompts broke.
+    expect(String(settle.error)).toMatch(/free-usage limit/i);
+    expect(result.spendMicros).toBeGreaterThan(0);
+  });
+
+  it("runs everything when the budget is ample", async () => {
+    const { result } = await run(5, PER_ANSWER * 100);
+    expect(vi.mocked(runQuery).mock.calls.length).toBe(5);
+    expect(result.budgetStopped).toBeUndefined();
+    const settle = (await run(5, PER_ANSWER * 100)).runUpdates.find((u) => "status" in u)!;
+    expect(settle.error).toBeNull();
+  });
+
+  it("asks nothing at all when the budget is already spent", async () => {
+    const { result } = await run(20, 0);
+    expect(vi.mocked(runQuery)).not.toHaveBeenCalled();
+    // No answers stored is a failed run by the engine's existing rule; what
+    // matters here is that it cost nothing.
+    expect(result.spendMicros).toBe(0);
+  });
+});
+
+describe("a run on the user's own key", () => {
+  it("is never cut short", async () => {
+    // budgetMicros null means BYOK: rationing here would be us rationing their
+    // money, which is not ours to do.
+    const { result } = await run(30, null);
+    expect(vi.mocked(runQuery).mock.calls.length).toBe(30);
+    expect(result.budgetStopped).toBeUndefined();
+  });
+});

--- a/lib/engine.ts
+++ b/lib/engine.ts
@@ -11,7 +11,8 @@ import type {
 import { runQuery, analyzeResponse, humanError, type AnalyzeEntity } from "@/lib/llm";
 import { detectMention, brandTerms } from "@/lib/mentions";
 import { pageKey } from "@/lib/metrics";
-import { modelLabel } from "@/lib/models";
+import { analysisModelFor, modelLabel } from "@/lib/models";
+import { spendMicros } from "@/lib/pricing";
 import { logActivity } from "@/lib/activity";
 import { selectAll } from "@/lib/paging";
 
@@ -82,6 +83,12 @@ export interface RunResult {
   status: "completed" | "failed";
   totalResponses: number;
   tokensUsed: number;
+  /** What this run cost, in micro-dollars, when it ran on an operator key.
+   *  Zero for a run on the user's own credential — that spend isn't ours. */
+  spendMicros: number;
+  /** Set when the run stopped early because the free-tier ceiling was reached:
+   *  the answers stored are real, there are just fewer of them than planned. */
+  budgetStopped?: boolean;
   error?: string;
 }
 
@@ -157,6 +164,17 @@ export interface ExecuteRunParams {
   route?: RouteInfo | null;
   /** Attribution for the activity log. Defaults to the internal system. */
   context?: RunContext;
+  /**
+   * How much operator money this run may spend, in micro-dollars. Omit (or
+   * null) for a run on the user's own key, where there is nothing for us to
+   * ration.
+   *
+   * A run has no natural size — prompts x replicates, with no cap on prompts —
+   * so a per-run allowance is the only thing standing between one free account
+   * and an arbitrary bill. Checked between answers rather than up front,
+   * because the cost of an answer isn't known until it arrives.
+   */
+  budgetMicros?: number | null;
 }
 
 /** A run row already created and logged, plus everything the job loop needs. */
@@ -265,7 +283,7 @@ export async function prepareRun(params: ExecuteRunParams): Promise<PreparedRun>
 
 /** Execute a prepared run's jobs and settle the run row. */
 export async function resumeRun(prepared: PreparedRun, params: ExecuteRunParams): Promise<RunResult> {
-  const { supabase, project, provider, model, apiKey, route } = params;
+  const { supabase, project, provider, model, apiKey, route, budgetMicros } = params;
   const { runId, jobs, competitors, attribution, startedMs } = prepared;
 
   if (jobs.length === 0) {
@@ -282,7 +300,7 @@ export async function resumeRun(prepared: PreparedRun, params: ExecuteRunParams)
       durationMs: Date.now() - startedMs,
       metadata: { provider, model, total_responses: 0, tokens_used: 0 },
     });
-    return { runId, status: "completed", totalResponses: 0, tokensUsed: 0 };
+    return { runId, status: "completed", totalResponses: 0, tokensUsed: 0, spendMicros: 0 };
   }
 
   // Mention terms derive from the PRIMARY domain only: phantom-site names
@@ -293,9 +311,25 @@ export async function resumeRun(prepared: PreparedRun, params: ExecuteRunParams)
   let processed = 0; // asks attempted (success or failure)
   let succeeded = 0; // answers actually stored
   let tokensUsed = 0; // total provider tokens consumed (for trial metering)
+  let spentMicros = 0; // what those tokens and searches cost, when we're paying
   let hardError: string | undefined;
 
+  // A ceiling only applies when the operator is footing the bill. On the user's
+  // own key there is nothing to ration, and capping their run would be us
+  // rationing their money.
+  const ceiling = typeof budgetMicros === "number" ? Math.max(0, budgetMicros) : null;
+  let budgetStopped = false;
+  const overBudget = () => ceiling !== null && spentMicros >= ceiling;
+
   await mapPool(jobs, CONCURRENCY, async (prompt) => {
+    // Checked per job rather than up front: the run is concurrent, so this is
+    // the point where in-flight answers have already reported their cost. Jobs
+    // already dispatched finish and are kept — a stored answer is real data,
+    // and throwing it away would waste money we have already spent.
+    if (overBudget()) {
+      budgetStopped = true;
+      return;
+    }
     try {
       const { text: answer, tokens: qTokens, sources } = await runQuery({
         provider,
@@ -306,6 +340,12 @@ export async function resumeRun(prepared: PreparedRun, params: ExecuteRunParams)
         webSearch: project.use_web_search,
       });
       tokensUsed += qTokens;
+      spentMicros += spendMicros({
+        provider,
+        model,
+        tokens: qTokens,
+        webSearch: project.use_web_search,
+      });
 
       const { data: respRow } = await supabase
         .from("responses")
@@ -408,6 +448,15 @@ export async function resumeRun(prepared: PreparedRun, params: ExecuteRunParams)
           entities,
         });
         tokensUsed += aTokens;
+        // Classification runs on the provider's cheap model and never searches,
+        // but it is still the operator's money and there are as many of these
+        // as there are answers.
+        spentMicros += spendMicros({
+          provider,
+          model: analysisModelFor(provider),
+          tokens: aTokens,
+          webSearch: false,
+        });
         analyzed = Object.fromEntries(
           results.map((r) => [r.key, { sentiment: r.sentiment, recommended: r.recommended }]),
         );
@@ -446,6 +495,16 @@ export async function resumeRun(prepared: PreparedRun, params: ExecuteRunParams)
   // A run only "completed" if at least one answer was actually stored; otherwise
   // it failed and we surface the captured error rather than reporting success.
   const status = succeeded > 0 ? "completed" : "failed";
+
+  // Stopping on the ceiling is not a failure and must not read as one: the
+  // answers that were stored are as good as any other run's. But it IS a
+  // shortfall, and a run that silently returns 40 of 200 answers would look
+  // like the prompts stopped working. Say which it was, in the run's own row.
+  const shortfall = budgetStopped ? jobs.length - processed : 0;
+  const budgetNote = budgetStopped
+    ? `Stopped after ${succeeded} of ${jobs.length} answers: this account reached its free-usage limit. ` +
+      `Add your own provider key in Settings to run the remaining ${shortfall}.`
+    : null;
   await supabase
     .from("runs")
     .update({
@@ -454,8 +513,8 @@ export async function resumeRun(prepared: PreparedRun, params: ExecuteRunParams)
       finished_at: finishedAt,
       error:
         status === "failed"
-          ? hardError ?? "No answers were stored, every prompt failed."
-          : null,
+          ? hardError ?? budgetNote ?? "No answers were stored, every prompt failed."
+          : budgetNote,
     })
     .eq("id", runId);
 
@@ -471,8 +530,10 @@ export async function resumeRun(prepared: PreparedRun, params: ExecuteRunParams)
     targetId: runId,
     summary:
       status === "completed"
-        ? `Run completed: ${succeeded} of ${jobs.length} ${jobs.length === 1 ? "answer" : "answers"} stored on ${modelLabel(provider, model)}`
-        : `Run failed: ${hardError ?? "no answers were stored"}`,
+        ? budgetStopped
+          ? `Run stopped at the free-usage limit: ${succeeded} of ${jobs.length} ${jobs.length === 1 ? "answer" : "answers"} stored on ${modelLabel(provider, model)}`
+          : `Run completed: ${succeeded} of ${jobs.length} ${jobs.length === 1 ? "answer" : "answers"} stored on ${modelLabel(provider, model)}`
+        : `Run failed: ${hardError ?? budgetNote ?? "no answers were stored"}`,
     durationMs: Date.now() - startedMs,
     metadata: {
       provider,
@@ -480,11 +541,21 @@ export async function resumeRun(prepared: PreparedRun, params: ExecuteRunParams)
       total_responses: succeeded,
       prompt_count: jobs.length,
       tokens_used: tokensUsed,
+      spend_micros: spentMicros,
+      ...(budgetStopped ? { budget_stopped: true, unrun_prompts: shortfall } : {}),
       ...(hardError ? { error: hardError } : {}),
     },
   });
 
-  return { runId, status, totalResponses: succeeded, tokensUsed, error: hardError };
+  return {
+    runId,
+    status,
+    totalResponses: succeeded,
+    tokensUsed,
+    spendMicros: spentMicros,
+    ...(budgetStopped ? { budgetStopped: true } : {}),
+    error: hardError,
+  };
 }
 
 /**

--- a/lib/pricing.test.ts
+++ b/lib/pricing.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  spendMicros,
+  tokenRateUsd,
+  trialSpendLimitMicros,
+  formatUsd,
+  searchRateUsd,
+} from "./pricing";
+
+const ENV_KEYS = [
+  "TRIAL_SPEND_LIMIT_USD",
+  "RATE_SEARCH_USD",
+  "RATE_ANTHROPIC_USD_PER_MTOK",
+  "RATE_OPENAI_USD_PER_MTOK",
+];
+
+afterEach(() => {
+  for (const k of ENV_KEYS) delete process.env[k];
+});
+
+describe("token rates", () => {
+  it("prices each Anthropic model at its own rate", () => {
+    expect(tokenRateUsd("anthropic", "claude-haiku-4-5")).toBe(5);
+    expect(tokenRateUsd("anthropic", "claude-sonnet-4-6")).toBe(15);
+    expect(tokenRateUsd("anthropic", "claude-opus-4-8")).toBe(25);
+  });
+
+  it("falls back to the dearest rate for a model it doesn't know", () => {
+    // The whole point of the fallback: a model added to the catalog without a
+    // rate must not be free. Cheaper-than-real would be a hole; dearer is only
+    // an early stop.
+    const known = tokenRateUsd("anthropic", "claude-opus-4-8");
+    expect(tokenRateUsd("anthropic", "claude-something-new")).toBeGreaterThanOrEqual(known);
+  });
+
+  it("lets a deployment correct a rate without a release", () => {
+    process.env.RATE_ANTHROPIC_USD_PER_MTOK = "2";
+    expect(tokenRateUsd("anthropic", "claude-opus-4-8")).toBe(2);
+  });
+
+  it("ignores a nonsense override rather than pricing at NaN", () => {
+    process.env.RATE_OPENAI_USD_PER_MTOK = "not-a-number";
+    expect(tokenRateUsd("openai", "gpt-4o")).toBeGreaterThan(0);
+  });
+});
+
+describe("spend", () => {
+  it("charges tokens at the model's rate", () => {
+    // 1M tokens on a $5/MTok model = $5 = 5_000_000 micros.
+    expect(spendMicros({ provider: "anthropic", model: "claude-haiku-4-5", tokens: 1_000_000 })).toBe(
+      5_000_000,
+    );
+  });
+
+  it("charges a grounded answer for its search allowance", () => {
+    const plain = spendMicros({
+      provider: "anthropic",
+      model: "claude-haiku-4-5",
+      tokens: 1000,
+      webSearch: false,
+    });
+    const grounded = spendMicros({
+      provider: "anthropic",
+      model: "claude-haiku-4-5",
+      tokens: 1000,
+      webSearch: true,
+    });
+    // The interesting property is not the exact figure but the ORDER: on a cheap
+    // model the searches dominate, and a cost model that ignored them would
+    // under-count a grounded run by more than an order of magnitude.
+    expect(grounded).toBeGreaterThan(plain * 10);
+  });
+
+  it("never returns a negative or fractional charge", () => {
+    expect(spendMicros({ provider: "openai", model: "gpt-4o", tokens: -5 })).toBe(0);
+    expect(spendMicros({ provider: "openai", model: "gpt-4o", tokens: NaN })).toBe(0);
+    const tiny = spendMicros({ provider: "anthropic", model: "claude-haiku-4-5", tokens: 1 });
+    expect(Number.isInteger(tiny)).toBe(true);
+  });
+
+  it("rounds a real charge up, so a long run of tiny calls can't be free", () => {
+    // Round-to-nearest would floor thousands of sub-micro calls to zero, which
+    // is precisely the accounting hole this whole module exists to close.
+    const one = spendMicros({ provider: "anthropic", model: "claude-haiku-4-5", tokens: 1 });
+    expect(one).toBeGreaterThan(0);
+  });
+
+  it("respects a search-rate override", () => {
+    process.env.RATE_SEARCH_USD = "0";
+    expect(searchRateUsd()).toBe(0);
+    const grounded = spendMicros({
+      provider: "anthropic",
+      model: "claude-haiku-4-5",
+      tokens: 1000,
+      webSearch: true,
+    });
+    const plain = spendMicros({
+      provider: "anthropic",
+      model: "claude-haiku-4-5",
+      tokens: 1000,
+      webSearch: false,
+    });
+    expect(grounded).toBe(plain);
+  });
+});
+
+describe("the ceiling", () => {
+  it("defaults to $5", () => {
+    expect(trialSpendLimitMicros()).toBe(5_000_000);
+  });
+
+  it("is configurable", () => {
+    process.env.TRIAL_SPEND_LIMIT_USD = "25";
+    expect(trialSpendLimitMicros()).toBe(25_000_000);
+  });
+
+  it("treats zero as a real setting, not as unset", () => {
+    // "0" is how an operator turns the free tier off entirely. Reading it as
+    // missing would hand out the $5 default to exactly the deployment that
+    // asked for none.
+    process.env.TRIAL_SPEND_LIMIT_USD = "0";
+    expect(trialSpendLimitMicros()).toBe(0);
+  });
+
+  it("falls back to the default on a malformed value", () => {
+    process.env.TRIAL_SPEND_LIMIT_USD = "five dollars";
+    expect(trialSpendLimitMicros()).toBe(5_000_000);
+  });
+
+  it("formats as money for the refusal message", () => {
+    expect(formatUsd(5_000_000)).toBe("$5.00");
+    expect(formatUsd(1_500_000)).toBe("$1.50");
+  });
+});

--- a/lib/pricing.ts
+++ b/lib/pricing.ts
@@ -1,0 +1,130 @@
+// ==================================================================
+// What a call costs, in money.
+//
+// This exists for one job: putting a dollar ceiling on what a single free-tier
+// user can spend of the OPERATOR's keys. It is not billing, it is not an
+// invoice, and nothing user-facing quotes it. That framing decides every
+// judgement call below — when in doubt, over-estimate. Charging too much stops
+// a runaway account slightly early; charging too little is how a trial user
+// runs up a bill nobody sees until it arrives.
+//
+// Two deliberate over-estimates:
+//
+//   1. Every token is billed at the model's OUTPUT rate. The adapters report a
+//      single combined figure (`tokens`), and splitting input from output would
+//      mean touching all four of them. Output is the dearer half, so pricing
+//      everything at it is the safe direction, and it costs nothing to be
+//      exactly right later — one field, one function.
+//
+//   2. A grounded answer is charged for the full search allowance it asked for
+//      (WEB_SEARCH_MAX_USES), not the searches it actually ran. We ask for a
+//      ceiling and can't see the actual count without parsing every provider's
+//      tool blocks. On a cheap model the searches, not the tokens, are the
+//      bill — so this is the number that matters most and the one most worth
+//      replacing with a real count later.
+//
+// PROVENANCE — read before trusting a row:
+//   Anthropic's rates are the published API prices.
+//   The other three are deliberately-high placeholders, NOT quoted rates: they
+//   sit at or above the dearest model each vendor offers, so the cap can only
+//   trigger early. Replace them with real per-model figures when you want the
+//   ceiling to sit where the spend actually is. Same for SEARCH_USD, which is a
+//   conservative stand-in rather than a verified per-search price.
+//
+// Everything here is overridable by env so a deployment can correct a rate
+// without a release.
+// ==================================================================
+
+import type { Provider } from "@/lib/types";
+
+/** USD per million tokens, charged at each model's output rate (see above). */
+const RATES: Record<Provider, { models: Record<string, number>; fallback: number }> = {
+  // Published Anthropic API pricing.
+  anthropic: {
+    models: {
+      "claude-opus-4-8": 25,
+      "claude-sonnet-4-6": 15,
+      "claude-haiku-4-5": 5,
+    },
+    fallback: 25,
+  },
+  // Placeholders that err high — see PROVENANCE above.
+  openai: { models: {}, fallback: 30 },
+  google: { models: {}, fallback: 30 },
+  perplexity: { models: {}, fallback: 30 },
+};
+
+/**
+ * USD per web search. A stand-in, not a quoted price: searches are billed per
+ * call by every provider that offers them, and this sits high enough that a
+ * search-heavy run is never under-counted.
+ */
+const DEFAULT_SEARCH_USD = 0.01;
+
+/** The search allowance a grounded ask requests; kept in step with lib/llm. */
+const SEARCH_USES_PER_ANSWER = 5;
+
+const MICROS_PER_USD = 1_000_000;
+
+function envNumber(name: string, fallback: number): number {
+  const raw = Number(process.env[name]);
+  return Number.isFinite(raw) && raw >= 0 ? raw : fallback;
+}
+
+/** USD per million tokens for an engine, erring high on anything unrecognised. */
+export function tokenRateUsd(provider: Provider, model: string): number {
+  const table = RATES[provider];
+  if (!table) return 30;
+  const override = envNumber(`RATE_${provider.toUpperCase()}_USD_PER_MTOK`, NaN);
+  if (Number.isFinite(override)) return override;
+  return table.models[model] ?? table.fallback;
+}
+
+/** USD per search. */
+export function searchRateUsd(): number {
+  return envNumber("RATE_SEARCH_USD", DEFAULT_SEARCH_USD);
+}
+
+export interface SpendInput {
+  provider: Provider;
+  model: string;
+  /** Combined prompt + completion tokens, as the adapters report them. */
+  tokens: number;
+  /** Whether this call asked the provider to search. */
+  webSearch?: boolean;
+}
+
+/**
+ * What a single call cost, in micro-dollars (integer, so it can be summed in
+ * the database without float drift). Rounded up: a call always costs something,
+ * and a long run of "0" answers is exactly the hole this closes.
+ */
+export function spendMicros(input: SpendInput): number {
+  const tokens = Number.isFinite(input.tokens) && input.tokens > 0 ? input.tokens : 0;
+  const tokenUsd = (tokens / 1_000_000) * tokenRateUsd(input.provider, input.model);
+  const searchUsd = input.webSearch ? SEARCH_USES_PER_ANSWER * searchRateUsd() : 0;
+  const micros = Math.ceil((tokenUsd + searchUsd) * MICROS_PER_USD);
+  return micros > 0 ? micros : 0;
+}
+
+const DEFAULT_TRIAL_SPEND_LIMIT_USD = 5;
+
+/**
+ * The per-user ceiling on operator-funded spend, in micro-dollars
+ * (env: TRIAL_SPEND_LIMIT_USD). Zero disables the free tier outright, which is
+ * a legitimate configuration — it is not the same as "unset".
+ */
+export function trialSpendLimitMicros(): number {
+  const raw = process.env.TRIAL_SPEND_LIMIT_USD;
+  const parsed = Number(raw);
+  const usd =
+    raw !== undefined && raw !== "" && Number.isFinite(parsed) && parsed >= 0
+      ? parsed
+      : DEFAULT_TRIAL_SPEND_LIMIT_USD;
+  return Math.round(usd * MICROS_PER_USD);
+}
+
+/** For messages: micro-dollars as a plain dollar figure. */
+export function formatUsd(micros: number): string {
+  return `$${(micros / MICROS_PER_USD).toFixed(2)}`;
+}

--- a/lib/trial.test.ts
+++ b/lib/trial.test.ts
@@ -20,6 +20,7 @@ import {
   trialModelFor,
   trialEnabled,
   pickDefaultProvider,
+  runBudgetMicros,
 } from "@/lib/trial";
 
 // Grounding is a required argument on the real resolver (a router that can't
@@ -467,5 +468,119 @@ describe("the exhausted message offers the router", () => {
     expect(message).toContain("router key");
     expect(message).not.toContain("Perplexity");
     expect(message).not.toContain("Gemini");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The spend ceiling.
+//
+// Counting runs bounds how OFTEN a free user starts something, not what it
+// costs. These cases pin the second ceiling: that it refuses independently of
+// the run count, that it says so in words that match which limit was hit, and
+// that it never applies to a user spending their own money.
+// ---------------------------------------------------------------------------
+
+/** A profile with both meters set. */
+function meters(runsUsed: number, spendMicros: number) {
+  return {
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: async () => ({
+            data: { trial_runs_used: runsUsed, trial_spend_micros: spendMicros },
+          }),
+        }),
+      }),
+    }),
+  } as never;
+}
+
+describe("the free-tier spend ceiling", () => {
+  beforeEach(() => {
+    process.env.TRIAL_ANTHROPIC_API_KEY = "sk-ant-operator";
+    process.env.TRIAL_SPEND_LIMIT_USD = "5";
+  });
+
+  afterEach(() => {
+    delete process.env.TRIAL_SPEND_LIMIT_USD;
+  });
+
+  it("serves a user who is under both ceilings", async () => {
+    const key = await resolveKey(meters(1, 2_000_000), "u1", "anthropic");
+    expect(key.source).toBe("trial");
+    expect(key.spentMicros).toBe(2_000_000);
+    expect(key.capMicros).toBe(5_000_000);
+  });
+
+  it("refuses on spend even with free runs left", async () => {
+    // The hole this closes: one run of a 500-prompt project costs more than the
+    // whole free tier, and the run counter says 1 of 5.
+    const key = await resolveKey(meters(1, 5_000_000), "u1", "anthropic");
+    expect(key.source).toBe("exhausted");
+    expect(key.exhaustedBy).toBe("spend");
+  });
+
+  it("still refuses on runs when spend is untouched", async () => {
+    const key = await resolveKey(meters(5, 0), "u1", "anthropic");
+    expect(key.source).toBe("exhausted");
+    expect(key.exhaustedBy).toBe("runs");
+  });
+
+  it("says which ceiling was hit", async () => {
+    const spent = await resolveKey(meters(1, 5_000_000), "u1", "anthropic");
+    const msg = engineKeyMessage(spent);
+    expect(msg).toContain("$5.00");
+    // The run-count wording would be actively misleading here: they have four
+    // runs left and would go looking for the bug.
+    expect(msg).not.toMatch(/all \d+ free runs/);
+
+    const runs = await resolveKey(meters(5, 0), "u1", "anthropic");
+    expect(engineKeyMessage(runs)).toMatch(/free runs/);
+  });
+
+  it("applies to the per-engine run resolver too", async () => {
+    const key = await runKeyFor(meters(0, 6_000_000), "u1", "anthropic");
+    expect(key.source).toBe("exhausted");
+    expect(key.exhaustedBy).toBe("spend");
+  });
+
+  it("never rations a user spending their own money", async () => {
+    vi.mocked(getDecryptedKey).mockResolvedValue("sk-ant-mine");
+    const key = await runKeyFor(meters(99, 999_000_000), "u1", "anthropic");
+    expect(key.source).toBe("own");
+    expect(runBudgetMicros(key)).toBeNull();
+  });
+
+  it("hands a run only what is left of the ceiling", async () => {
+    const key = await resolveKey(meters(0, 4_000_000), "u1", "anthropic");
+    expect(runBudgetMicros(key)).toBe(1_000_000);
+  });
+
+  it("never hands a run a negative budget", async () => {
+    // Overshoot is expected: cost is known only after the call, so the last
+    // answer of a run can carry the total past the cap.
+    const key = await resolveKey(meters(0, 4_000_000), "u1", "anthropic");
+    expect(runBudgetMicros(key)).toBeGreaterThanOrEqual(0);
+  });
+
+  it("treats a limit of zero as no free tier at all", async () => {
+    process.env.TRIAL_SPEND_LIMIT_USD = "0";
+    const key = await resolveKey(meters(0, 0), "u1", "anthropic");
+    expect(key.source).toBe("exhausted");
+    expect(key.exhaustedBy).toBe("spend");
+  });
+
+  it("reads a profile with no spend column as unspent", async () => {
+    // A deployment that hasn't run the migration yet must still serve its
+    // users rather than refusing everyone as over-budget.
+    const legacy = {
+      from: () => ({
+        select: () => ({
+          eq: () => ({ maybeSingle: async () => ({ data: { trial_runs_used: 0 } }) }),
+        }),
+      }),
+    } as never;
+    const key = await resolveKey(legacy, "u1", "anthropic");
+    expect(key.source).toBe("trial");
   });
 });

--- a/lib/trial.test.ts
+++ b/lib/trial.test.ts
@@ -563,6 +563,13 @@ describe("the free-tier spend ceiling", () => {
     expect(runBudgetMicros(key)).toBeGreaterThanOrEqual(0);
   });
 
+  it("serves one micro-dollar under the cap and refuses at it", async () => {
+    // The boundary is exclusive: $5.00 spent of $5.00 means the $5 is gone.
+    // Verified against the live database at this exact granularity.
+    expect((await resolveKey(meters(0, 4_999_999), "u1", "anthropic")).source).toBe("trial");
+    expect((await resolveKey(meters(0, 5_000_000), "u1", "anthropic")).source).toBe("exhausted");
+  });
+
   it("treats a limit of zero as no free tier at all", async () => {
     process.env.TRIAL_SPEND_LIMIT_USD = "0";
     const key = await resolveKey(meters(0, 0), "u1", "anthropic");

--- a/lib/trial.ts
+++ b/lib/trial.ts
@@ -16,6 +16,7 @@ import {
   routerSupport,
 } from "@/lib/routers";
 import { article } from "@/lib/utils";
+import { formatUsd, trialSpendLimitMicros } from "@/lib/pricing";
 
 // ------------------------------------------------------------------
 // Credential resolution + the free-trial layer.
@@ -88,12 +89,57 @@ export async function getTrialRunsUsed(
   supabase: SupabaseClient,
   userId: string,
 ): Promise<number> {
+  return (await getTrialUsage(supabase, userId)).runs;
+}
+
+/** What the free tier has cost this user so far, in micro-dollars. */
+export async function getTrialSpendMicros(
+  supabase: SupabaseClient,
+  userId: string,
+): Promise<number> {
+  return (await getTrialUsage(supabase, userId)).spendMicros;
+}
+
+export interface TrialUsage {
+  runs: number;
+  spendMicros: number;
+}
+
+/**
+ * Both meters in one read. They are always wanted together — the free tier is
+ * gated on whichever runs out first — and two round trips per resolve is two
+ * more than this needs.
+ *
+ * A missing profile row reads as zero usage rather than as an error: it is the
+ * state a brand-new account is in for the moment before the signup trigger
+ * lands, and refusing to serve them would be a worse bug than a free run.
+ */
+export async function getTrialUsage(
+  supabase: SupabaseClient,
+  userId: string,
+): Promise<TrialUsage> {
   const { data } = await supabase
     .from("profiles")
-    .select("trial_runs_used")
+    .select("trial_runs_used, trial_spend_micros")
     .eq("id", userId)
     .maybeSingle();
-  return Number((data as { trial_runs_used?: number } | null)?.trial_runs_used ?? 0);
+  const row = data as { trial_runs_used?: number; trial_spend_micros?: number } | null;
+  return {
+    runs: Number(row?.trial_runs_used ?? 0),
+    spendMicros: Number(row?.trial_spend_micros ?? 0),
+  };
+}
+
+/**
+ * Is this user still inside BOTH free-tier ceilings?
+ *
+ * Runs bound how often they can start something; spend bounds what those
+ * somethings may cost. Neither implies the other: five runs of a thousand
+ * prompts is a large bill under a small run count, and a script hammering
+ * /suggest spends without touching the run counter at all.
+ */
+function withinTrial(usage: TrialUsage, runLimit: number, capMicros: number): boolean {
+  return usage.runs < runLimit && usage.spendMicros < capMicros;
 }
 
 export type KeySource =
@@ -127,6 +173,14 @@ export interface ResolvedKey {
   requested: { provider: Provider; model: string };
   remaining?: number; // free runs left (for 'trial'/'exhausted')
   limit?: number; // the free-run allowance
+  /** For 'exhausted': WHICH ceiling was hit. The two need different words —
+   *  "you've used all 5 free runs" is simply false for someone stopped by the
+   *  spend cap on their second run, and sends them looking for a bug. */
+  exhaustedBy?: "runs" | "spend";
+  /** For 'trial'/'exhausted': operator-funded spend so far, and the ceiling,
+   *  both in micro-dollars. */
+  spentMicros?: number;
+  capMicros?: number;
   /** For 'mismatch': providers the user DOES hold a key for, so the message can
    *  name the one-click fix instead of just refusing. */
   available?: Provider[];
@@ -200,29 +254,42 @@ export async function resolveKey(
     }
   }
 
-  // 2. A trial key, if free runs remain.
+  // 2. A trial key, if free runs AND free spend remain.
   const limit = trialRunLimit();
-  const used = await getTrialRunsUsed(supabase, userId);
+  const cap = trialSpendLimitMicros();
+  const usage = await getTrialUsage(supabase, userId);
   let trialConfigured = false;
   for (const p of order) {
     const tk = trialKeyFor(p);
     if (!tk) continue;
     trialConfigured = true;
-    if (used < limit) {
+    if (withinTrial(usage, limit, cap)) {
       return {
         source: "trial",
         apiKey: tk,
         provider: p,
         model: trialModelFor(p, modelFor(p)),
         requested,
-        remaining: Math.max(0, limit - used),
+        remaining: Math.max(0, limit - usage.runs),
         limit,
+        spentMicros: usage.spendMicros,
+        capMicros: cap,
       };
     }
   }
 
   if (trialConfigured) {
-    return { source: "exhausted", provider: preferred, model: requested.model, requested, remaining: 0, limit };
+    return {
+      source: "exhausted",
+      provider: preferred,
+      model: requested.model,
+      requested,
+      remaining: Math.max(0, limit - usage.runs),
+      limit,
+      exhaustedBy: usage.spendMicros >= cap ? "spend" : "runs",
+      spentMicros: usage.spendMicros,
+      capMicros: cap,
+    };
   }
   return { source: "none", provider: preferred, model: requested.model, requested };
 }
@@ -275,10 +342,12 @@ export async function resolveRunKeyFor(
 
   // The operator's shared key, but only for the engine actually chosen.
   const limit = trialRunLimit();
+  const cap = trialSpendLimitMicros();
   const trialKey = trialKeyFor(provider);
+  let trialUsage: TrialUsage | null = null;
   if (trialKey) {
-    const used = await getTrialRunsUsed(supabase, userId);
-    if (used < limit) {
+    trialUsage = await getTrialUsage(supabase, userId);
+    if (withinTrial(trialUsage, limit, cap)) {
       return {
         ...base,
         source: "trial",
@@ -286,8 +355,10 @@ export async function resolveRunKeyFor(
         // Still a substitution, but within the chosen provider: the answers
         // remain that assistant's, and `requested` carries the difference.
         model: trialModelFor(provider, requested.model),
-        remaining: Math.max(0, limit - used),
+        remaining: Math.max(0, limit - trialUsage.runs),
         limit,
+        spentMicros: trialUsage.spendMicros,
+        capMicros: cap,
       };
     }
   }
@@ -322,7 +393,18 @@ export async function resolveRunKeyFor(
   const others = Array.from(new Set([...direct, ...viaRouters])).filter((p) => p !== provider);
   if (others.length > 0) return { ...base, source: "mismatch", available: others };
 
-  if (trialKey) return { ...base, source: "exhausted", remaining: 0, limit };
+  if (trialKey) {
+    const usage = trialUsage ?? (await getTrialUsage(supabase, userId));
+    return {
+      ...base,
+      source: "exhausted",
+      remaining: Math.max(0, limit - usage.runs),
+      limit,
+      exhaustedBy: usage.spendMicros >= cap ? "spend" : "runs",
+      spentMicros: usage.spendMicros,
+      capMicros: cap,
+    };
+  }
   return { ...base, source: "none" };
 }
 
@@ -374,6 +456,17 @@ export function engineKeyMessage(key: ResolvedKey): string {
   if (key.source === "unroutable" && key.refusal) return key.refusal;
 
   if (key.source === "exhausted") {
+    // The spend ceiling and the run ceiling are different refusals. Someone
+    // stopped on their second run by a large project needs to know it was the
+    // size of the run, not a count they haven't reached — otherwise the message
+    // contradicts the run counter sitting next to it.
+    if (key.exhaustedBy === "spend") {
+      return (
+        `This account has used its ${formatUsd(key.capMicros ?? 0)} of free ${engine} usage. ` +
+        `Add your own ${providerLabel} key in Settings to keep monitoring, ` +
+        `or one router key (${routerNames()}) that covers several assistants at once.`
+      );
+    }
     // Name the router here and only here. A router key ranks BELOW the trial in
     // both resolvers — a working grounded credential beats refusing — so a trial
     // user never encounters one in the ordinary course of things, and they are
@@ -429,13 +522,42 @@ export function nextRunMessage(key: ResolvedKey): string {
 }
 
 /** Add consumed tokens to the caller's trial tally (atomic, self-scoped rpc).
- * Recording only; the free tier is gated on runs, not tokens. */
+ * Recording only — the enforceable meter is spend, below. */
 export async function recordTrialUsage(
   supabase: SupabaseClient,
   tokens: number,
 ): Promise<void> {
   if (!tokens || tokens <= 0) return;
   await supabase.rpc("increment_trial_tokens", { amount: Math.round(tokens) });
+}
+
+/**
+ * How much this run may spend, given the key that will pay for it.
+ *
+ * Null for anything but a trial: on the user's own credential (direct or via a
+ * router) there is nothing for us to ration, and cutting their run short would
+ * be us rationing their money.
+ */
+export function runBudgetMicros(key: ResolvedKey): number | null {
+  if (key.source !== "trial") return null;
+  return Math.max(0, (key.capMicros ?? 0) - (key.spentMicros ?? 0));
+}
+
+/**
+ * Add operator-funded spend to the caller's tally (atomic, self-scoped rpc).
+ *
+ * Called AFTER the money is spent, unlike consumeTrialRun which gates before.
+ * That ordering is forced: the cost isn't known until the provider answers. The
+ * consequence is that the LAST call of a run can carry the total past the cap —
+ * bounded overshoot, by design. Enforcing per-call in advance would mean
+ * refusing on an estimate, and the estimate is the thing we're least sure of.
+ */
+export async function recordTrialSpend(
+  supabase: SupabaseClient,
+  micros: number,
+): Promise<void> {
+  if (!micros || micros <= 0) return;
+  await supabase.rpc("increment_trial_spend", { amount: Math.round(micros) });
 }
 
 /**

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -57,6 +57,31 @@ as $$
     returning trial_tokens_used;
 $$;
 
+-- What the free tier has COST, in micro-dollars, priced by lib/pricing.ts.
+--
+-- Tokens above are a tally; this is the ceiling. Counting runs alone bounds how
+-- many times a user may start something, not how much that something spends —
+-- a run is prompts x replicates calls, with no cap on prompts, and the three
+-- suggest/generate endpoints spend operator money without consuming a run at
+-- all. Both holes close against this column.
+--
+-- Micro-dollars rather than a numeric so the increment is integer arithmetic:
+-- summing fractional currency across concurrent calls is how a ledger drifts.
+-- Safe to re-run.
+alter table public.profiles
+  add column if not exists trial_spend_micros bigint not null default 0;
+
+create or replace function public.increment_trial_spend(amount bigint)
+returns bigint
+language sql
+security definer set search_path = public
+as $$
+  update public.profiles
+    set trial_spend_micros = trial_spend_micros + greatest(amount, 0)
+    where id = auth.uid()
+    returning trial_spend_micros;
+$$;
+
 -- Free-trial gating is per RUN: monitoring runs executed on the operator's
 -- shared keys before the user brings their own (tokens above are still
 -- recorded so the operator can watch spend). Safe to re-run.


### PR DESCRIPTION
## The problem

The free tier is gated on **runs**, which bounds how *often* someone starts something — not what it costs.

- A run is `prompts x replicates` provider calls. `replicates` is capped at 10; **prompts are not capped**, and neither is the number of projects. So one free run can be arbitrarily expensive: 500 prompts x 10 replicates is 5,000 paid calls, and the counter says `1 of 5`.
- **Three endpoints spend the operator's key without consuming a run at all** — `competitors/suggest`, `topics/:id/generate`, `onboarding/suggest`. They only refuse once `source === "exhausted"`, which is itself run-based, so a user who never triggers a run can call them indefinitely.
- `profiles.trial_tokens_used` existed but was **write-only** — nothing anywhere read it. A meter, with nothing enforcing it.

Signup is open, so this needs only a disposable email.

## The fix

A dollar ceiling per user, default **$5** (`TRIAL_SPEND_LIMIT_USD`; `0` turns the free tier off entirely).

**`lib/pricing.ts`** prices a call in micro-dollars. It deliberately over-estimates, and the header says why: this is a safety cap, not billing, so stopping slightly early is a much smaller failure than a bill nobody saw coming. Two specific over-estimates, both documented at the call site:

- Every token is charged at the model's **output** rate. The adapters report one combined `tokens` figure; output is the dearer half, so this errs the safe way and costs one field to fix properly later.
- A grounded answer is charged for the **full search allowance it requested** (5), not the searches it actually ran. We can't see the real count without parsing four providers' tool blocks.

**Schema:** `profiles.trial_spend_micros` + `increment_trial_spend`, mirroring the existing tokens meter. Micro-dollars rather than a numeric so concurrent increments are integer arithmetic and can't drift.

**Both resolvers** gate on whichever ceiling runs out first, and record **which one** — `exhaustedBy: "runs" | "spend"`. That distinction earns its place: "you've used all 5 free runs" is simply false for someone stopped by spend on their second run, and sends them looking for a bug that isn't there.

**Runs stop themselves.** `resumeRun` takes a `budgetMicros` and checks between answers. Answers already paid for are kept — discarding them would waste money already spent — and the shortfall is written to the run row, so a run that returns 4 of 50 answers doesn't read as broken prompts. **A run on the user's own key is never rationed**; that would be us rationing their money.

## Verified, not assumed

Rather than trusting the assertions, I ran the engine and printed what it actually did:

```
one grounded answer costs $0.055

budget   0 answers ($0.00) of 50 queued ->  0 paid calls,  0 stored, stopped=true
budget   3 answers ($0.17) of 50 queued ->  4 paid calls,  4 stored, stopped=true
budget  10 answers ($0.55) of 50 queued -> 11 paid calls, 11 stored, stopped=true
budget 100 answers ($5.50) of 50 queued -> 50 paid calls, 50 stored, stopped=false
own key (no ceiling)         of 50 queued -> 50 paid calls,            stopped=false
```

The one-call overshoot (4 against a 3-answer budget) is the concurrency window: cost is only known after a call returns, so in-flight answers land after the ceiling trips. Bounded and documented — the alternative is refusing in advance on an estimate, and the estimate is the least certain part of this.

20 new tests (549 total), typecheck, lint and build clean.

## Two things to decide

**1. The per-search price is a placeholder, not a quoted rate.** I could not verify it from a source and would not invent a precise-looking number, so it sits at a conservative `$0.01`/search and is a single env var: `RATE_SEARCH_USD`. It currently **dominates** — $0.05 of a $0.055 grounded answer — which puts the $5 ceiling at roughly **90 grounded answers**. If the real price is lower, the cap bites earlier than actual spend does. Worth setting once verified. Same for the OpenAI/Google/Perplexity token rates, which are deliberately-high placeholders rather than quoted figures; only the Anthropic rows are real published prices.

**2. The ceiling is enforced after the fact, not before.** Cost isn't known until the provider answers, so the last call of a run can carry the total past the cap. Overshoot is bounded by one concurrency window — worst case a few cents. Enforcing in advance would mean refusing on an estimate.

## Not addressed here

The **sourceless-answer guard** is still open: a forced search returning zero sources is stored as though grounded. Separate concern, still your call.
