### PR TITLE
Run the tests on every push, not when someone remembers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+# The checks that were only ever run by whoever remembered.
+#
+# The suite is worth something — it has caught real bugs — but a suite that only
+# runs locally protects the person who ran it, not the branch. This runs the
+# same four gates on every push and every pull request, in the order that fails
+# fastest: typecheck (seconds) before build (a minute), so an obvious break
+# doesn't wait on a bundle.
+#
+# Deliberately requires NO secrets. The whole pipeline was verified in a clean
+# checkout with no .env of any kind, which is why it can also run on a fork's
+# pull request. If a future change makes the build need a real key, that is
+# worth noticing here rather than working around with a secret: the build
+# reaching for a credential means it is doing something at build time that
+# belongs at request time.
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+# A second push to the same branch makes the first run's answer irrelevant.
+# Cancel it rather than paying for an answer nobody will read.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: typecheck, test, lint, build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          # .nvmrc is the single source of truth for the version, so CI and a
+          # developer's shell can't drift apart.
+          node-version-file: .nvmrc
+          cache: npm
+
+      # ci, not install: build from the lockfile exactly, and fail if
+      # package.json and the lockfile disagree.
+      - run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build

--- a/lib/.ci-canary.test.ts
+++ b/lib/.ci-canary.test.ts
@@ -1,0 +1,7 @@
+// TEMPORARY: proves CI fails a red branch. Removed in the next commit.
+import { describe, it, expect } from "vitest";
+describe("ci canary", () => {
+  it("fails on purpose", () => {
+    expect(2 + 2).toBe(5);
+  });
+});

--- a/lib/.ci-canary.test.ts
+++ b/lib/.ci-canary.test.ts
@@ -1,7 +1,0 @@
-// TEMPORARY: proves CI fails a red branch. Removed in the next commit.
-import { describe, it, expect } from "vitest";
-describe("ci canary", () => {
-  it("fails on purpose", () => {
-    expect(2 + 2).toBe(5);
-  });
-});


### PR DESCRIPTION
## The gap

There was no `.github/workflows` at all. 550 tests, a typecheck, a lint and a build — none of it ran unless a person remembered. A pull request that goes red merges green.

That matters more than it sounds given the last few days: the suite caught three real regressions, and four more bugs were only found by deliberate live probing. None of that protects a branch nobody ran it on.

## What runs

Push to `master` and every pull request, ordered to fail fastest — typecheck (seconds) before build (a minute), so an obvious break doesn't wait on a bundle:

| Step | Command |
|---|---|
| Typecheck | `npm run typecheck` |
| Test | `npm test` |
| Lint | `npm run lint` |
| Build | `npm run build` |

Node comes from `.nvmrc`, so CI and a developer's shell can't drift apart. `npm ci` rather than `npm install`, so the lockfile is authoritative and a mismatch with `package.json` fails rather than resolving silently.

## Verified before pushing, not after

I ran the whole pipeline in a **clean git worktree with no `.env.local`** — the state CI is actually in — rather than pushing a workflow and hoping:

```
typecheck   OK
test        550 passed
lint        clean
build       compiled successfully
```

**It needs no secrets.** That's worth stating as a property rather than a coincidence: it means the workflow can run on a fork's pull request, and there's no credential to rotate or leak. The comment in the file says why that should stay true — if the build ever *needs* a key, that's a signal the build is doing something at build time that belongs at request time, and it should fail loudly here rather than be worked around with a secret.

## What this does not do

**Merging is still not blocked on it.** A workflow that runs is not a workflow that gates — that's a branch-protection setting, not a file in the repo. Once this is on `master` and has one green run, the rule to add under Settings → Branches is *Require status checks to pass* → `typecheck, test, lint, build`.

`npm audit` is deliberately not a step. It would fail on the known Next.js CVE from day one, and a CI that is red for a reason everyone has agreed to defer trains people to ignore it. That upgrade is its own piece of work.
