### PR TITLE
Show the operator list on the ops dashboard

### DIFF
--- a/app/admin/operators.tsx
+++ b/app/admin/operators.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useState } from "react";
+import { Check, Copy } from "lucide-react";
+import { Badge, Card, CardBody } from "@/components/ui";
+import type { OperatorRoster } from "@/lib/ops-operators";
+import { timeAgo } from "@/lib/utils";
+
+/**
+ * The operator list, shown because Vercel will not show it to you.
+ *
+ * A "sensitive" variable is write-only in the management UI: editing it means
+ * retyping the whole list from memory, and a mistake locks someone out
+ * silently. The running app can read it perfectly well, so it is displayed
+ * here with a copy button — the edit becomes copy, append, paste.
+ */
+export function Operators({ roster }: { roster: OperatorRoster }) {
+  const [copied, setCopied] = useState(false);
+  const varName = roster.gate === "user-id" ? "ADMIN_USER_IDS" : "ADMIN_EMAILS";
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(roster.currentValue);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      /* clipboard blocked; the value is still selectable below */
+    }
+  };
+
+  if (roster.gate === "none") return null;
+
+  return (
+    <section className="space-y-3">
+      <h3 className="text-lg font-semibold text-ink">Operators</h3>
+      <p className="text-sm text-ink-faint">
+        Everyone who can open this page, from{" "}
+        <code className="font-mono text-xs">{varName}</code>.
+      </p>
+
+      <Card>
+        <CardBody className="divide-y divide-ink/5 p-0">
+          {roster.entries.map((e) => (
+            <div key={e.value} className="flex items-center justify-between gap-4 px-6 py-3">
+              <div className="min-w-0">
+                <p className="truncate text-sm text-ink">
+                  {e.email ?? <span className="text-ink-faint">no account matches this entry</span>}
+                </p>
+                <p className="truncate font-mono text-xs text-ink-faint">{e.value}</p>
+              </div>
+              <div className="flex shrink-0 items-center gap-3">
+                {e.resolved && (
+                  <span className="hidden text-xs text-ink-faint sm:inline">
+                    last seen {timeAgo(e.lastSignInAt)}
+                  </span>
+                )}
+                {e.resolved ? (
+                  <Badge tone="mint">active</Badge>
+                ) : (
+                  <Badge tone="terracotta">
+                    {roster.gate === "user-id" ? "unknown id" : "claimable"}
+                  </Badge>
+                )}
+              </div>
+            </div>
+          ))}
+        </CardBody>
+      </Card>
+
+      {/* An unresolved entry means different things per gate, and the email
+          one is a live weakness rather than a typo. Say which. */}
+      {roster.entries.some((e) => !e.resolved) &&
+        (roster.gate === "user-id" ? (
+          <p className="text-xs text-terracotta-dark">
+            An id matching no account grants nothing — it is almost certainly a typo, and whoever
+            it was meant to be cannot get in.
+          </p>
+        ) : (
+          <p className="text-xs text-terracotta-dark">
+            An allowlisted address with no account can be registered by anyone who guesses it,
+            which would hand them this page. Switch to{" "}
+            <code className="font-mono">ADMIN_USER_IDS</code>, or make sure every address here has
+            signed up.
+          </p>
+        ))}
+
+      {roster.degraded && (
+        <p className="text-xs text-ink-faint">
+          Accounts could not be fully read ({roster.degraded}) — an entry shown as unmatched may
+          simply not have been checked.
+        </p>
+      )}
+
+      <div className="space-y-2">
+        <p className="text-xs text-ink-faint">
+          Vercel marks this variable sensitive, so it will not show you the current value when you
+          edit it. Here it is — copy, add the new id on the end after a comma, and paste it back.
+        </p>
+        <div className="relative rounded border border-ink/10 bg-paper-shade/60">
+          <pre className="overflow-x-auto p-3 pr-12 font-mono text-xs text-ink-soft">
+            {roster.currentValue}
+          </pre>
+          <button
+            type="button"
+            onClick={copy}
+            aria-label={copied ? "Copied" : "Copy to clipboard"}
+            title={copied ? "Copied" : "Copy"}
+            className="absolute right-2 top-2 inline-flex h-7 w-7 items-center justify-center rounded-[2px] text-ink-faint transition hover:bg-ink/10 hover:text-ink"
+          >
+            {copied ? <Check className="h-4 w-4" aria-hidden /> : <Copy className="h-4 w-4" aria-hidden />}
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -12,6 +12,8 @@ import {
 import { requireAdmin } from "@/lib/admin";
 import { liveHealth, inFlightCount } from "@/lib/ops-live";
 import { opsReport } from "@/lib/ops-report";
+import { operatorRoster } from "@/lib/ops-operators";
+import { Operators } from "./operators";
 import { Badge, Card, CardBody, SectionHeading, StatCard } from "@/components/ui";
 import { timeAgo } from "@/lib/utils";
 
@@ -24,7 +26,12 @@ export default async function AdminPage() {
   // see for a route that does not exist, which is the honest answer to them.
   if (!admin) notFound();
 
-  const [live, ops, inFlight] = await Promise.all([liveHealth(24), opsReport(24), inFlightCount()]);
+  const [live, ops, inFlight, roster] = await Promise.all([
+    liveHealth(24),
+    opsReport(24),
+    inFlightCount(),
+    operatorRoster(),
+  ]);
   const failing =
     live.stuck.length > 0 ||
     live.failures.length > 0 ||
@@ -270,6 +277,8 @@ export default async function AdminPage() {
           </Card>
         )}
       </section>
+
+      <Operators roster={roster} />
 
       <p className="text-xs text-ink-faint">
         Last run {timeAgo(live.lastRunAt)}. Nothing on this page records or displays customer content —

--- a/lib/ops-operators.ts
+++ b/lib/ops-operators.ts
@@ -1,0 +1,125 @@
+import { createServiceClient } from "@/lib/supabase/service";
+import { adminGate, adminUserIds, adminEmails, type AdminGate } from "@/lib/admin";
+
+/**
+ * Who is currently an operator, resolved back to real accounts.
+ *
+ * This exists because of a genuinely awkward property of the deployment: a
+ * Vercel variable marked "sensitive" is write-only. It can never be read back,
+ * not through the dashboard and not through the API — so adding one person to
+ * ADMIN_USER_IDS means retyping the entire list from memory, and getting it
+ * wrong silently locks somebody out.
+ *
+ * But the RUNNING APP can read it. It is an ordinary environment variable in
+ * the process; only the management UI hides it. So the page shows you the list
+ * you cannot otherwise see, which turns "retype it blind" into "copy, append,
+ * paste".
+ *
+ * Resolving each entry to an account does the other half of the job: a
+ * mistyped id belongs to nobody, and that is invisible in a config file but
+ * obvious here. On the email gate it surfaces something sharper still — an
+ * allowlisted address with no account is the claimable hole that ADMIN_USER_IDS
+ * exists to close, and now it says so on the page rather than in a commit
+ * message nobody rereads.
+ */
+
+export interface OperatorEntry {
+  /** The literal value configured — an id, or an address on the email gate. */
+  value: string;
+  email: string | null;
+  /** False when nothing in auth.users matches: a typo, or a claimable address. */
+  resolved: boolean;
+  lastSignInAt: string | null;
+}
+
+export interface OperatorRoster {
+  gate: AdminGate;
+  entries: OperatorEntry[];
+  /** The current setting, ready to copy, extend and paste back. */
+  currentValue: string;
+  /** Set when accounts could not be read, so the page says so rather than
+   *  rendering every operator as unresolved and implying they are all typos. */
+  degraded: string | null;
+}
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export async function operatorRoster(): Promise<OperatorRoster> {
+  const gate = adminGate();
+  const values = gate === "user-id" ? adminUserIds() : gate === "email" ? adminEmails() : [];
+  const currentValue = values.join(",");
+  const base: OperatorRoster = { gate, entries: [], currentValue, degraded: null };
+  if (values.length === 0) return base;
+
+  try {
+    const admin = createServiceClient();
+
+    if (gate === "user-id") {
+      // Looked up one at a time rather than by listing every user: exact, and
+      // it stays cheap on a deployment with a large user table, since the
+      // operator list is always short.
+      const entries = await Promise.all(
+        values.map(async (value): Promise<OperatorEntry> => {
+          if (!UUID.test(value)) {
+            // Not a uuid at all — almost certainly an address pasted into the
+            // id list, which would match nobody and grant nothing.
+            return { value, email: null, resolved: false, lastSignInAt: null };
+          }
+          const { data, error } = await admin.auth.admin.getUserById(value);
+          if (error || !data?.user) return { value, email: null, resolved: false, lastSignInAt: null };
+          return {
+            value,
+            email: data.user.email ?? null,
+            resolved: true,
+            lastSignInAt: data.user.last_sign_in_at ?? null,
+          };
+        }),
+      );
+      return { ...base, entries };
+    }
+
+    // Email gate: there is no lookup-by-address, so scan. Bounded, and the
+    // page reports a scan that ran out rather than pretending it was complete.
+    const seen = new Map<string, { email: string; lastSignInAt: string | null }>();
+    let page = 1;
+    let exhausted = false;
+    while (page <= 10) {
+      const { data, error } = await admin.auth.admin.listUsers({ page, perPage: 1000 });
+      if (error) throw error;
+      const users = data?.users ?? [];
+      for (const u of users) {
+        if (u.email) {
+          seen.set(u.email.toLowerCase(), {
+            email: u.email,
+            lastSignInAt: u.last_sign_in_at ?? null,
+          });
+        }
+      }
+      if (users.length < 1000) {
+        exhausted = true;
+        break;
+      }
+      page += 1;
+    }
+    const entries = values.map((value): OperatorEntry => {
+      const hit = seen.get(value);
+      return {
+        value,
+        email: hit?.email ?? null,
+        resolved: Boolean(hit),
+        lastSignInAt: hit?.lastSignInAt ?? null,
+      };
+    });
+    return {
+      ...base,
+      entries,
+      degraded: exhausted ? null : "more accounts exist than were scanned",
+    };
+  } catch (err) {
+    return {
+      ...base,
+      entries: values.map((value) => ({ value, email: null, resolved: false, lastSignInAt: null })),
+      degraded: err instanceof Error ? err.message : "could not read accounts",
+    };
+  }
+}


### PR DESCRIPTION
Solves a real operational problem: a Vercel variable marked **sensitive is write-only**. It can never be read back — not in the dashboard, not through the API — so adding one person to `ADMIN_USER_IDS` means retyping the entire list from memory, and a mistake locks somebody out silently.

**The running app can read it perfectly well.** Only the management UI hides it. So the page now shows the current list with a copy button, and the edit becomes copy → append → paste.

Each entry resolves to a real account, which does the other half of the job:

| Entry | Shows as |
|---|---|
| A valid id | The account email + last sign-in |
| A mistyped id | `unknown id` — grants nothing, and whoever it was meant to be cannot get in |
| An address pasted into the id list | `unknown id` (not a uuid, so it never matches) |
| On the email gate: an address with no account | **`claimable`** — the exact hole `ADMIN_USER_IDS` closes |

That last row is the point. It was previously a warning in a commit message; now it is a red badge next to the offending entry.

Verified against the live project: real ids resolve to their accounts, `00000000-…` reports unresolved, and an address in the id list is caught as a non-uuid.

Ids resolve individually rather than by listing every user — exact, and cheap on a large user table since the operator list is always short. The email gate has no lookup-by-address so it scans, bounded at 10k, and says when a scan ran out rather than implying every unmatched entry is a typo.

605 tests pass, typecheck/lint/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)