### PR TITLE
Release CLI 0.1.2

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lettertrace",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Command-line client for a Lettertrace deployment: monitor how your brand shows up in AI assistant answers.",
   "license": "MIT",
   "author": "The Letter Company",


### PR DESCRIPTION
`npm install -g lettertrace` currently serves **0.1.1**, which is the version that **hangs forever in a non-interactive shell**. The fix merged in #73, but git isn't where users get the CLI from.

npm won't overwrite a published version, so shipping it needs a new one.

Nothing else changed — the tarball is the same modules plus `args.mjs`, already covered by the existing `"*.mjs"` files glob (verified with `npm pack --dry-run`).

## After this merges, one manual step

```
cd cli && npm publish
```

There's no publish workflow in the repo, so it's a hand-run command. Worth adding one later so the published version can't drift from `master` again — that gap is exactly what let a known-hanging build stay live.