### PR TITLE
Stop the CLI hanging headless, and start testing it

### DIFF
--- a/cli/args.mjs
+++ b/cli/args.mjs
@@ -1,0 +1,46 @@
+/**
+ * Command-line argument parsing.
+ *
+ * Extracted from lettertrace.mjs so it can be tested. That file reads
+ * process.argv at import time, so importing it from a test runs the CLI —
+ * which is why the one bug this function has already had (a boolean flag
+ * swallowing the following word) went unnoticed until someone hit it.
+ */
+
+/**
+ * Flags that take NO value.
+ *
+ * Without this set, `--json` consumed whatever followed it, so
+ * `lettertrace competitors --json acme` parsed as `--json=acme` with no
+ * project — and the failure surfaced as "needs a <project>" on a command line
+ * that plainly had one. Every value-less flag must be listed here.
+ */
+export const BOOLEAN_FLAGS = new Set(["json", "on", "off", "mcp", "both", "ipv6", "help"]);
+
+/**
+ * Split argv into positionals and flags.
+ *
+ * `--flag value` takes the value unless the flag is known to be boolean;
+ * `--flag --other` never consumes `--other`, so a boolean flag at the end of a
+ * line behaves the same as one in the middle.
+ */
+export function parseArgs(argv) {
+  const positionals = [];
+  const flags = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith("--")) {
+      const key = a.slice(2);
+      const next = argv[i + 1];
+      if (!BOOLEAN_FLAGS.has(key) && next !== undefined && !next.startsWith("--")) {
+        flags[key] = next;
+        i++;
+      } else {
+        flags[key] = true;
+      }
+    } else {
+      positionals.push(a);
+    }
+  }
+  return { positionals, flags };
+}

--- a/cli/args.test.ts
+++ b/cli/args.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { parseArgs as parseArgsRaw, BOOLEAN_FLAGS as BOOLEAN_FLAGS_RAW } from "./args.mjs";
+
+/** args.mjs is plain ESM with no types, so give the two imports a shape here
+ *  rather than scattering casts through every assertion. */
+type Parsed = { positionals: string[]; flags: Record<string, string | true> };
+const parseArgs = parseArgsRaw as (argv: string[]) => Parsed;
+const BOOLEAN_FLAGS = BOOLEAN_FLAGS_RAW as Set<string>;
+
+/**
+ * The CLI is the surface the landing page tells people to install, and until
+ * now none of it was tested — which is how a boolean flag quietly eating the
+ * following word shipped and stayed shipped.
+ */
+
+describe("boolean flags", () => {
+  it("does not swallow the word after --json", () => {
+    // The actual bug: `competitors --json acme` parsed as --json="acme" with no
+    // positional, and the error said "needs a <project>" on a line that had one.
+    const { positionals, flags } = parseArgs(["competitors", "--json", "acme"]);
+    expect(positionals).toEqual(["competitors", "acme"]);
+    expect(flags.json).toBe(true);
+  });
+
+  it("holds for every flag declared boolean", () => {
+    for (const flag of BOOLEAN_FLAGS) {
+      const { positionals, flags } = parseArgs(["cmd", `--${flag}`, "value"]);
+      expect(positionals).toEqual(["cmd", "value"]);
+      expect(flags[flag]).toBe(true);
+    }
+  });
+
+  it("works at the end of the line too", () => {
+    const { positionals, flags } = parseArgs(["projects", "--json"]);
+    expect(positionals).toEqual(["projects"]);
+    expect(flags.json).toBe(true);
+  });
+});
+
+describe("value flags", () => {
+  it("takes the following word", () => {
+    const { flags } = parseArgs(["run", "--project", "acme"]);
+    expect(flags.project).toBe("acme");
+  });
+
+  it("never consumes another flag as its value", () => {
+    // Otherwise `--url --json` would set url="--json" and silently drop the flag.
+    const { flags } = parseArgs(["projects", "--url", "--json"]);
+    expect(flags.url).toBe(true);
+    expect(flags.json).toBe(true);
+  });
+
+  it("treats a missing trailing value as a bare flag rather than crashing", () => {
+    const { flags } = parseArgs(["keys", "set", "--label"]);
+    expect(flags.label).toBe(true);
+  });
+});
+
+describe("positionals", () => {
+  it("keeps order and survives flags interleaved", () => {
+    const { positionals, flags } = parseArgs([
+      "competitors", "add", "--json", "Vanta", "--name", "Drata", "Secureframe",
+    ]);
+    expect(positionals).toEqual(["competitors", "add", "Vanta", "Secureframe"]);
+    expect(flags.name).toBe("Drata");
+  });
+
+  it("handles an empty line", () => {
+    expect(parseArgs([])).toEqual({ positionals: [], flags: {} });
+  });
+
+  it("keeps values that look like paths or URLs intact", () => {
+    const { flags } = parseArgs(["keys", "set", "anthropic", "--key-file", "/tmp/k.txt"]);
+    expect(flags["key-file"]).toBe("/tmp/k.txt");
+  });
+});

--- a/cli/lettertrace.mjs
+++ b/cli/lettertrace.mjs
@@ -13,6 +13,7 @@
  */
 
 import { resolveBase, loadConfig } from "./config.mjs";
+import { parseArgs } from "./args.mjs";
 import { login, logout, getAccessToken, revoke, NeedsLogin } from "./oauth.mjs";
 import { rest, ApiError } from "./http.mjs";
 import { listTools, callTool, renderToolResult } from "./mcp.mjs";
@@ -25,29 +26,6 @@ import { banner, withSpinner } from "./brand.mjs";
 // following word as its value, so `--json competitors <id>` set json to
 // "competitors" and then failed with "Unknown command: <id>" — the documented
 // "every command takes --json" only worked if you put it last.
-const BOOLEAN_FLAGS = new Set(["json", "on", "off", "mcp", "both", "ipv6", "help"]);
-
-function parseArgs(argv) {
-  const positionals = [];
-  const flags = {};
-  for (let i = 0; i < argv.length; i++) {
-    const a = argv[i];
-    if (a.startsWith("--")) {
-      const key = a.slice(2);
-      const next = argv[i + 1];
-      if (!BOOLEAN_FLAGS.has(key) && next !== undefined && !next.startsWith("--")) {
-        flags[key] = next;
-        i++;
-      } else {
-        flags[key] = true;
-      }
-    } else {
-      positionals.push(a);
-    }
-  }
-  return { positionals, flags };
-}
-
 const { positionals, flags } = parseArgs(process.argv.slice(2));
 const [command, ...rest_] = positionals;
 const JSON_OUT = Boolean(flags.json);
@@ -92,6 +70,33 @@ function dynamicTable(rows) {
   table(rows, keys.map((k) => ({ key: k })));
 }
 
+/**
+ * Can we actually complete a browser login here?
+ *
+ * The OAuth flow opens a browser and then blocks on a loopback callback. With
+ * no terminal attached — CI, a cron, an AI agent driving the CLI — nobody can
+ * complete it, so blocking means hanging forever with no output. That is the
+ * worst failure shape available: not an error, just silence.
+ *
+ * So a non-interactive run refuses up front and says what to do instead.
+ */
+function canLoginInteractively() {
+  return Boolean(process.stdin.isTTY && process.stdout.isTTY);
+}
+
+function refuseHeadlessLogin(resource) {
+  // Thrown, not printed: `fail` only writes to stderr, so printing and falling
+  // through would show the explanation and then hang anyway — the exact
+  // behaviour this guards against, now with a misleading message above it.
+  // UsageError lands in the top-level handler, which exits non-zero.
+  throw new UsageError(
+    `Not authenticated for "${resource}", and this isn't an interactive terminal.\n` +
+      `  Browser login can't complete without a TTY, so it would hang rather than fail.\n` +
+      `  Run \`lettertrace login\` once from a terminal — the stored credential is then\n` +
+      `  picked up by scripts, cron jobs and agents on this machine.`,
+  );
+}
+
 // Run a data command, auto-launching the OAuth login for the exact audience it
 // needs if there is no usable credential yet, then retrying once.
 async function withAutoLogin(fn) {
@@ -99,6 +104,7 @@ async function withAutoLogin(fn) {
     return await fn();
   } catch (e) {
     if (e instanceof NeedsLogin) {
+      if (!canLoginInteractively()) refuseHeadlessLogin(e.resource);
       info(c.yellow(`${e.detail ?? `Not authenticated for "${e.resource}".`} Launching login...`));
       await login(base, e.resource, { ipv6: IPV6 });
       return await fn();
@@ -741,6 +747,7 @@ async function withAutoLoginMcp(fn) {
     return await fn();
   } catch (e) {
     if (e instanceof NeedsLogin) {
+      if (!canLoginInteractively()) refuseHeadlessLogin("mcp");
       info(c.yellow(`Not authenticated for "mcp". Launching login...`));
       await login(base, "mcp", { ipv6: IPV6 });
       return await fn();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,6 @@ export default defineConfig({
   resolve: { alias: { "@": root } },
   test: {
     environment: "node",
-    include: ["lib/**/*.test.ts", "app/**/*.test.ts"],
+    include: ["lib/**/*.test.ts", "app/**/*.test.ts", "cli/**/*.test.ts"],
   },
 });


### PR DESCRIPTION
Pre-launch review of the CLI turned up two gaps.

## It hangs forever in a non-interactive shell

Any data command without a stored credential auto-launches a browser login, then blocks on a loopback callback. With no TTY — CI, cron, an **AI agent driving the CLI** — nobody can complete that, so it waits indefinitely with no output.

That's the worst failure shape available: not an error, just silence. Especially bad for a CLI that ships MCP support and is meant to be agent-friendly.

```
$ lettertrace projects --json < /dev/null
  (12s later: still running, nothing printed)
```

Now:

```
✗ Not authenticated for "v1", and this isn't an interactive terminal.
  Browser login can't complete without a TTY, so it would hang rather than fail.
  Run `lettertrace login` once from a terminal — the stored credential is then
  picked up by scripts, cron jobs and agents on this machine.
```

**The refusal throws rather than prints.** My first attempt called `fail()`, which only writes to stderr — so it printed the explanation and then hung anyway, i.e. the same bug with a misleading message above it. Caught by running it headless rather than assuming.

## It had no tests at all

1,700 lines, the surface the landing page tells people to install, zero coverage. That's how a boolean flag quietly eating the following word shipped and stayed shipped — `competitors --json acme` parsed as `--json="acme"` with no positional, then complained there was no project on a command line that plainly had one.

`parseArgs` is extracted to `cli/args.mjs` so it can be imported without executing the CLI (`lettertrace.mjs` reads `process.argv` at import time, which is exactly why it was never testable). Nine tests, including that bug and its mirror image: a value flag swallowing another flag.

`vitest` now includes `cli/**`, so anything added there is covered by CI from here.

## Also checked, and fine

- **The published npm package is byte-identical to the repo** across all 8 modules — no drift between what users install and what's in git
- A fresh user (clean HOME, no env) gets `Not logged in. Run: lettertrace login`, and the base URL correctly defaults to `https://lettertrace.com`
- Unknown commands, `--help`, and the `--json` fix all behave

typecheck clean · **578 tests** (9 new) · lint clean · build compiles.