### PR TITLE
Let a router key stand behind the engine you picked, and say when it can't

### DIFF
--- a/app/api/onboarding/complete/route.ts
+++ b/app/api/onboarding/complete/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
-import { getConfiguredProviders, setActiveProject } from "@/lib/data";
+import { getConfiguredProviders, getRouterKeysPublic, setActiveProject } from "@/lib/data";
 import { executeRun } from "@/lib/engine";
 import { humanError } from "@/lib/llm";
 import {
@@ -13,6 +13,7 @@ import {
   engineKeyMessage,
 } from "@/lib/trial";
 import { defaultModelFor } from "@/lib/models";
+import { coveredProviders } from "@/lib/routers";
 import { normalizeCompetitorList } from "@/lib/competitors";
 import { logDashboard } from "@/lib/activity";
 import type { Project } from "@/lib/types";
@@ -123,9 +124,21 @@ export async function POST(request: Request) {
   // trial config would hand a BYOK user a project whose first monitor can't
   // execute — with a perfectly good key sitting in Settings. Their own key wins
   // over the trial; the env default applies only when they have none.
+  //
+  // A router key counts here exactly as a direct key does. It used to not, so a
+  // user whose only credential was a gateway got a project pinned to the env
+  // default and a first run refused for a key they had deliberately replaced.
+  // New projects are created grounded (use_web_search defaults on in the
+  // database), so coverage is asked for the grounded case.
+  const routerKeys = await getRouterKeysPublic(supabase, user.id);
+  const runnable = coveredProviders({
+    direct: providers,
+    routers: routerKeys.map((k) => ({ router: k.router, searchVerified: k.search_verified ?? [] })),
+    webSearch: true,
+  });
   const envDefault = pickDefaultProvider();
   const provider =
-    providers.length === 0 || providers.includes(envDefault) ? envDefault : providers[0];
+    runnable.length === 0 || runnable.includes(envDefault) ? envDefault : runnable[0];
   const model = defaultModelFor(provider);
 
   const { data: projRow, error: projErr } = await supabase

--- a/app/api/onboarding/onboarding-competitors.test.ts
+++ b/app/api/onboarding/onboarding-competitors.test.ts
@@ -38,11 +38,12 @@ vi.mock("@/lib/data", () => ({
   setActiveProject: vi.fn(),
   getProjects: vi.fn(async () => []),
   getConfiguredProviders: vi.fn(async () => []),
+  getRouterKeysPublic: vi.fn(async () => []),
 }));
 vi.mock("@/lib/llm", () => ({ humanError: (e: unknown) => String(e) }));
 vi.mock("@/lib/activity", () => ({ logDashboard: vi.fn() }));
 vi.mock("@/lib/trial", () => ({
-  pickDefaultProvider: () => "anthropic",
+  pickDefaultProvider: vi.fn(() => "anthropic"),
   // No key: the route returns before executing a run, which is all we need.
   resolveRunKey: vi.fn(async () => ({
     source: "none",
@@ -56,6 +57,8 @@ vi.mock("@/lib/trial", () => ({
 }));
 vi.mock("@/lib/engine", () => ({ executeRun: vi.fn() }));
 
+const { getConfiguredProviders, getRouterKeysPublic } = await import("@/lib/data");
+const { pickDefaultProvider } = await import("@/lib/trial");
 const { POST } = await import("@/app/api/onboarding/complete/route");
 
 function req(body: unknown) {
@@ -147,5 +150,42 @@ describe("POST /api/onboarding/complete — competitors", () => {
     const res = await POST(req({ ...BASE, competitors: "Asana" }));
     expect(res.status).toBe(200);
     expect(inserts.some((i) => i.table === "competitors")).toBe(false);
+  });
+});
+
+// LET-176, the same blindness one surface over: this route also PICKS an answer
+// engine, and it picked it from direct keys alone.
+describe("POST /api/onboarding/complete — the engine a new org starts on", () => {
+  const projectInsert = () =>
+    inserts.find((i) => i.table === "projects")?.values as { default_provider: string };
+
+  it("starts on an engine a saved router covers, not the env default", async () => {
+    // The reported setup: no provider keys, one gateway. Defaulting to the
+    // operator's trial provider here created an org whose first run was refused
+    // for a key the user had deliberately replaced with a router.
+    vi.mocked(pickDefaultProvider).mockReturnValueOnce("google");
+    vi.mocked(getRouterKeysPublic).mockResolvedValueOnce([
+      { router: "openrouter", search_verified: ["anthropic"] },
+    ] as never);
+
+    await POST(req(BASE));
+    expect(projectInsert().default_provider).toBe("anthropic");
+  });
+
+  it("still prefers a direct key over a router", async () => {
+    vi.mocked(pickDefaultProvider).mockReturnValueOnce("google");
+    vi.mocked(getConfiguredProviders).mockResolvedValueOnce(["openai"] as never);
+    vi.mocked(getRouterKeysPublic).mockResolvedValueOnce([
+      { router: "concentrate", search_verified: ["anthropic", "openai"] },
+    ] as never);
+
+    await POST(req(BASE));
+    expect(projectInsert().default_provider).toBe("openai");
+  });
+
+  it("falls back to the env default when nothing covers anything", async () => {
+    vi.mocked(pickDefaultProvider).mockReturnValueOnce("google");
+    await POST(req(BASE));
+    expect(projectInsert().default_provider).toBe("google");
   });
 });

--- a/app/api/onboarding/onboarding-route.test.ts
+++ b/app/api/onboarding/onboarding-route.test.ts
@@ -16,6 +16,7 @@ vi.mock("@/lib/data", () => ({
   setActiveProject: vi.fn(),
   getProjects: vi.fn(async () => []),
   getConfiguredProviders: vi.fn(async () => []),
+  getRouterKeysPublic: vi.fn(async () => []),
 }));
 vi.mock("@/lib/llm", () => ({ humanError: (e: unknown) => String(e) }));
 vi.mock("@/lib/trial", () => ({

--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -8,7 +8,6 @@ import RoutersManager from "./routers-manager";
 import ApiKeysManager from "./api-keys-manager";
 import ProjectForm from "./project-form";
 import type { ApiKeyPublic } from "@/lib/types";
-import { routerCanMeasure, routerProviders } from "@/lib/routers";
 import { trialEnabled } from "@/lib/trial";
 
 export const dynamic = "force-dynamic";
@@ -32,21 +31,14 @@ export default async function SettingsPage() {
   ]);
   const apiKeys = (apiKeysRes.data as ApiKeyPublic[] | null) ?? [];
 
-  // What the saved routers cover, split by whether their native web search was
-  // confirmed — the engine picker needs both, because the answer depends on the
-  // project's own web-search setting. Deduped: two routers can cover one engine.
-  const routedProviders = Array.from(
-    new Set(routerKeys.flatMap((k) => routerProviders(k.router))),
-  );
-  const routedGroundedProviders = Array.from(
-    new Set(
-      routerKeys.flatMap((k) =>
-        routerProviders(k.router).filter((p) =>
-          routerCanMeasure(k.router, p, { webSearch: true, verified: k.search_verified ?? [] }),
-        ),
-      ),
-    ),
-  );
+  // The saved routers as the engine picker sees them: what each gateway reaches,
+  // and what its search was confirmed for. Not reduced to a provider list here —
+  // coverage depends on the web-search toggle inside the form, which is client
+  // state, so the picker resolves it per keystroke from these credentials.
+  const routerCoverage = routerKeys.map((k) => ({
+    router: k.router,
+    searchVerified: k.search_verified ?? [],
+  }));
 
   return (
     <div className="space-y-8">
@@ -112,8 +104,7 @@ export default async function SettingsPage() {
           <ProjectForm
             project={project}
             configuredProviders={keys.map((k) => k.provider)}
-            routedProviders={routedProviders}
-            routedGroundedProviders={routedGroundedProviders}
+            routerKeys={routerCoverage}
             onTrial={trialEnabled() && keys.length === 0 && routerKeys.length === 0}
           />
         </CardBody>

--- a/app/dashboard/settings/project-form.tsx
+++ b/app/dashboard/settings/project-form.tsx
@@ -5,6 +5,12 @@ import { useRouter } from "next/navigation";
 import { Check } from "lucide-react";
 import { Button, Input, Textarea, Select, Label } from "@/components/ui";
 import { PROVIDER_LIST, PROVIDERS } from "@/lib/models";
+import {
+  ROUTERS,
+  coveredProviders,
+  engineCoverage,
+  type RouterCoverage,
+} from "@/lib/routers";
 import { article } from "@/lib/utils";
 import type { Project, Provider, Schedule } from "@/lib/types";
 
@@ -25,25 +31,30 @@ function splitEngine(value: string): { provider: string; model: string } {
     : { provider: value.slice(0, sep), model: value.slice(sep + 1) };
 }
 
+/** "Claude", "Claude or GPT", "Claude, GPT or Gemini" — same phrasing the run
+ *  resolver uses when it lists the engines you could switch to. */
+function joinOr(labels: string[]): string {
+  return labels.length <= 1
+    ? labels[0] ?? ""
+    : `${labels.slice(0, -1).join(", ")} or ${labels[labels.length - 1]}`;
+}
+
 export default function ProjectForm({
   project,
   configuredProviders = [],
-  routedProviders = [],
-  routedGroundedProviders = [],
+  routerKeys = [],
   onTrial = false,
 }: {
   project: Project | null;
-  /** Providers the user has a key for, so the picker can flag an engine that
-   *  can't run before they discover it as a failed run. */
+  /** Providers the user has a direct key for, so the picker can flag an engine
+   *  that can't run before they discover it as a failed run. */
   configuredProviders?: Provider[];
-  /** Providers a saved router credential can reach. Counts as having a key —
-   *  otherwise a user who set up one router key and no direct keys is told every
-   *  engine will fail, which is both wrong and the opposite of the point. */
-  routedProviders?: Provider[];
-  /** The subset whose live-web search the router was confirmed to carry. Split
-   *  from the above because the answer depends on the toggle in this very form:
-   *  with web search on, a router that can't ground can't serve the engine. */
-  routedGroundedProviders?: Provider[];
+  /** The saved router credentials. A router counts as having a key for every
+   *  engine it can measure — otherwise a user who set up one router key and no
+   *  direct keys is told every engine will fail, which is the opposite of the
+   *  point. Passed as credentials rather than as a provider list because what
+   *  they cover depends on the web-search toggle in this very form. */
+  routerKeys?: RouterCoverage[];
   /** Running on the operator's shared keys, which force a cheaper model. The
    *  picker promises "the assistant we query", so on the trial that promise is
    *  only true of the provider, not the model. */
@@ -75,11 +86,39 @@ export default function ProjectForm({
   // reason it reads the live web-search toggle: with grounding on, a router that
   // doesn't carry native search can't serve the engine, and that combination is
   // reachable in this form before anything is saved.
+  //
+  // Every engine in the catalog stays SELECTABLE — an engine that disappeared
+  // when a key was removed, or when web search was switched on, would leave a
+  // saved project pointing at an option its own picker no longer lists. What
+  // changes is what the form says about it, and the three states below are the
+  // three the next run can actually be in.
   const selectedProvider = splitEngine(engine).provider as Provider;
-  const covered =
-    configuredProviders.includes(selectedProvider) ||
-    (useWebSearch ? routedGroundedProviders : routedProviders).includes(selectedProvider);
-  const engineNeedsKey = Boolean(PROVIDERS[selectedProvider]) && !covered;
+  const known = Boolean(PROVIDERS[selectedProvider]);
+  const credentials = {
+    direct: configuredProviders,
+    routers: routerKeys,
+    webSearch: useWebSearch,
+  };
+  const coverage = engineCoverage(selectedProvider, credentials);
+  const providerLabel = known ? PROVIDERS[selectedProvider].label : selectedProvider;
+  const engineNeedsKey = known && coverage.kind === "none";
+  // Reachable through a saved router, but not measurably — the run resolver
+  // returns 'unroutable' for exactly this and refuses. Flagged rather than
+  // hidden, because two of the three fixes (turn web search off, re-check the
+  // key) leave this engine selected.
+  const unroutable = coverage.kind === "unroutable" ? coverage : null;
+  // Which credential will carry the run, when one can. Worth saying: a user who
+  // set up a gateway shouldn't have to infer that it covers the engine they just
+  // picked from the absence of a warning.
+  const routed = coverage.kind === "routed" ? coverage : null;
+  // For the no-coverage case: the engines these credentials DO cover, so the
+  // message names the one-click fix instead of only refusing. Same list the run
+  // resolver offers as 'mismatch'.
+  const alternatives = engineNeedsKey
+    ? coveredProviders(credentials)
+        .filter((p) => p !== selectedProvider)
+        .map((p) => PROVIDERS[p].label)
+    : [];
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -229,17 +268,34 @@ export default function ProjectForm({
         </Select>
         {engineNeedsKey ? (
           <p className="mt-1.5 text-xs text-terracotta">
-            No {PROVIDERS[selectedProvider].label} key saved, so runs on this engine
-            will fail. Add one in the section above, or pick an engine you have a key
-            for. We never answer with a different assistant than the one selected.
+            {routerKeys.length > 0
+              ? `No ${providerLabel} key saved, and no router you've added reaches ${providerLabel}, so runs on this engine will fail.`
+              : `No ${providerLabel} key saved, so runs on this engine will fail.`}{" "}
+            {alternatives.length > 0
+              ? `Add one in the section above, or switch to ${joinOr(alternatives)}, which your saved keys already cover.`
+              : "Add one in the section above, or pick an engine you have a key for."}{" "}
+            We never answer with a different assistant than the one selected.
           </p>
+        ) : unroutable ? (
+          // Selectable, but flagged in the router's own words. This is exactly
+          // the combination resolveRunKeyFor refuses as 'unroutable', so saying
+          // it here — while the toggle that causes it is on screen — is the
+          // difference between a fixable setting and a failed run.
+          <p className="mt-1.5 text-xs text-butter-ink">{unroutable.reason}</p>
         ) : (
           <div className="mt-1.5 space-y-1">
             <p className="text-xs text-ink-faint">
               Which assistant we query for this brand. You&apos;ll need a key for the
-              matching provider in the section above. Google AI Overviews and Gemini both
-              use your Google key.
+              matching provider, or a router that covers it, in the sections above.
+              Google AI Overviews and Gemini both use your Google key.
             </p>
+            {routed && (
+              <p className="text-xs text-ink-faint">
+                Covered by your {ROUTERS[routed.router].label} key. Runs are still
+                recorded under {providerLabel}, so the history stays continuous if you
+                add a direct key later.
+              </p>
+            )}
             {onTrial && (
               <p className="text-xs text-ink-faint">
                 While you&apos;re on free runs we use a faster, cheaper model from the
@@ -312,8 +368,12 @@ export default function ProjectForm({
             <Check className="h-4 w-4 text-teal-dark" />
             {engineNeedsKey ? (
               <span>
-                Saved, but runs need {article(PROVIDERS[selectedProvider].label)}{" "}
-                {PROVIDERS[selectedProvider].label} key
+                Saved, but runs need {article(providerLabel)} {providerLabel} key
+              </span>
+            ) : unroutable ? (
+              <span>
+                Saved, but {ROUTERS[unroutable.router].label} can&apos;t measure{" "}
+                {providerLabel} on these settings
               </span>
             ) : (
               "Saved"

--- a/lib/routers.test.ts
+++ b/lib/routers.test.ts
@@ -35,13 +35,14 @@ describe("router registry", () => {
   });
 
   it("serves only the engines whose measurement survives a gateway", () => {
-    expect(routerProviders("concentrate")).toEqual(["anthropic", "openai"]);
-    expect(routerProviders("openrouter")).toEqual(["anthropic", "openai"]);
-    // Gemini's grounding chunks, the AI Overviews pseudo-model and Perplexity's
-    // always-on search are all provider-shaped; routed, they'd answer with a
-    // different measurement under the same label.
-    expect(routerSupport("concentrate", "google")).toBeNull();
+    expect(routerProviders("concentrate")).toEqual(["anthropic", "openai", "google"]);
+    expect(routerProviders("openrouter")).toEqual(["anthropic", "openai", "google"]);
+    // Perplexity stays out: its search is always on and inseparable from the
+    // answer, so a routed Perplexity call cannot be the ungrounded fallback the
+    // `search: "none"` tier relies on. Gemini earns its place only in that
+    // tier — reachable, never grounded (see the routed Gemini cases below).
     expect(routerSupport("concentrate", "perplexity")).toBeNull();
+    expect(routerSupport("openrouter", "perplexity")).toBeNull();
   });
 
   // Both of these are the provider's OWN wire format, which is what preserves
@@ -151,14 +152,14 @@ describe("routerCanMeasure", () => {
 
   it("never allows an engine the router doesn't serve", () => {
     expect(
-      routerCanMeasure("concentrate", "google", { webSearch: false, verified: [] }),
+      routerCanMeasure("concentrate", "perplexity", { webSearch: false, verified: [] }),
     ).toBe(false);
   });
 });
 
 describe("routerRefusalMessage", () => {
   it("names the alternative engines when the router can't serve one", () => {
-    const message = routerRefusalMessage("concentrate", "google", {
+    const message = routerRefusalMessage("concentrate", "perplexity", {
       webSearch: true,
       verified: [],
     });
@@ -251,11 +252,10 @@ describe("engineCoverage", () => {
   });
 
   it("reports no coverage for an engine no router serves", () => {
-    // The LET-176 report itself: router keys, no Google key. Gemini's grounding
-    // doesn't survive a gateway, so no router reaches it at all — which is a
-    // different message from "reachable but not measurable".
+    // Perplexity is the engine no router serves at all — a different state
+    // from Gemini's "reachable but never grounded" (covered below).
     expect(
-      engineCoverage("google", {
+      engineCoverage("perplexity", {
         direct: [],
         routers: [concentrate, openrouter],
         webSearch: true,
@@ -282,10 +282,13 @@ describe("coveredProviders", () => {
 
   it("drops an engine the routers can reach but not ground", () => {
     const routers: RouterCoverage[] = [{ router: "openrouter", searchVerified: ["anthropic"] }];
+    // Grounded: only Claude survives the gateway. GPT and Gemini are both
+    // reachable and both `search: "none"`, so both drop out.
     expect(coveredProviders({ direct: [], routers, webSearch: true })).toEqual(["anthropic"]);
     expect(coveredProviders({ direct: [], routers, webSearch: false })).toEqual([
       "anthropic",
       "openai",
+      "google",
     ]);
   });
 
@@ -298,7 +301,63 @@ describe("coveredProviders", () => {
       ],
       webSearch: false,
     });
-    expect(covered).not.toContain("google");
+    // Perplexity is served by no router, so it can never appear. Gemini is not
+    // asserted here — ungrounded, it is legitimately covered.
     expect(covered).not.toContain("perplexity");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Routed Gemini (LET-176).
+//
+// Both routers can SERVE Gemini and neither can GROUND it — probed 2026-08-02
+// against live keys. These cases pin that distinction, because the tempting
+// fix (accept OpenRouter's `:online` Exa plugin as grounding) would silently
+// swap the search engine underneath a number labelled "Gemini".
+// ---------------------------------------------------------------------------
+
+describe("routed Gemini", () => {
+  it("is reachable through both routers", () => {
+    for (const router of ["openrouter", "concentrate"] as const) {
+      expect(routerProviders(router)).toContain("google");
+    }
+  });
+
+  it("is selectable for an ungrounded project", () => {
+    const cov = engineCoverage("google", {
+      direct: [],
+      routers: [{ router: "openrouter", searchVerified: [] }],
+      webSearch: false,
+    });
+    expect(cov.kind).toBe("routed");
+  });
+
+  it("is refused for a grounded project, however the key was verified", () => {
+    // `verified` cannot rescue it: search is "none", so there is no native
+    // grounding to have verified in the first place.
+    for (const verified of [[], ["google"] as Provider[]]) {
+      const cov = engineCoverage("google", {
+        direct: [],
+        routers: [{ router: "openrouter", searchVerified: verified }],
+        webSearch: true,
+      });
+      expect(cov.kind).toBe("unroutable");
+    }
+  });
+
+  it("maps every catalog Gemini model to a real router slug", () => {
+    // Google's catalog ids are rolling aliases no router resolves, so each one
+    // needs an explicit override; the slugPrefix fallback would 404.
+    for (const model of ["gemini-pro-latest", "gemini-flash-latest", "gemini-flash-lite-latest"]) {
+      const slug = routerSlug("openrouter", "google", model);
+      expect(slug).toMatch(/^google\/gemini-2\.5-(pro|flash|flash-lite)$/);
+    }
+  });
+
+  it("never routes the AI Overviews pseudo-model", () => {
+    // It is our own construct, grounded in Google Search by definition — there
+    // is nothing on a router that could stand in for it.
+    expect(routerSlug("openrouter", "google", GOOGLE_AI_OVERVIEWS_MODEL)).toBeNull();
+    expect(routerSlug("concentrate", "google", GOOGLE_AI_OVERVIEWS_MODEL)).toBeNull();
   });
 });

--- a/lib/routers.test.ts
+++ b/lib/routers.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 import { GOOGLE_AI_OVERVIEWS_MODEL } from "@/lib/models";
 import {
   ROUTERS,
+  coveredProviders,
+  engineCoverage,
   isRouterId,
   parseRouterId,
   routerCanMeasure,
@@ -9,6 +11,7 @@ import {
   routerRefusalMessage,
   routerSlug,
   routerSupport,
+  type RouterCoverage,
 } from "@/lib/routers";
 import type { Provider } from "@/lib/types";
 
@@ -181,5 +184,121 @@ describe("routerRefusalMessage", () => {
       verified: [],
     });
     expect(message).toContain("Re-check the key");
+  });
+});
+
+// LET-176. A user holding only router keys was told every engine would fail,
+// because the answer-engine picker asked "do you have a provider key?" while the
+// run resolver asks "can anything you hold measure this engine?". These are the
+// picker's half of that second question, and they have to agree with
+// resolveRunKeyFor's states or the two surfaces drift apart again.
+describe("engineCoverage", () => {
+  // Confirmed for both engines, which is what saving the key probes for.
+  const concentrate: RouterCoverage = {
+    router: "concentrate",
+    searchVerified: ["anthropic", "openai"],
+  };
+  const openrouter: RouterCoverage = {
+    router: "openrouter",
+    searchVerified: ["anthropic"],
+  };
+
+  it("covers an engine reachable only through a saved router", () => {
+    expect(
+      engineCoverage("anthropic", { direct: [], routers: [concentrate], webSearch: true }),
+    ).toEqual({ kind: "routed", router: "concentrate" });
+  });
+
+  it("still covers an engine held as a direct key", () => {
+    // And prefers it: the run resolver tries the direct key first, so a picker
+    // that named a router here would describe a call that won't be made.
+    expect(
+      engineCoverage("anthropic", {
+        direct: ["anthropic"],
+        routers: [concentrate],
+        webSearch: true,
+      }),
+    ).toEqual({ kind: "direct" });
+  });
+
+  it("covers a grounded engine only through a router confirmed to ground it", () => {
+    // OpenRouter reaches GPT but cannot ask it for its own web search, so a
+    // grounded project is 'unroutable' — reachable, not measurable — and the
+    // reason carries the fix rather than a bare refusal.
+    const grounded = engineCoverage("openai", {
+      direct: [],
+      routers: [openrouter],
+      webSearch: true,
+    });
+    expect(grounded.kind).toBe("unroutable");
+    expect(grounded.kind === "unroutable" && grounded.reason).toContain("Turn off web search");
+
+    // Same credentials, same engine, grounding off: nothing is being claimed
+    // about the live web, so the router serves it.
+    expect(
+      engineCoverage("openai", { direct: [], routers: [openrouter], webSearch: false }),
+    ).toEqual({ kind: "routed", router: "openrouter" });
+  });
+
+  it("prefers a router that can measure over one that merely reaches", () => {
+    expect(
+      engineCoverage("openai", {
+        direct: [],
+        routers: [openrouter, concentrate],
+        webSearch: true,
+      }),
+    ).toEqual({ kind: "routed", router: "concentrate" });
+  });
+
+  it("reports no coverage for an engine no router serves", () => {
+    // The LET-176 report itself: router keys, no Google key. Gemini's grounding
+    // doesn't survive a gateway, so no router reaches it at all — which is a
+    // different message from "reachable but not measurable".
+    expect(
+      engineCoverage("google", {
+        direct: [],
+        routers: [concentrate, openrouter],
+        webSearch: true,
+      }),
+    ).toEqual({ kind: "none" });
+  });
+
+  it("treats a router as no coverage when the user has saved none", () => {
+    expect(engineCoverage("anthropic", { direct: [], routers: [], webSearch: false })).toEqual({
+      kind: "none",
+    });
+  });
+});
+
+describe("coveredProviders", () => {
+  it("lists direct keys first, then what the routers add", () => {
+    const covered = coveredProviders({
+      direct: ["google"],
+      routers: [{ router: "concentrate", searchVerified: ["anthropic", "openai"] }],
+      webSearch: true,
+    });
+    expect(covered).toEqual(["google", "anthropic", "openai"]);
+  });
+
+  it("drops an engine the routers can reach but not ground", () => {
+    const routers: RouterCoverage[] = [{ router: "openrouter", searchVerified: ["anthropic"] }];
+    expect(coveredProviders({ direct: [], routers, webSearch: true })).toEqual(["anthropic"]);
+    expect(coveredProviders({ direct: [], routers, webSearch: false })).toEqual([
+      "anthropic",
+      "openai",
+    ]);
+  });
+
+  it("never invents coverage for an engine that needs a direct key", () => {
+    const covered = coveredProviders({
+      direct: [],
+      routers: [
+        { router: "concentrate", searchVerified: ["anthropic", "openai"] },
+        { router: "openrouter", searchVerified: ["anthropic"] },
+      ],
+      webSearch: false,
+    });
+    expect(covered).not.toContain("google");
+    expect(covered).not.toContain("perplexity");
   });
 });

--- a/lib/routers.ts
+++ b/lib/routers.ts
@@ -163,6 +163,27 @@ export const ROUTERS: Record<RouterId, RouterInfo> = {
         search: "passthrough",
         slugPrefix: "openai",
       },
+      google: {
+        // Routable, but never measurable. Probed 2026-08-02 with a live key:
+        // the call succeeds and returns a ~36-character ungrounded answer with
+        // no sources — Concentrate mirrors Google's chat surface but not its
+        // grounding, and there is no equivalent of the forced tool_choice that
+        // makes the Anthropic and OpenAI paths comparable. Ungrounded runs are
+        // served; a grounded project is refused rather than quietly measured
+        // against an answer that never searched.
+        shape: "openai-chat",
+        search: "none",
+        // Our catalog carries Google's rolling ALIASES (gemini-flash-latest),
+        // which no router resolves — every model needs an explicit slug, and
+        // the `slugPrefix` fallback would produce a 404. A Google model added
+        // to the catalog without an entry here will not route.
+        slugPrefix: "google",
+        slugOverrides: {
+          "gemini-pro-latest": "google/gemini-2.5-pro",
+          "gemini-flash-latest": "google/gemini-2.5-flash",
+          "gemini-flash-lite-latest": "google/gemini-2.5-flash-lite",
+        },
+      },
     },
   },
   openrouter: {
@@ -207,6 +228,28 @@ export const ROUTERS: Record<RouterId, RouterInfo> = {
         shape: "openai-chat",
         search: "none",
         slugPrefix: "openai",
+      },
+      google: {
+        // Routable, but never measurable. Probed 2026-08-02 with a live key:
+        // a plain call returns no structured sources at all, and the only thing
+        // that grounds is OpenRouter's `:online` suffix — its own Exa-backed
+        // web plugin, not Google's native grounding. Substituting that would
+        // mean measuring a different search engine and labelling it Gemini,
+        // which is the one thing this product must not do. So `search: "none"`,
+        // exactly as for OpenRouter's GPT path: a grounded project is refused
+        // with a message naming the fixes, an ungrounded one runs fine.
+        shape: "openai-chat",
+        search: "none",
+        // Our catalog carries Google's rolling ALIASES (gemini-flash-latest),
+        // which no router resolves — every model needs an explicit slug, and
+        // the `slugPrefix` fallback would produce a 404. A Google model added
+        // to the catalog without an entry here will not route.
+        slugPrefix: "google",
+        slugOverrides: {
+          "gemini-pro-latest": "google/gemini-2.5-pro",
+          "gemini-flash-latest": "google/gemini-2.5-flash",
+          "gemini-flash-lite-latest": "google/gemini-2.5-flash-lite",
+        },
       },
     },
   },

--- a/lib/routers.ts
+++ b/lib/routers.ts
@@ -326,3 +326,89 @@ export function routerRefusalMessage(
     `Re-check the key in Settings, or add a direct ${providerLabel} key.`
   );
 }
+
+/**
+ * A saved router credential as a PICKER sees it: which gateway, and which
+ * engines this key's native search has actually been confirmed for.
+ *
+ * Deliberately not the decrypted credential. Choosing an answer engine needs to
+ * know what a key can reach, never what the key is, so this shape is safe to
+ * hand a client component — it is the non-secret half of DecryptedRouterKey.
+ */
+export interface RouterCoverage {
+  router: RouterId;
+  searchVerified: Provider[];
+}
+
+/**
+ * Whether the user's saved credentials can serve an engine, and how.
+ *
+ * The states mirror the ones resolveRunKeyFor produces at run time — 'direct'
+ * and 'routed' are its 'own', 'unroutable' is its 'unroutable', 'none' is its
+ * 'mismatch'/'none' — because selection is the same question execution asks,
+ * one step earlier. Answering it two different ways is what let a user pick an
+ * engine the next run would refuse.
+ */
+export type EngineCoverage =
+  | { kind: "direct" }
+  | { kind: "routed"; router: RouterId }
+  | { kind: "unroutable"; router: RouterId; reason: string }
+  | { kind: "none" };
+
+/**
+ * Resolve coverage for one engine, in the same order the run resolver uses:
+ * a direct key, then a router that can MEASURE the engine, then a router that
+ * merely reaches it.
+ *
+ * `webSearch` is the project's grounding setting, not a preference — with it on,
+ * a router that can't carry the provider's own search can't serve the engine at
+ * all, so the same credentials cover different engines depending on the toggle.
+ */
+export function engineCoverage(
+  provider: Provider,
+  opts: { direct: Provider[]; routers: RouterCoverage[]; webSearch: boolean },
+): EngineCoverage {
+  if (opts.direct.includes(provider)) return { kind: "direct" };
+
+  const usable = opts.routers.find((rk) =>
+    routerCanMeasure(rk.router, provider, {
+      webSearch: opts.webSearch,
+      verified: rk.searchVerified,
+    }),
+  );
+  if (usable) return { kind: "routed", router: usable.router };
+
+  // Reachable, but not comparably. The run would be refused, so the refusal is
+  // composed HERE, in the same words, rather than left for the user to discover
+  // by running — and it names which of the three fixes applies.
+  const blocked = opts.routers.find((rk) => routerSupport(rk.router, provider) !== null);
+  if (blocked) {
+    return {
+      kind: "unroutable",
+      router: blocked.router,
+      reason: routerRefusalMessage(blocked.router, provider, {
+        webSearch: opts.webSearch,
+        verified: blocked.searchVerified,
+      }),
+    };
+  }
+
+  return { kind: "none" };
+}
+
+/**
+ * Every engine these credentials can actually run, direct keys first.
+ *
+ * Direct keys lead because that is the order the resolvers prefer them in, so a
+ * list offered as "engines you already have" reads in the order they'd be used.
+ */
+export function coveredProviders(opts: {
+  direct: Provider[];
+  routers: RouterCoverage[];
+  webSearch: boolean;
+}): Provider[] {
+  const routed = (Object.keys(PROVIDERS) as Provider[]).filter(
+    (p) => engineCoverage(p, opts).kind === "routed",
+  );
+  return Array.from(new Set([...opts.direct, ...routed]));
+}

--- a/lib/trial.test.ts
+++ b/lib/trial.test.ts
@@ -301,11 +301,34 @@ describe("resolveRunKeyFor with a router credential", () => {
   // router user "you have no keys" and offering no switch was the failure this
   // guards: the engines their gateway does cover are exactly the useful advice.
   it("offers the router's own engines as the switch for an engine it can't serve", async () => {
+    // Perplexity is served by no router: its search is always on and
+    // inseparable from the answer, so there is no ungrounded tier to fall to.
     hasRouter("concentrate", ["anthropic"]);
-    const k = await runKeyFor(db(0), "user-1", "google", undefined, { webSearch: true });
+    const k = await runKeyFor(db(0), "user-1", "perplexity", undefined, { webSearch: true });
     expect(k.source).toBe("mismatch");
-    expect(k.available).toEqual(["anthropic", "openai"]);
-    expect(engineKeyMessage(k)).toContain("Anthropic (Claude) or OpenAI (ChatGPT)");
+    expect(k.available).toEqual(["anthropic", "openai", "google"]);
+    expect(engineKeyMessage(k)).toContain("Anthropic (Claude)");
+  });
+
+  // LET-176. A router reaches Gemini but cannot ground it, so a GROUNDED
+  // project is refused as unroutable rather than reported as "no key" — the
+  // fixes differ (turn search off, or add a direct key), and the old message
+  // named neither.
+  it("refuses grounded Gemini as unroutable, not as a missing key", async () => {
+    hasRouter("openrouter", ["anthropic"]);
+    const k = await runKeyFor(db(0), "user-1", "google", undefined, { webSearch: true });
+    expect(k.source).toBe("unroutable");
+    expect(k.refusal).toBeTruthy();
+  });
+
+  it("serves ungrounded Gemini through the router", async () => {
+    // The half of LET-176 that is genuinely fixed: no Google key, router only,
+    // web search off — this now runs instead of being unselectable.
+    hasRouter("openrouter", ["anthropic"]);
+    const k = await runKeyFor(db(0), "user-1", "google", undefined, { webSearch: false });
+    expect(k.source).toBe("own");
+    expect(k.apiKey).toBe("key-for-openrouter");
+    expect(k.route?.router).toBe("openrouter");
   });
 
   it("takes a router key before falling back to the operator's trial", async () => {


### PR DESCRIPTION
Closes part of [LET-176](https://linear.app/letterbrace/issue/LET-176/if-using-router-key-answer-engine-selection-broken) — but **not the headline symptom**, and that difference needs a decision. See the last section.

## What the ticket reported

> have openrouter and concentrate keys added and removed gemini key → can't select gemini as answer engine

## What I found

**Gemini is not routable in this build, by design.** Both routers declare only `anthropic` and `openai` in their `providers` map, and `routerProviders()` returns exactly those keys. `lib/llm/index.ts` has no routed Google path at all. So "can't select Gemini with only router keys" is current intended behaviour, not a coverage bug — OpenRouter serves Gemini *in the world*, but this integration never mapped it.

The exclusion was deliberate and is documented in `lib/routers.ts`: Gemini's grounding chunks come back through a Google-specific redirect host, and AI Overviews is our own pseudo-model.

**Two genuine bugs were sitting next to it, and this fixes both.**

### 1. The picker collapsed three different states into one false sentence

`project-form.tsx` printed *"No &lt;Provider&gt; key saved, so runs on this engine will fail"* for every uncovered case. That is simply **wrong** for the case where a saved router reaches the engine but can't measure it — OpenRouter + GPT with web search on, which `resolveRunKeyFor` refuses as `unroutable`. It also hid two of the three available fixes, and never named which engines the user's credentials *do* cover.

Selection and execution were answering the same question in different vocabularies. `engineCoverage()` now asks the run resolver's question one step earlier, in the same precedence order, and the `unroutable` state carries `routerRefusalMessage(...)` **verbatim** — so the picker and the eventual run refusal say the same words.

### 2. Onboarding was genuinely router-blind

`app/api/onboarding/complete/route.ts` picked a new org's starting engine from `getConfiguredProviders` alone. A router-only user got pinned to the operator's env default and their first run refused for a key they'd deliberately replaced with a router. This is the reported bug's real shape — just on the automatic path rather than the dropdown.

## The web-search case: selectable but flagged

Coverage depends on the web-search toggle *in the same form*, so hiding options would make them appear and disappear as an unrelated switch flips — and an already-saved project could point at an engine its own picker no longer lists. Instead the engine stays selectable with an amber flag (distinct from the red no-key state) naming the gateway, the reason, and all three fixes. The **Saved confirmation is qualified too** (`Saved, but OpenRouter can't measure OpenAI (ChatGPT) on these settings`), which is what stops a user silently committing a combination that refuses at run time.

`lib/trial.ts` is untouched — run-time resolution was already correct.

## Verification

typecheck clean · **562 tests** (was 550) · lint clean (2 pre-existing `no-img-element` warnings) · build ✓

## The decision this leaves you

A router-only user **still cannot select Gemini** after this PR. To change that, Google has to be added to the router registry — which needs a shape decision, a slug map, and a live probe, and cuts against the measurement-integrity call already documented there. The `search: "none"` tier already exists for exactly this shape (it's what OpenRouter + OpenAI uses), so routed-but-ungrounded Gemini is a coherent follow-up if you want it.

I can run that probe against the OpenRouter key if you want the answer before deciding.

## Unrelated router blindness, not touched

`app/dashboard/topics/page.tsx` and `app/dashboard/competitors/page.tsx` both compute `hasKey` from direct keys only, so a router-only user is told to add a key on both pages even though `resolveKey` would serve them. Worth its own ticket.