### PR TITLE
Stop the landing header breaking on a phone

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -173,8 +173,10 @@ export default function LandingPage() {
               <Github className="h-4 w-4" aria-hidden />
             </a>
             <ThemeToggle />
-            <Button href="/login" variant="ghost" size="sm">Sign in</Button>
-            <Button href="/login" size="sm">Initialize</Button>
+            <div className="hidden items-center gap-2 sm:flex">
+              <Button href="/login" variant="ghost" size="sm">Sign in</Button>
+              <Button href="/login" size="sm">Initialize</Button>
+            </div>
           </div>
         </div>
       </header>


### PR DESCRIPTION
Five things were competing for a phone's width in one row — wordmark, GitHub, theme toggle, "Sign in", "Initialize". There wasn't room, so "Sign in" wrapped onto two lines and dragged the whole bar out of shape.

Below `sm` the header is now wordmark + GitHub + theme toggle. At `sm` and up, nothing changes.

## The change

```diff
-            <Button href="/login" variant="ghost" size="sm">Sign in</Button>
-            <Button href="/login" size="sm">Initialize</Button>
+            <div className="hidden items-center gap-2 sm:flex">
+              <Button href="/login" variant="ghost" size="sm">Sign in</Button>
+              <Button href="/login" size="sm">Initialize</Button>
+            </div>
```

Hidden as a pair via a wrapper rather than `hidden sm:inline-flex` on each `Button`: `Button`'s base class already includes `inline-flex`, so a per-element override would be fighting the component's own styling. The `<nav>` immediately above already uses exactly this wrapper pattern.

## Verified by rendering it, not by types

A visual bug isn't proven fixed by a green test run, so I measured the real page at four widths:

| width | GitHub | Sign in | Initialize | toggle | header height |
|---|---|---|---|---|---|
| 390px (iPhone) | ✓ | — | — | ✓ | 65px |
| 639px (just below `sm`) | ✓ | — | — | ✓ | 65px |
| 640px (`sm`) | ✓ | ✓ | ✓ | ✓ | 65px |
| 768px | ✓ | ✓ | ✓ | ✓ | 65px |

**The constant 65px is the actual proof.** The bug was a wrap making the bar taller; an unchanged height at every width is what says the wrap is gone.

## Sign-in is still reachable on a phone

Worth checking before hiding an auth entry point. Both remaining CTAs point at the same `/login` destination and neither is breakpoint-hidden:

- Hero: `Start monitoring: it's free`
- Closing section: `Start monitoring, free`

So a mobile visitor loses the header shortcut, not the ability to sign in.

Typecheck, 550 tests, lint and build all clean.