### PR TITLE
Team-only operations dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -103,6 +103,22 @@ ADMIN_ALERT_FROM=Lettertrace <alerts@example.com>
 RESEND_API_KEY=
 
 # ------------------------------------------------------------------
+# Operations dashboard (optional)
+# ------------------------------------------------------------------
+# Comma-separated addresses that may open /admin — deployment health, what is
+# failing and where. EMPTY BY DEFAULT, which means nobody: on a fresh install
+# the route 404s for every user, including you, until you name someone here.
+# That is deliberate. This file ships in a public repository, and a default
+# that admitted anyone would admit them on every deployment of it.
+ADMIN_EMAILS=
+# Record operational telemetry (run outcomes, errors, and where they were
+# raised) into the ops_events table. Off unless set to 1 — a self-hosted
+# install records nothing at all by default. The dashboard still works without
+# it; it reads run history directly, and only loses errors raised outside the
+# run lifecycle. Never records prompts, answers, brand names or domains.
+OPS_TELEMETRY=
+
+# ------------------------------------------------------------------
 # NOTE: This app is Bring-Your-Own-Key (BYOK). Users add their own
 # Anthropic / OpenAI / Google API keys inside the app (Settings). You
 # do NOT put provider API keys here.

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,0 +1,41 @@
+import type { ReactNode } from "react";
+import Link from "next/link";
+import { Logo } from "@/components/logo";
+import { ThemeToggle } from "@/components/theme";
+
+/**
+ * A deliberately plain shell, separate from the dashboard's.
+ *
+ * The dashboard layout loads projects, trial state and an unseen-run banner —
+ * all of which are properties of the signed-in account, and none of which mean
+ * anything here. Worse, an operations page that renders inside the product's
+ * own chrome invites reading it as part of the product; it is not, and nothing
+ * on it is scoped to one account.
+ *
+ * No nav link points here from anywhere. The route is reached by typing it,
+ * which is the correct amount of discoverability for a page most signed-in
+ * users would get a 404 from.
+ */
+export default function AdminLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen bg-paper">
+      <header className="border-b border-ink/10">
+        <div className="mx-auto flex max-w-5xl items-center justify-between gap-4 px-6 py-4">
+          <div className="flex items-center gap-3">
+            <Logo />
+            <span className="rounded-sm bg-ink/[0.06] px-2 py-0.5 text-xs font-medium text-ink-soft">
+              operations
+            </span>
+          </div>
+          <div className="flex items-center gap-3">
+            <Link href="/dashboard" className="text-sm text-ink-faint hover:text-ink">
+              Dashboard
+            </Link>
+            <ThemeToggle />
+          </div>
+        </div>
+      </header>
+      <main className="mx-auto max-w-5xl px-6 py-10">{children}</main>
+    </div>
+  );
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,0 +1,287 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { AlertTriangle, Activity, CheckCircle2, CircleSlash, Clock, XCircle } from "lucide-react";
+import { requireAdmin } from "@/lib/admin";
+import { liveHealth, inFlightCount } from "@/lib/ops-live";
+import { opsReport } from "@/lib/ops-report";
+import { configChecks, configProblems } from "@/lib/ops-config";
+import { Badge, Card, CardBody, SectionHeading, StatCard } from "@/components/ui";
+import { timeAgo } from "@/lib/utils";
+
+export const dynamic = "force-dynamic";
+export const metadata = { robots: { index: false, follow: false } };
+
+export default async function AdminPage() {
+  const admin = await requireAdmin();
+  // 404, not 403. Everyone who is not an operator sees exactly what they would
+  // see for a route that does not exist, which is the honest answer to them.
+  if (!admin) notFound();
+
+  const [live, ops, inFlight] = await Promise.all([liveHealth(24), opsReport(24), inFlightCount()]);
+  const checks = configChecks();
+  const problems = configProblems(checks);
+
+  const failing =
+    problems.length > 0 ||
+    live.stuck.length > 0 ||
+    live.failures.length > 0 ||
+    (live.successRate !== null && live.successRate < 90);
+
+  return (
+    <div className="space-y-8">
+      <SectionHeading
+        title="Operations"
+        description={`Deployment health for the last 24 hours. Visible only to addresses in ADMIN_EMAILS — signed in as ${admin.email}.`}
+      />
+
+      {/* The single sentence someone should be able to read from a phone. */}
+      <Card
+        className={
+          failing ? "border-terracotta/40 bg-terracotta/[0.04]" : "border-mint/40 bg-mint-tint/40"
+        }
+      >
+        <CardBody className="flex items-start gap-3">
+          {failing ? (
+            <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-terracotta" />
+          ) : (
+            <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-mint-ink" />
+          )}
+          <div className="space-y-1">
+            <p className="font-semibold text-ink">
+              {failing ? "Something needs attention" : "Everything looks operational"}
+            </p>
+            <p className="text-sm text-ink-soft">
+              {problems.length > 0 &&
+                `${problems.length} required setting${problems.length === 1 ? " is" : "s are"} missing. `}
+              {live.stuck.length > 0 && `${live.stuck.length} run(s) stuck in flight. `}
+              {live.failures.length > 0 &&
+                `${live.failures.length} distinct run failure${live.failures.length === 1 ? "" : "s"}. `}
+              {!failing &&
+                (live.runs24h.total === 0
+                  ? "No runs in the last 24 hours — nothing has failed, but nothing has been exercised either."
+                  : `${live.runs24h.completed} of ${live.runs24h.completed + live.runs24h.failed} runs completed.`)}
+            </p>
+            {live.degraded && (
+              <p className="text-sm text-terracotta-dark">
+                Some figures could not be loaded ({live.degraded}) — treat the numbers below as
+                incomplete rather than as zero.
+              </p>
+            )}
+          </div>
+        </CardBody>
+      </Card>
+
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        <StatCard
+          label="Run success (24h)"
+          value={live.successRate === null ? "—" : `${live.successRate}%`}
+          hint={
+            live.successRate === null
+              ? "no runs settled"
+              : `${live.runs24h.completed} ok · ${live.runs24h.failed} failed`
+          }
+          accent={live.successRate !== null && live.successRate < 90 ? "terracotta" : "mint"}
+        />
+        <StatCard
+          label="In flight now"
+          value={inFlight.toLocaleString()}
+          hint={live.stuck.length > 0 ? `${live.stuck.length} stuck` : "none stuck"}
+          accent={live.stuck.length > 0 ? "terracotta" : "teal"}
+        />
+        <StatCard
+          label="Signups (24h)"
+          value={live.signups24h.toLocaleString()}
+          hint={`${live.totalUsers.toLocaleString()} total`}
+          accent="butter"
+        />
+        <StatCard
+          label="Failed actions (24h)"
+          value={live.apiErrors24h.toLocaleString()}
+          hint="from the activity log"
+          accent={live.apiErrors24h > 0 ? "terracotta" : "sand"}
+        />
+      </div>
+
+      {/* ---- Configuration, first, because it explains most other failures --- */}
+      <section className="space-y-3">
+        <h3 className="text-lg font-semibold text-ink">Configuration</h3>
+        <p className="text-sm text-ink-faint">
+          Whether each setting is present. Values are never shown or checked, only presence.
+        </p>
+        <Card>
+          <CardBody className="divide-y divide-ink/5 p-0">
+            {checks.map((c) => (
+              <div key={c.key} className="flex items-center justify-between gap-4 px-6 py-3">
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium text-ink">{c.label}</p>
+                  <p className="truncate font-mono text-xs text-ink-faint">{c.key}</p>
+                </div>
+                <div className="flex shrink-0 items-center gap-3">
+                  {c.state !== "ok" && (
+                    <span className="hidden text-xs text-ink-faint sm:inline">{c.impact}</span>
+                  )}
+                  {c.state === "ok" ? (
+                    <Badge tone="mint">set</Badge>
+                  ) : c.required ? (
+                    <Badge tone="terracotta">missing</Badge>
+                  ) : (
+                    <Badge tone="neutral">not set</Badge>
+                  )}
+                </div>
+              </div>
+            ))}
+          </CardBody>
+        </Card>
+      </section>
+
+      {/* ---- Stuck runs: the failure nothing else reports ------------------- */}
+      {live.stuck.length > 0 && (
+        <section className="space-y-3">
+          <h3 className="flex items-center gap-2 text-lg font-semibold text-ink">
+            <Clock className="h-4 w-4 text-terracotta" />
+            Stuck runs
+          </h3>
+          <p className="text-sm text-ink-faint">
+            Still marked running after 30 minutes. Usually an invocation that died without writing a
+            status — the run will never finish on its own.
+          </p>
+          <Card>
+            <CardBody className="divide-y divide-ink/5 p-0">
+              {live.stuck.map((r) => (
+                <div key={r.id} className="flex items-center justify-between gap-4 px-6 py-3">
+                  <div className="min-w-0">
+                    <p className="truncate text-sm text-ink">
+                      {r.provider}/{r.model}
+                    </p>
+                    <p className="font-mono text-xs text-ink-faint">{r.id.slice(0, 8)}</p>
+                  </div>
+                  <div className="shrink-0 text-right">
+                    <p className="text-sm font-medium text-terracotta-dark">{r.minutes}m</p>
+                    <p className="text-xs text-ink-faint">
+                      {r.done}/{r.planned} answers
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </CardBody>
+          </Card>
+        </section>
+      )}
+
+      {/* ---- What is failing, grouped ---------------------------------------- */}
+      <section className="space-y-3">
+        <h3 className="flex items-center gap-2 text-lg font-semibold text-ink">
+          <XCircle className="h-4 w-4 text-terracotta" />
+          Run failures
+        </h3>
+        {live.failures.length === 0 ? (
+          <Card>
+            <CardBody className="flex items-center gap-2 text-sm text-ink-faint">
+              <CheckCircle2 className="h-4 w-4 text-mint-ink" />
+              No failed runs in the last 24 hours.
+            </CardBody>
+          </Card>
+        ) : (
+          <Card>
+            <CardBody className="divide-y divide-ink/5 p-0">
+              {live.failures.map((f) => (
+                <div key={f.signature} className="space-y-1 px-6 py-4">
+                  <div className="flex items-start justify-between gap-4">
+                    <p className="min-w-0 flex-1 text-sm text-ink">{f.example}</p>
+                    <Badge tone="terracotta">
+                      {f.count}
+                      {f.count === 1 ? " run" : " runs"}
+                    </Badge>
+                  </div>
+                  <p className="text-xs text-ink-faint">
+                    {f.engines.join(", ")} · last {timeAgo(f.lastSeen)}
+                  </p>
+                </div>
+              ))}
+            </CardBody>
+          </Card>
+        )}
+      </section>
+
+      {/* ---- Per engine, so "is it us or them" is answerable ------------------ */}
+      {live.engines.length > 0 && (
+        <section className="space-y-3">
+          <h3 className="text-lg font-semibold text-ink">By engine</h3>
+          <p className="text-sm text-ink-faint">
+            Where a failure sits. One engine failing while the rest succeed is a provider problem,
+            not ours.
+          </p>
+          <Card>
+            <CardBody className="divide-y divide-ink/5 p-0">
+              {live.engines.map((e) => (
+                <div key={e.engine} className="flex items-center justify-between gap-4 px-6 py-3">
+                  <p className="truncate font-mono text-sm text-ink">{e.engine}</p>
+                  <div className="flex shrink-0 items-center gap-3">
+                    <span className="text-xs text-ink-faint">
+                      {e.completed} ok · {e.failed} failed
+                    </span>
+                    <Badge tone={e.rate !== null && e.rate < 90 ? "terracotta" : "mint"}>
+                      {e.rate === null ? "—" : `${e.rate}%`}
+                    </Badge>
+                  </div>
+                </div>
+              ))}
+            </CardBody>
+          </Card>
+        </section>
+      )}
+
+      {/* ---- Errors from outside the run lifecycle ---------------------------- */}
+      <section className="space-y-3">
+        <h3 className="flex items-center gap-2 text-lg font-semibold text-ink">
+          <Activity className="h-4 w-4 text-ink-faint" />
+          Recorded errors
+        </h3>
+        {!ops.enabled ? (
+          <Card>
+            <CardBody className="flex items-start gap-2 text-sm text-ink-faint">
+              <CircleSlash className="mt-0.5 h-4 w-4 shrink-0" />
+              <span>
+                Telemetry is off, so errors outside the run lifecycle — API routes, background jobs,
+                individual provider calls — are not being recorded. Set{" "}
+                <code className="font-mono text-xs">OPS_TELEMETRY=1</code> to collect them. The
+                figures above do not depend on this.
+              </span>
+            </CardBody>
+          </Card>
+        ) : ops.problems.length === 0 ? (
+          <Card>
+            <CardBody className="flex items-center gap-2 text-sm text-ink-faint">
+              <CheckCircle2 className="h-4 w-4 text-mint-ink" />
+              Nothing recorded in the last 24 hours.
+            </CardBody>
+          </Card>
+        ) : (
+          <Card>
+            <CardBody className="divide-y divide-ink/5 p-0">
+              {ops.problems.map((p) => (
+                <div key={p.signature} className="space-y-1 px-6 py-4">
+                  <div className="flex items-start justify-between gap-4">
+                    <p className="min-w-0 flex-1 break-words text-sm text-ink">{p.signature}</p>
+                    <Badge tone="terracotta">{p.occurrences}×</Badge>
+                  </div>
+                  <p className="text-xs text-ink-faint">
+                    {p.source} · last {timeAgo(p.lastSeen)}
+                  </p>
+                </div>
+              ))}
+            </CardBody>
+          </Card>
+        )}
+      </section>
+
+      <p className="text-xs text-ink-faint">
+        Last run {timeAgo(live.lastRunAt)}. Nothing on this page records or displays customer content —
+        prompts, answers and brand names are never written to telemetry.{" "}
+        <Link href="/dashboard" className="underline">
+          Back to dashboard
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/lib/admin.ts
+++ b/lib/admin.ts
@@ -1,0 +1,48 @@
+import { createClient } from "@/lib/supabase/server";
+
+/**
+ * Who may see the operations dashboard.
+ *
+ * An env allowlist rather than a database role, for two reasons. This
+ * repository is public, so a hardcoded list of Letterstory addresses would be
+ * both wrong and permanent — a self-hoster sets their own and nothing about
+ * our team ships in the source. And it needs no migration, no admin UI to
+ * manage admins, and no way to accidentally grant it through the product.
+ *
+ * The list is empty by default, which means NOBODY is an operator. A fresh
+ * deployment has no admin surface at all until someone deliberately names one.
+ * That is the right default for a public repo: the failure mode of an empty
+ * list is a locked door, and of a permissive default is an open one.
+ */
+export function adminEmails(): string[] {
+  return (process.env.ADMIN_EMAILS ?? "")
+    .split(",")
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+/** Is this address an operator? Case-insensitive; empty list means no. */
+export function isAdminEmail(email: string | null | undefined): boolean {
+  const address = email?.trim().toLowerCase();
+  if (!address) return false;
+  const allowed = adminEmails();
+  if (allowed.length === 0) return false;
+  return allowed.includes(address);
+}
+
+/**
+ * The signed-in user, if they are an operator. Null otherwise.
+ *
+ * Callers treat null as "not found" rather than "forbidden" — an operations
+ * dashboard that announces its own existence to everyone who guesses the URL
+ * is telling people where to push. There is nothing secret in the CODE, but
+ * there is no reason to confirm the route resolves.
+ */
+export async function requireAdmin(): Promise<{ email: string } | null> {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user?.email || !isAdminEmail(user.email)) return null;
+  return { email: user.email };
+}

--- a/lib/api-service.ts
+++ b/lib/api-service.ts
@@ -1,4 +1,5 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { recordOpsError } from "@/lib/ops";
 import type {
   Competitor,
   Mention,
@@ -1199,6 +1200,7 @@ export async function triggerRunForProject(
         // a poller that would never see a terminal state. Settle it here
         // instead. Only a killed invocation can still strand a row, which is
         // what the cron sweeper is for.
+        recordOpsError("api-service.background-run", err, { run_id: prepared.runId });
         await settleAbandonedRun(
           supabase,
           prepared.runId,

--- a/lib/engine.ts
+++ b/lib/engine.ts
@@ -13,6 +13,7 @@ import { detectMention, brandTerms } from "@/lib/mentions";
 import { pageKey } from "@/lib/metrics";
 import { analysisModelFor, modelLabel } from "@/lib/models";
 import { spendMicros } from "@/lib/pricing";
+import { recordOps, recordOpsError } from "@/lib/ops";
 import { logActivity } from "@/lib/activity";
 import { selectAll } from "@/lib/paging";
 
@@ -144,7 +145,12 @@ export async function settleAbandonedRun(
     .eq("id", runId)
     .eq("status", "running")
     .select("id");
-  return (data ?? []).length > 0;
+  const settled = (data ?? []).length > 0;
+  // An abandoned run means an invocation died mid-flight — the single most
+  // useful thing to know about a deployment's health, and previously visible
+  // only as a row quietly changing state.
+  if (settled) recordOps("run.abandoned", { level: "error", signature: "run.abandoned" });
+  return settled;
 }
 
 /** What an interrupted run says for itself. Shared so the sweeper, the status
@@ -482,6 +488,10 @@ export async function resumeRun(prepared: PreparedRun, params: ExecuteRunParams)
     } catch (err) {
       // A single failed ask shouldn't kill the whole run.
       if (!hardError) hardError = humanError(err);
+      // ...but every one of them is recorded. Only the FIRST becomes the run's
+      // error message, so without this a run that lost 90 of 100 answers to a
+      // rate limit looks identical to one that lost a single answer.
+      recordOpsError("engine.answer", err, { provider, model, route: route?.router ?? "direct" });
     } finally {
       processed++;
       // Periodic progress checkpoint, completed_count reflects stored answers.
@@ -544,6 +554,23 @@ export async function resumeRun(prepared: PreparedRun, params: ExecuteRunParams)
       spend_micros: spentMicros,
       ...(budgetStopped ? { budget_stopped: true, unrun_prompts: shortfall } : {}),
       ...(hardError ? { error: hardError } : {}),
+    },
+  });
+
+  recordOps(status === "completed" ? "run.completed" : "run.failed", {
+    level: status === "completed" ? "info" : "error",
+    // Signed by engine and outcome, not by run id: the useful question is
+    // "which engine is failing", and a per-run signature could never answer it.
+    signature: `run.${status}:${provider}/${model}`,
+    sample: {
+      provider,
+      model,
+      route: route?.router ?? "direct",
+      planned: jobs.length,
+      stored: succeeded,
+      failed: jobs.length - succeeded,
+      duration_ms: Date.now() - startedMs,
+      budget_stopped: Boolean(budgetStopped),
     },
   });
 

--- a/lib/ops-config.ts
+++ b/lib/ops-config.ts
@@ -1,0 +1,76 @@
+/**
+ * Is this deployment configured, or only running?
+ *
+ * Most launch-night failures are not code failures. They are a variable that
+ * was never set, or was set under a name one character off — which produces a
+ * deployment that boots, serves pages, and silently cannot do the one thing it
+ * exists for. Nothing in the app surfaces that; the feature just quietly does
+ * nothing, and the first report comes from a user.
+ *
+ * PRESENCE ONLY. This reports whether a variable is set, never any part of its
+ * value — not a prefix, not a length, not a masked tail. A page behind an
+ * allowlist is still a page, and a secret confirmed four characters at a time
+ * is still a leaked secret.
+ */
+
+export type CheckState = "ok" | "missing" | "off";
+
+export interface ConfigCheck {
+  key: string;
+  label: string;
+  state: CheckState;
+  /** What actually breaks when this is missing — the reason it is on the list. */
+  impact: string;
+  required: boolean;
+}
+
+const isSet = (v: string | undefined): boolean => typeof v === "string" && v.trim().length > 0;
+
+export function configChecks(env: NodeJS.ProcessEnv = process.env): ConfigCheck[] {
+  const check = (
+    key: string,
+    label: string,
+    impact: string,
+    required: boolean,
+  ): ConfigCheck => ({
+    key,
+    label,
+    state: isSet(env[key]) ? "ok" : required ? "missing" : "off",
+    impact,
+    required,
+  });
+
+  return [
+    check("NEXT_PUBLIC_SUPABASE_URL", "Supabase URL", "Nothing works without it", true),
+    check("NEXT_PUBLIC_SUPABASE_ANON_KEY", "Supabase anon key", "Nobody can sign in", true),
+    check(
+      "SUPABASE_SERVICE_ROLE_KEY",
+      "Service role key",
+      "Background runs and this dashboard both fail",
+      true,
+    ),
+    check(
+      "ENCRYPTION_KEY",
+      "Encryption key",
+      "Provider keys cannot be saved or read back",
+      true,
+    ),
+    check("NEXT_PUBLIC_SITE_URL", "Site URL", "OAuth redirects and emails point at the wrong host", true),
+    check(
+      "TRIAL_ANTHROPIC_API_KEY",
+      "Trial key",
+      "New users cannot run anything before adding their own key",
+      true,
+    ),
+    check("RESEND_API_KEY", "Resend key", "Signup alerts are not sent", false),
+    check("ADMIN_ALERT_EMAIL", "Alert recipient", "Signup alerts have nowhere to go", false),
+    check("CRON_SECRET", "Cron secret", "Scheduled runs are unauthenticated or off", false),
+    check("ADMIN_EMAILS", "Operator allowlist", "This dashboard is unreachable", false),
+    check("OPS_TELEMETRY", "Telemetry", "Errors outside runs are not recorded", false),
+  ];
+}
+
+/** Required things that are missing — the list worth interrupting someone for. */
+export function configProblems(checks: ConfigCheck[]): ConfigCheck[] {
+  return checks.filter((c) => c.required && c.state === "missing");
+}

--- a/lib/ops-live.ts
+++ b/lib/ops-live.ts
@@ -1,0 +1,210 @@
+import { createServiceClient } from "@/lib/supabase/service";
+import { signatureOf } from "@/lib/ops";
+
+/**
+ * The half of the operations picture that does not need telemetry.
+ *
+ * `ops_events` only knows what has happened since it was switched on, which on
+ * the first night is nothing — and a dashboard that renders empty is read as
+ * "all healthy", the single most dangerous thing an operations page can say by
+ * accident.
+ *
+ * These numbers come from tables that already carry history: `runs`,
+ * `activity_logs`, `profiles`. They are authoritative rather than sampled — a
+ * failed run is a row, not a report of a row — so where the two disagree,
+ * this side is right and the telemetry has a gap.
+ *
+ * Service role, because it deliberately crosses every user boundary: the
+ * question is "is the deployment working", which no single account can answer.
+ * The caller is responsible for the admin gate.
+ */
+
+export interface StuckRun {
+  id: string;
+  provider: string;
+  model: string;
+  startedAt: string | null;
+  minutes: number;
+  done: number;
+  planned: number;
+}
+
+export interface FailureGroup {
+  signature: string;
+  count: number;
+  lastSeen: string;
+  example: string;
+  engines: string[];
+}
+
+export interface LiveHealth {
+  runs24h: { completed: number; failed: number; running: number; pending: number; total: number };
+  successRate: number | null;
+  /** Runs that say "running" but have not moved in a long time — the failure
+   *  mode where an invocation dies without ever writing a status. */
+  stuck: StuckRun[];
+  failures: FailureGroup[];
+  engines: { engine: string; completed: number; failed: number; rate: number | null }[];
+  signups24h: number;
+  totalUsers: number;
+  apiErrors24h: number;
+  lastRunAt: string | null;
+  /** Set when a query failed, so the page can say "unknown" instead of "zero". */
+  degraded: string | null;
+}
+
+/** A run still "running" past this is not slow, it is gone. Long, because a big
+ *  prompt set against a slow provider is legitimately a multi-minute job. */
+const STUCK_MINUTES = 30;
+
+interface RunRow {
+  id: string;
+  status: string;
+  provider: string;
+  model: string;
+  error: string | null;
+  prompt_count: number;
+  completed_count: number;
+  started_at: string | null;
+  created_at: string;
+}
+
+export function shapeLive(
+  runs: RunRow[],
+  now: number,
+  signups24h: number,
+  totalUsers: number,
+  apiErrors24h: number,
+  degraded: string | null = null,
+): LiveHealth {
+  const counts = { completed: 0, failed: 0, running: 0, pending: 0, total: runs.length };
+  const failures = new Map<string, FailureGroup>();
+  const engines = new Map<string, { completed: number; failed: number }>();
+  const stuck: StuckRun[] = [];
+  let lastRunAt: string | null = null;
+
+  for (const r of runs) {
+    if (!lastRunAt || r.created_at > lastRunAt) lastRunAt = r.created_at;
+    if (r.status === "completed") counts.completed += 1;
+    else if (r.status === "failed") counts.failed += 1;
+    else if (r.status === "running") counts.running += 1;
+    else counts.pending += 1;
+
+    const engine = `${r.provider}/${r.model}`;
+    const e = engines.get(engine) ?? { completed: 0, failed: 0 };
+    if (r.status === "completed") e.completed += 1;
+    if (r.status === "failed") e.failed += 1;
+    engines.set(engine, e);
+
+    if (r.status === "failed" && r.error) {
+      // Group by the SHAPE of the message, so one provider outage is one line
+      // with a count rather than fifty near-identical rows.
+      const sig = signatureOf(r.error);
+      const g = failures.get(sig);
+      if (g) {
+        g.count += 1;
+        if (r.created_at > g.lastSeen) g.lastSeen = r.created_at;
+        if (!g.engines.includes(engine)) g.engines.push(engine);
+      } else {
+        failures.set(sig, {
+          signature: sig,
+          count: 1,
+          lastSeen: r.created_at,
+          example: r.error.slice(0, 300),
+          engines: [engine],
+        });
+      }
+    }
+
+    if (r.status === "running" || r.status === "pending") {
+      const started = r.started_at ?? r.created_at;
+      const minutes = Math.floor((now - new Date(started).getTime()) / 60000);
+      if (minutes >= STUCK_MINUTES) {
+        stuck.push({
+          id: r.id,
+          provider: r.provider,
+          model: r.model,
+          startedAt: r.started_at,
+          minutes,
+          done: r.completed_count,
+          planned: r.prompt_count,
+        });
+      }
+    }
+  }
+
+  const settled = counts.completed + counts.failed;
+  return {
+    runs24h: counts,
+    // Null, not 100, when nothing settled — see ops-report for why that
+    // distinction is the whole point of this number.
+    successRate: settled > 0 ? Math.round((counts.completed / settled) * 100) : null,
+    stuck: stuck.sort((a, b) => b.minutes - a.minutes),
+    failures: [...failures.values()].sort(
+      (a, b) => b.count - a.count || b.lastSeen.localeCompare(a.lastSeen),
+    ),
+    engines: [...engines.entries()]
+      .map(([engine, v]) => ({
+        engine,
+        ...v,
+        rate: v.completed + v.failed > 0 ? Math.round((v.completed / (v.completed + v.failed)) * 100) : null,
+      }))
+      .sort((a, b) => b.failed - a.failed || b.completed - a.completed),
+    signups24h,
+    totalUsers,
+    apiErrors24h,
+    lastRunAt,
+    degraded,
+  };
+}
+
+export async function liveHealth(hours = 24): Promise<LiveHealth> {
+  const sinceIso = new Date(Date.now() - hours * 60 * 60 * 1000).toISOString();
+  try {
+    const admin = createServiceClient();
+    const [runsRes, signupRes, usersRes, apiErrRes] = await Promise.all([
+      admin
+        .from("runs")
+        .select("id, status, provider, model, error, prompt_count, completed_count, started_at, created_at")
+        .gte("created_at", sinceIso)
+        .order("created_at", { ascending: false })
+        .limit(2000),
+      admin.from("profiles").select("id", { count: "exact", head: true }).gte("created_at", sinceIso),
+      admin.from("profiles").select("id", { count: "exact", head: true }),
+      admin
+        .from("activity_logs")
+        .select("id", { count: "exact", head: true })
+        .eq("status", "failure")
+        .gte("created_at", sinceIso),
+    ]);
+
+    // Runs are the load-bearing query: without them every number below is a
+    // lie of omission, so a failure there degrades the whole card rather than
+    // quietly reporting zero runs and a clean bill of health.
+    if (runsRes.error) throw runsRes.error;
+
+    return shapeLive(
+      (runsRes.data ?? []) as RunRow[],
+      Date.now(),
+      signupRes.count ?? 0,
+      usersRes.count ?? 0,
+      apiErrRes.count ?? 0,
+    );
+  } catch (err) {
+    return shapeLive([], Date.now(), 0, 0, 0, err instanceof Error ? err.message : "query failed");
+  }
+}
+
+/** Runs still in flight right now, regardless of age — "what is happening". */
+export async function inFlightCount(): Promise<number> {
+  try {
+    const admin = createServiceClient();
+    const { count } = await admin
+      .from("runs")
+      .select("id", { count: "exact", head: true })
+      .in("status", ["pending", "running"]);
+    return count ?? 0;
+  } catch {
+    return 0;
+  }
+}

--- a/lib/ops-report.ts
+++ b/lib/ops-report.ts
@@ -1,0 +1,143 @@
+import { createServiceClient } from "@/lib/supabase/service";
+
+/**
+ * Reading operational telemetry back.
+ *
+ * Service-role only, because `ops_events` has RLS on and no policies —
+ * `authenticated` cannot read it at all. The gate is the caller's, and it is
+ * the admin allowlist; this module assumes it has already been passed.
+ *
+ * The shaping lives here rather than in the page so it can be tested without
+ * rendering anything, and so the numbers behind "is it healthy" are inspectable
+ * on their own.
+ */
+
+export interface OpsRow {
+  kind: string;
+  level: "info" | "warn" | "error";
+  signature: string;
+  hour: string;
+  occurrences: number;
+  sample: Record<string, unknown>;
+  last_seen_at: string;
+}
+
+export interface Problem {
+  signature: string;
+  kind: string;
+  occurrences: number;
+  lastSeen: string;
+  source: string;
+  sample: Record<string, unknown>;
+}
+
+export interface OpsReport {
+  /** Whether telemetry is switched on at all. Without this, an empty dashboard
+   *  reads as "everything is fine" when it means "nothing is being recorded". */
+  enabled: boolean;
+  windowHours: number;
+  runs: { completed: number; failed: number; abandoned: number; successRate: number | null };
+  errors: number;
+  problems: Problem[];
+  engines: { engine: string; completed: number; failed: number }[];
+  quietSince: string | null;
+}
+
+const asRecord = (v: unknown): Record<string, unknown> =>
+  v && typeof v === "object" && !Array.isArray(v) ? (v as Record<string, unknown>) : {};
+
+/**
+ * Roll the last `hours` of buckets into the answers an operator wants first:
+ * is it working, what is failing, and where.
+ */
+export function shapeOps(rows: OpsRow[], hours: number, enabled: boolean): OpsReport {
+  let completed = 0;
+  let failed = 0;
+  let abandoned = 0;
+  let errors = 0;
+  const problems = new Map<string, Problem>();
+  const engines = new Map<string, { completed: number; failed: number }>();
+  let latest: string | null = null;
+
+  for (const r of rows) {
+    const n = r.occurrences ?? 0;
+    if (!latest || r.last_seen_at > latest) latest = r.last_seen_at;
+
+    if (r.kind === "run.completed") completed += n;
+    else if (r.kind === "run.failed") failed += n;
+    else if (r.kind === "run.abandoned") abandoned += n;
+
+    if (r.level === "error") {
+      errors += n;
+      const existing = problems.get(r.signature);
+      const sample = asRecord(r.sample);
+      const source = String(sample.source ?? r.kind);
+      if (existing) {
+        existing.occurrences += n;
+        if (r.last_seen_at > existing.lastSeen) existing.lastSeen = r.last_seen_at;
+      } else {
+        problems.set(r.signature, {
+          signature: r.signature,
+          kind: r.kind,
+          occurrences: n,
+          lastSeen: r.last_seen_at,
+          source,
+          sample,
+        });
+      }
+    }
+
+    if (r.kind === "run.completed" || r.kind === "run.failed") {
+      const sample = asRecord(r.sample);
+      const engine = `${sample.provider ?? "?"}/${sample.model ?? "?"}`;
+      const e = engines.get(engine) ?? { completed: 0, failed: 0 };
+      if (r.kind === "run.completed") e.completed += n;
+      else e.failed += n;
+      engines.set(engine, e);
+    }
+  }
+
+  const attempted = completed + failed;
+  return {
+    enabled,
+    windowHours: hours,
+    runs: {
+      completed,
+      failed,
+      abandoned,
+      // Null rather than 100% when nothing ran: a success rate computed from
+      // zero runs is not a healthy deployment, it is an idle one, and showing
+      // "100%" for it is the most reassuring possible lie.
+      successRate: attempted > 0 ? Math.round((completed / attempted) * 100) : null,
+    },
+    errors,
+    problems: [...problems.values()].sort(
+      (a, b) => b.occurrences - a.occurrences || b.lastSeen.localeCompare(a.lastSeen),
+    ),
+    engines: [...engines.entries()]
+      .map(([engine, v]) => ({ engine, ...v }))
+      .sort((a, b) => b.failed - a.failed || b.completed - a.completed),
+    quietSince: latest,
+  };
+}
+
+/** Load and shape the last `hours` of operational telemetry. */
+export async function opsReport(hours = 24): Promise<OpsReport> {
+  const enabled = process.env.OPS_TELEMETRY === "1" || process.env.OPS_TELEMETRY === "true";
+  const since = new Date(Date.now() - hours * 60 * 60 * 1000).toISOString();
+  try {
+    const admin = createServiceClient();
+    const { data, error } = await admin
+      .from("ops_events")
+      .select("kind, level, signature, hour, occurrences, sample, last_seen_at")
+      .gte("hour", since)
+      .order("last_seen_at", { ascending: false })
+      .limit(1000);
+    if (error) throw error;
+    return shapeOps((data ?? []) as OpsRow[], hours, enabled);
+  } catch {
+    // A dashboard that 500s when its own storage is unhappy is a dashboard you
+    // cannot use during an incident, which is the only time it matters.
+    return shapeOps([], hours, enabled);
+  }
+}

--- a/lib/ops.test.ts
+++ b/lib/ops.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+
+// admin.ts reads the signed-in user through the cookie client, which calls
+// React's cache() at module load — unavailable in the node test env. Only the
+// pure allowlist helpers are under test here.
+vi.mock("@/lib/supabase/server", () => ({ createClient: vi.fn() }));
+import { signatureOf, opsEnabled } from "@/lib/ops";
+import { shapeOps, type OpsRow } from "@/lib/ops-report";
+import { shapeLive } from "@/lib/ops-live";
+import { configChecks, configProblems } from "@/lib/ops-config";
+import { isAdminEmail, adminEmails } from "@/lib/admin";
+
+const HOUR = "2026-08-03T14:00:00.000Z";
+
+function opsRow(over: Partial<OpsRow> = {}): OpsRow {
+  return {
+    kind: "run.completed",
+    level: "info",
+    signature: "run.completed:anthropic/claude-opus-5",
+    hour: HOUR,
+    occurrences: 1,
+    sample: {},
+    last_seen_at: HOUR,
+    ...over,
+  };
+}
+
+describe("signatureOf", () => {
+  it("collapses occurrences of the same problem into one signature", () => {
+    const a = signatureOf("run 4f3c9a21-1111-2222-3333-444455556666 failed after 12.5s");
+    const b = signatureOf("run 9999aaaa-bbbb-cccc-dddd-eeeeffff0000 failed after 3s");
+    // The whole bucketing design rests on this: if ids or durations survived,
+    // every occurrence would open its own row and the count would always be 1.
+    expect(a).toBe(b);
+  });
+
+  it("keeps genuinely different problems apart", () => {
+    expect(signatureOf("rate limit exceeded")).not.toBe(signatureOf("invalid api key"));
+  });
+
+  it("strips quoted values, which are usually the varying part", () => {
+    expect(signatureOf(`model "gpt-4" not found`)).toBe(signatureOf(`model "gemini-pro" not found`));
+  });
+
+  it("bounds the length so a stack trace cannot become a signature", () => {
+    expect(signatureOf("x".repeat(5000)).length).toBeLessThanOrEqual(200);
+  });
+});
+
+describe("opsEnabled", () => {
+  const original = process.env.OPS_TELEMETRY;
+  afterEach(() => {
+    if (original === undefined) delete process.env.OPS_TELEMETRY;
+    else process.env.OPS_TELEMETRY = original;
+  });
+
+  it("is off unless explicitly switched on", () => {
+    delete process.env.OPS_TELEMETRY;
+    expect(opsEnabled()).toBe(false);
+    // A self-hosted deployment must not start recording because someone set the
+    // variable to something falsy-looking but non-empty.
+    process.env.OPS_TELEMETRY = "0";
+    expect(opsEnabled()).toBe(false);
+    process.env.OPS_TELEMETRY = "false";
+    expect(opsEnabled()).toBe(false);
+    process.env.OPS_TELEMETRY = "1";
+    expect(opsEnabled()).toBe(true);
+  });
+});
+
+describe("shapeOps", () => {
+  it("reports no success rate when nothing ran, rather than 100%", () => {
+    const r = shapeOps([], 24, true);
+    // The dangerous alternative: 0/0 rendered as a perfect score on a
+    // deployment that is doing nothing at all.
+    expect(r.runs.successRate).toBeNull();
+  });
+
+  it("sums occurrences across hourly buckets for the same problem", () => {
+    const r = shapeOps(
+      [
+        opsRow({ kind: "error", level: "error", signature: "boom", occurrences: 30, hour: HOUR }),
+        opsRow({
+          kind: "error",
+          level: "error",
+          signature: "boom",
+          occurrences: 12,
+          hour: "2026-08-03T15:00:00.000Z",
+          last_seen_at: "2026-08-03T15:30:00.000Z",
+        }),
+      ],
+      24,
+      true,
+    );
+    expect(r.problems).toHaveLength(1);
+    expect(r.problems[0].occurrences).toBe(42);
+    expect(r.problems[0].lastSeen).toBe("2026-08-03T15:30:00.000Z");
+  });
+
+  it("ranks the loudest problem first", () => {
+    const r = shapeOps(
+      [
+        opsRow({ kind: "error", level: "error", signature: "quiet", occurrences: 2 }),
+        opsRow({ kind: "error", level: "error", signature: "loud", occurrences: 200 }),
+      ],
+      24,
+      true,
+    );
+    expect(r.problems.map((p) => p.signature)).toEqual(["loud", "quiet"]);
+  });
+
+  it("counts only error rows as problems", () => {
+    const r = shapeOps([opsRow({ level: "info", occurrences: 5 })], 24, true);
+    expect(r.problems).toHaveLength(0);
+    expect(r.errors).toBe(0);
+  });
+
+  it("survives a malformed sample without throwing", () => {
+    const r = shapeOps([opsRow({ sample: null as never })], 24, true);
+    expect(r.engines[0].engine).toBe("?/?");
+  });
+});
+
+describe("shapeLive", () => {
+  const now = new Date("2026-08-03T16:00:00.000Z").getTime();
+  const run = (over: Record<string, unknown> = {}) => ({
+    id: "aaaaaaaa-0000-0000-0000-000000000000",
+    status: "completed",
+    provider: "anthropic",
+    model: "claude-opus-5",
+    error: null,
+    prompt_count: 10,
+    completed_count: 10,
+    started_at: "2026-08-03T15:50:00.000Z",
+    created_at: "2026-08-03T15:50:00.000Z",
+    ...over,
+  });
+
+  it("flags a run still running long past any plausible duration", () => {
+    const r = shapeLive(
+      [run({ status: "running", started_at: "2026-08-03T14:00:00.000Z", completed_count: 3 })],
+      now,
+      0,
+      0,
+      0,
+    );
+    expect(r.stuck).toHaveLength(1);
+    expect(r.stuck[0].minutes).toBe(120);
+  });
+
+  it("does not flag a run that is merely slow", () => {
+    const r = shapeLive([run({ status: "running", started_at: "2026-08-03T15:45:00.000Z" })], now, 0, 0, 0);
+    expect(r.stuck).toHaveLength(0);
+  });
+
+  it("falls back to created_at when a pending run never started", () => {
+    // A run that never got picked up has no started_at at all; using it
+    // directly would produce NaN minutes and silently drop the row.
+    const r = shapeLive(
+      [run({ status: "pending", started_at: null, created_at: "2026-08-03T13:00:00.000Z" })],
+      now,
+      0,
+      0,
+      0,
+    );
+    expect(r.stuck).toHaveLength(1);
+    expect(r.stuck[0].minutes).toBe(180);
+  });
+
+  it("groups failures by message shape and lists the engines involved", () => {
+    const r = shapeLive(
+      [
+        run({ status: "failed", error: "rate limit exceeded, retry in 30s" }),
+        run({ status: "failed", error: "rate limit exceeded, retry in 5s", model: "claude-sonnet-5" }),
+        run({ status: "failed", error: "invalid api key" }),
+      ],
+      now,
+      0,
+      0,
+      0,
+    );
+    expect(r.failures).toHaveLength(2);
+    expect(r.failures[0].count).toBe(2);
+    expect(r.failures[0].engines).toEqual(["anthropic/claude-opus-5", "anthropic/claude-sonnet-5"]);
+  });
+
+  it("computes success rate from settled runs only", () => {
+    const r = shapeLive(
+      [run(), run(), run({ status: "failed", error: "x" }), run({ status: "running" })],
+      now,
+      0,
+      0,
+      0,
+    );
+    // 2 of 3 settled; the in-flight run is not evidence either way.
+    expect(r.successRate).toBe(67);
+    expect(r.runs24h.running).toBe(1);
+  });
+
+  it("separates per-engine health so a single bad provider is visible", () => {
+    const r = shapeLive(
+      [
+        run({ provider: "openai", model: "gpt-5", status: "failed", error: "boom" }),
+        run({ provider: "openai", model: "gpt-5", status: "failed", error: "boom" }),
+        run(),
+      ],
+      now,
+      0,
+      0,
+      0,
+    );
+    const openai = r.engines.find((e) => e.engine === "openai/gpt-5");
+    expect(openai?.rate).toBe(0);
+    expect(r.engines.find((e) => e.engine === "anthropic/claude-opus-5")?.rate).toBe(100);
+  });
+
+  it("carries a degraded reason so the page can say unknown instead of zero", () => {
+    const r = shapeLive([], now, 0, 0, 0, "connection refused");
+    expect(r.degraded).toBe("connection refused");
+    expect(r.successRate).toBeNull();
+  });
+});
+
+describe("configChecks", () => {
+  it("marks a missing required setting as a problem", () => {
+    const problems = configProblems(configChecks({ NEXT_PUBLIC_SUPABASE_URL: "https://x" } as never));
+    expect(problems.map((p) => p.key)).toContain("SUPABASE_SERVICE_ROLE_KEY");
+    expect(problems.map((p) => p.key)).not.toContain("NEXT_PUBLIC_SUPABASE_URL");
+  });
+
+  it("treats whitespace as unset", () => {
+    // Vercel happily stores a variable whose value is a stray space, and it
+    // behaves exactly like a missing one everywhere else in the app.
+    const checks = configChecks({ ENCRYPTION_KEY: "   " } as never);
+    expect(checks.find((c) => c.key === "ENCRYPTION_KEY")?.state).toBe("missing");
+  });
+
+  it("never reports an optional setting as a problem", () => {
+    const problems = configProblems(configChecks({} as never));
+    expect(problems.every((p) => p.required)).toBe(true);
+  });
+
+  it("reports presence only, never any part of a value", () => {
+    const secret = "sk-super-secret-value";
+    const serialized = JSON.stringify(configChecks({ ENCRYPTION_KEY: secret } as never));
+    expect(serialized).not.toContain(secret);
+    expect(serialized).not.toContain("sk-");
+  });
+});
+
+describe("isAdminEmail", () => {
+  const original = process.env.ADMIN_EMAILS;
+  afterEach(() => {
+    if (original === undefined) delete process.env.ADMIN_EMAILS;
+    else process.env.ADMIN_EMAILS = original;
+  });
+
+  it("admits nobody when the allowlist is unset", () => {
+    delete process.env.ADMIN_EMAILS;
+    expect(adminEmails()).toEqual([]);
+    expect(isAdminEmail("anyone@example.com")).toBe(false);
+  });
+
+  it("admits nobody when the allowlist is empty or only separators", () => {
+    process.env.ADMIN_EMAILS = " , , ";
+    expect(isAdminEmail("anyone@example.com")).toBe(false);
+    // The dangerous bug this guards: an empty split producing [""] and then
+    // matching an empty-ish address.
+    expect(isAdminEmail("")).toBe(false);
+  });
+
+  it("matches case-insensitively and ignores surrounding space", () => {
+    process.env.ADMIN_EMAILS = " Casey@Letterstory.com , mathew@letterstory.com";
+    expect(isAdminEmail("casey@letterstory.com")).toBe(true);
+    expect(isAdminEmail("  MATHEW@letterstory.com ")).toBe(true);
+  });
+
+  it("does not match on substrings", () => {
+    process.env.ADMIN_EMAILS = "casey@letterstory.com";
+    expect(isAdminEmail("casey@letterstory.com.attacker.test")).toBe(false);
+    expect(isAdminEmail("notcasey@letterstory.com")).toBe(false);
+  });
+
+  it("rejects null and undefined", () => {
+    process.env.ADMIN_EMAILS = "casey@letterstory.com";
+    expect(isAdminEmail(null)).toBe(false);
+    expect(isAdminEmail(undefined)).toBe(false);
+  });
+});

--- a/lib/ops.ts
+++ b/lib/ops.ts
@@ -1,0 +1,116 @@
+import { createServiceClient } from "@/lib/supabase/service";
+import { fireAndForget } from "@/lib/notify";
+
+/**
+ * Operational telemetry: what this deployment is doing, and what is failing.
+ *
+ * Three rules, in priority order, and they are the same ones the alerting
+ * follows — a monitoring system that can break the thing it monitors is worse
+ * than no monitoring at all:
+ *
+ *   1. NEVER THROW. Every function here swallows its own failures. A run must
+ *      not fail because recording that it succeeded failed.
+ *   2. NEVER BLOCK. Callers hand these to `fireAndForget`; nothing waits.
+ *   3. NEVER RECORD CONTENT. Provider and model, yes. Prompt text, brand
+ *      names, answers, customer domains — never. The same line the phantom
+ *      access telemetry draws, for the same reason: this is a public
+ *      repository and an operator's database, not a log of what customers
+ *      asked.
+ *
+ * Events are bucketed by (kind, signature, hour), so a provider failing on
+ * every prompt of every run produces ONE row with a count rather than
+ * thousands. The interesting fact is "this failed 400 times since 14:00", and
+ * that is exactly what a bucket says.
+ */
+
+export type OpsLevel = "info" | "warn" | "error";
+
+/** Sample payloads are debugging aids, not logs — keep them small and shapely. */
+export type OpsSample = Record<string, string | number | boolean | null>;
+
+/**
+ * Reduce an error to something that identifies the PROBLEM rather than the
+ * occurrence.
+ *
+ * Numbers, uuids and quoted strings are stripped, because a message like
+ * `run 4f3c… failed after 12s` is the same problem every time it happens and
+ * would otherwise create a new bucket per occurrence — which is precisely the
+ * flood this design exists to prevent.
+ */
+export function signatureOf(input: string): string {
+  return input
+    .replace(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi, "<id>")
+    // No \b anchors: a digit followed by a letter has no word boundary, so
+    // `\b\d+\b` silently fails to match "30s", "12ms", "5m" — exactly the
+    // retry-after and duration values that differ on every occurrence of the
+    // same error. With them, one rate limit would open a new row per retry.
+    .replace(/\d+(\.\d+)?/g, "<n>")
+    .replace(/'[^']*'|"[^"]*"/g, "<s>")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 200);
+}
+
+/** Is operational telemetry switched on for this deployment? */
+export function opsEnabled(): boolean {
+  // Off unless asked for. A self-hosted install records nothing by default —
+  // this repository is public, and someone running it did not sign up to be
+  // measured. Set OPS_TELEMETRY=1 on a deployment you own.
+  const v = process.env.OPS_TELEMETRY;
+  return v === "1" || v === "true";
+}
+
+async function write(kind: string, level: OpsLevel, signature: string, sample: OpsSample) {
+  if (!opsEnabled()) return;
+  try {
+    const admin = createServiceClient();
+    await admin.rpc("record_ops_event", {
+      p_kind: kind,
+      p_level: level,
+      p_signature: signature,
+      p_sample: sample as never,
+    });
+  } catch (err) {
+    // Deliberately swallowed, and deliberately still logged: if telemetry is
+    // broken, the console is the only place left to say so.
+    console.error(
+      `[ops] could not record ${kind}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+/**
+ * Record something that happened. Fire-and-forget; returns immediately.
+ *
+ * `signature` should describe the CLASS of event — an engine, a route, a
+ * failure mode — never a specific id, or every occurrence becomes its own row.
+ */
+export function recordOps(
+  kind: string,
+  opts: { level?: OpsLevel; signature?: string; sample?: OpsSample } = {},
+): void {
+  fireAndForget(
+    write(kind, opts.level ?? "info", signatureOf(opts.signature ?? kind), opts.sample ?? {}),
+  );
+}
+
+/**
+ * Record an error, with where it came from.
+ *
+ * `source` is the thing a person would need in order to start looking — a
+ * route, a module, a job. It is part of the signature, so the same message
+ * raised in two places stays two problems rather than one confusing one.
+ */
+export function recordOpsError(
+  source: string,
+  error: unknown,
+  sample: OpsSample = {},
+): void {
+  const message = error instanceof Error ? error.message : String(error);
+  const name = error instanceof Error ? error.name : "Error";
+  recordOps("error", {
+    level: "error",
+    signature: `${source}: ${message}`,
+    sample: { ...sample, source, name, message: message.slice(0, 300) },
+  });
+}

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -962,3 +962,86 @@ create policy "activity_logs_owner_read" on public.activity_logs
   for select using (user_id = auth.uid());
 
 revoke insert, update, delete on table public.activity_logs from anon, authenticated;
+
+-- ---------- ops_events (operational telemetry, staff-only) ----------------
+--
+-- What is happening in this deployment and what is failing. Runs, provider
+-- calls, errors — recorded so an operator can answer "is it working, and if
+-- not, where" without reading function logs.
+--
+-- BUCKETED BY THE HOUR, not one row per event. A failing provider throws on
+-- every prompt of every run; per-event rows would turn one bad afternoon into
+-- tens of thousands of them, and the interesting number is "this failed 400
+-- times", not four hundred timestamps. Each row is (kind, signature, hour) with
+-- a count, so volume is bounded by the number of DISTINCT problems rather than
+-- by how badly they are going.
+--
+-- RLS ON WITH NO POLICIES. This is the same default-deny the oauth_* tables
+-- use: `authenticated` can never read it, whatever the schema says, because
+-- this file is public and the rows are not. Reads go through a staff-gated
+-- server route using the service role.
+--
+-- Nothing here records customer content. Provider and model, yes; prompt text,
+-- brand names, answers and domains never — the same line the phantom access
+-- telemetry draws.
+create table if not exists public.ops_events (
+  id uuid default gen_random_uuid() primary key,
+
+  -- 'run.completed', 'run.failed', 'provider.error', 'api.error', …
+  kind text not null,
+  level text not null default 'info' check (level in ('info', 'warn', 'error')),
+
+  -- What makes two occurrences "the same problem": for an error, the message
+  -- shape plus where it was raised. Stable across occurrences, so the count is
+  -- meaningful and a storm collapses into one row.
+  signature text not null,
+  -- The hour this falls in (UTC), truncated. The bucket.
+  hour timestamp with time zone not null,
+
+  occurrences integer not null default 0,
+  -- One representative example. Enough to debug from; not a log.
+  sample jsonb not null default '{}'::jsonb,
+
+  first_seen_at timestamp with time zone default timezone('utc'::text, now()) not null,
+  last_seen_at timestamp with time zone default timezone('utc'::text, now()) not null,
+
+  unique (kind, signature, hour)
+);
+
+alter table public.ops_events enable row level security;
+
+create index if not exists idx_ops_events_hour on public.ops_events(hour desc);
+create index if not exists idx_ops_events_level_hour on public.ops_events(level, hour desc)
+  where level = 'error';
+
+-- Atomic bucket increment. Events arrive concurrently from every request, so
+-- read-then-write would lose counts exactly when volume matters most.
+create or replace function public.record_ops_event(
+  p_kind text,
+  p_level text,
+  p_signature text,
+  p_sample jsonb
+)
+returns void
+language sql
+security definer set search_path = public
+as $$
+  insert into public.ops_events as e (kind, level, signature, hour, occurrences, sample)
+  values (
+    p_kind,
+    coalesce(nullif(p_level, ''), 'info'),
+    p_signature,
+    date_trunc('hour', timezone('utc'::text, now())),
+    1,
+    coalesce(p_sample, '{}'::jsonb)
+  )
+  on conflict (kind, signature, hour)
+  do update set
+    occurrences = e.occurrences + 1,
+    -- Keep the FIRST sample, not the latest: the earliest occurrence is the one
+    -- closest to the cause, before retries and knock-on failures muddy it.
+    last_seen_at = timezone('utc'::text, now());
+$$;
+
+revoke all on function public.record_ops_event(text, text, text, jsonb) from public, anon, authenticated;
+grant execute on function public.record_ops_event(text, text, text, jsonb) to service_role;


### PR DESCRIPTION
Answers **"is it working, and if not where"** without reading function logs.

## The gate

`/admin`, allowlisted on `ADMIN_EMAILS`. **Empty by default, which means nobody** — this repository is public, so a permissive default would ship an open door on every deployment of it. A non-operator gets a **404, not a 403**: there is nothing secret in the code, but no reason to confirm the route resolves. Verified: unauthenticated `/admin` returns 404 where `/dashboard` returns a 307 to login.

## Two sources, deliberately

**Run history, signups and failed actions read straight from `runs`, `profiles` and `activity_logs`** — tables that already carry history. The page is therefore useful the moment it merges, not after telemetry accumulates. This matters more than it sounds: an ops page that renders empty gets read as *healthy*, which is the most dangerous thing it could say by accident.

**`ops_events` records what those tables cannot see** — errors raised outside the run lifecycle, and per-answer provider failures. Previously only the *first* of a hundred failed answers became the run's error message, so a run that lost 90 of 100 answers to a rate limit looked identical to one that lost a single answer.

Where the two disagree, the tables are right and the telemetry has a gap.

## What it shows

- One-line verdict, readable from a phone
- Run success rate over 24h — **null, never 100%, when nothing settled**
- **Stuck runs**: still `running` after 30 minutes, i.e. an invocation that died without ever writing a status. Nothing else in the product reports these
- Failures grouped by message shape, with counts and the engines involved
- Per-engine success rate, so "is it us or them" is answerable
- **Configuration presence.** Most launch failures are not code failures — they are a variable never set, or set one character off (we hit exactly this with `PHANTOM_ACCESS_BLOG` last week), producing a deployment that boots and silently cannot do its job. **Presence only**: no value, prefix or length is ever read or displayed, and a test asserts the serialized output contains no part of a secret

## Privacy and open-source posture

- `ops_events` has **RLS on with no policies**, matching the `oauth_*` tables — `authenticated` can never read it, whatever the schema says
- The RPC is `security definer` with a pinned `search_path`, revoked from `public, anon, authenticated`, granted only to `service_role`
- Bucketed by `(kind, signature, hour)`, so a provider failing on every prompt of every run is **one row with a count** rather than thousands
- **No customer content, ever** — provider and model yes; prompts, answers, brand names and domains never
- Telemetry is **off unless `OPS_TELEMETRY=1`**, so a self-hosted install records nothing at all. The dashboard still works without it and says so plainly rather than showing a reassuring blank
- Recording never throws and never blocks: a run must not fail because recording its success failed

## A real bug found on the way

`signatureOf` used `\b\d+\b`, which **never matches "30s", "12ms" or "5m"** — a digit followed by a letter has no word boundary. Every retry-after message would have opened its own row, defeating the bucketing precisely where it matters most. Caught by a test that asserted two rate-limit messages collapse; they didn't.

## Verification

- 604 tests pass (26 new), typecheck, lint and build all clean
- Every dashboard query run against production read-only: `runs` (237 rows), `profiles` (17), `activity_logs`, in-flight count — all valid
- `ops_events` does not exist in production yet, and the dashboard **degrades correctly**: live figures render, the telemetry section says telemetry is off

## To deploy

1. Run the `ops_events` section of `supabase/schema.sql` (idempotent, ~80 lines from the `ops_events` comment block down)
2. Set `ADMIN_EMAILS` in Vercel — comma-separated. **Without it nobody can open the page, including us**
3. Set `OPS_TELEMETRY=1` to collect errors outside the run lifecycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)