### PR TITLE
Ops page: search, filters, and bounded lists

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,19 +1,12 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
-import {
-  AlertTriangle,
-  Activity,
-  CheckCircle2,
-  CircleSlash,
-  Clock,
-  ShieldAlert,
-  XCircle,
-} from "lucide-react";
+import { AlertTriangle, CheckCircle2, ShieldAlert } from "lucide-react";
 import { requireAdmin } from "@/lib/admin";
 import { liveHealth, inFlightCount } from "@/lib/ops-live";
 import { opsReport } from "@/lib/ops-report";
 import { operatorRoster } from "@/lib/ops-operators";
 import { OperatorsMenu } from "./operators";
+import { Telemetry } from "./telemetry";
 import { Badge, Card, CardBody, SectionHeading, StatCard } from "@/components/ui";
 import { timeAgo } from "@/lib/utils";
 import { maskEmail } from "@/lib/mask";
@@ -21,18 +14,35 @@ import { maskEmail } from "@/lib/mask";
 export const dynamic = "force-dynamic";
 export const metadata = { robots: { index: false, follow: false } };
 
-export default async function AdminPage() {
+/** The windows worth having. Anything finer is noise; anything longer stops
+ *  being "what is happening" and becomes reporting. */
+const WINDOWS: { label: string; hours: number }[] = [
+  { label: "1h", hours: 1 },
+  { label: "24h", hours: 24 },
+  { label: "7d", hours: 168 },
+];
+
+type SP = Record<string, string | string[] | undefined>;
+
+function windowFrom(searchParams: SP): { label: string; hours: number } {
+  const raw = Array.isArray(searchParams.w) ? searchParams.w[0] : searchParams.w;
+  return WINDOWS.find((w) => w.label === raw) ?? WINDOWS[1];
+}
+
+export default async function AdminPage({ searchParams }: { searchParams: SP }) {
   const admin = await requireAdmin();
   // 404, not 403. Everyone who is not an operator sees exactly what they would
   // see for a route that does not exist, which is the honest answer to them.
   if (!admin) notFound();
 
+  const win = windowFrom(searchParams);
   const [live, ops, inFlight, roster] = await Promise.all([
-    liveHealth(24),
-    opsReport(24),
+    liveHealth(win.hours),
+    opsReport(win.hours),
     inFlightCount(),
     operatorRoster(),
   ]);
+
   const failing =
     live.stuck.length > 0 ||
     live.failures.length > 0 ||
@@ -42,72 +52,89 @@ export default async function AdminPage() {
     <div className="space-y-8">
       <SectionHeading
         title="Operations"
-        description={`Deployment health for the last 24 hours. Signed in as ${maskEmail(admin.email)}.`}
+        description={`Deployment health. Signed in as ${maskEmail(admin.email)}.`}
         action={<OperatorsMenu roster={roster} />}
       />
 
-      {/* Gating on email is usable but conditional: it holds only while every
-          allowlisted address already has an account, because signup issues a
-          session immediately and an address with no account can simply be
-          registered. A user id cannot be claimed that way. */}
       {admin.gate === "email" && (
         <Card className="border-butter/50 bg-butter-tint/40">
           <CardBody className="flex items-start gap-3">
-            <ShieldAlert className="mt-0.5 h-5 w-5 shrink-0 text-butter-ink" />
+            <ShieldAlert className="mt-0.5 h-5 w-5 shrink-0 text-butter-ink" aria-hidden />
             <div className="space-y-1 text-sm">
               <p className="font-semibold text-ink">Access is gated on email addresses</p>
               <p className="text-ink-soft">
-                That is safe only while every address in{" "}
+                Safe only while every address in{" "}
                 <code className="font-mono text-xs">ADMIN_EMAILS</code> already has an account —
-                signup issues a session immediately, so an allowlisted address that nobody has
-                registered can be claimed by anyone who guesses it. Set{" "}
-                <code className="font-mono text-xs">ADMIN_USER_IDS</code> instead: a user id is
-                assigned by the auth server and cannot be registered into. When it is set, the
-                email list is ignored.
+                signup issues a session immediately, so an allowlisted address nobody has
+                registered can be claimed by whoever guesses it. Set{" "}
+                <code className="font-mono text-xs">ADMIN_USER_IDS</code> instead.
               </p>
             </div>
           </CardBody>
         </Card>
       )}
 
-      {/* The single sentence someone should be able to read from a phone. */}
-      <Card
-        className={
-          failing ? "border-terracotta/40 bg-terracotta/[0.04]" : "border-mint/40 bg-mint-tint/40"
-        }
-      >
-        <CardBody className="flex items-start gap-3">
-          {failing ? (
-            <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-terracotta" />
-          ) : (
-            <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-mint-ink" />
-          )}
-          <div className="space-y-1">
-            <p className="font-semibold text-ink">
-              {failing ? "Something needs attention" : "Everything looks operational"}
-            </p>
-            <p className="text-sm text-ink-soft">
-              {live.stuck.length > 0 && `${live.stuck.length} run(s) stuck in flight. `}
-              {live.failures.length > 0 &&
-                `${live.failures.length} distinct run failure${live.failures.length === 1 ? "" : "s"}. `}
-              {!failing &&
-                (live.runs24h.total === 0
-                  ? "No runs in the last 24 hours — nothing has failed, but nothing has been exercised either."
-                  : `${live.runs24h.completed} of ${live.runs24h.completed + live.runs24h.failed} runs completed.`)}
-            </p>
-            {live.degraded && (
-              <p className="text-sm text-terracotta-dark">
-                Some figures could not be loaded ({live.degraded}) — treat the numbers below as
-                incomplete rather than as zero.
-              </p>
-            )}
+      {/* ---- The verdict, and the window it applies to ---------------------- */}
+      <div className="space-y-3">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <p className="text-sm text-ink-faint">Showing the last {win.label}</p>
+          <div className="flex items-center gap-1 rounded border border-ink/10 bg-surface p-1">
+            {WINDOWS.map((w) => (
+              <Link
+                key={w.label}
+                href={`/admin?w=${w.label}`}
+                scroll={false}
+                aria-current={w.label === win.label ? "page" : undefined}
+                className={`rounded-sm px-2.5 py-1 text-xs transition ${
+                  w.label === win.label
+                    ? "bg-ink/[0.08] font-medium text-ink"
+                    : "text-ink-faint hover:text-ink-soft"
+                }`}
+              >
+                {w.label}
+              </Link>
+            ))}
           </div>
-        </CardBody>
-      </Card>
+        </div>
+
+        <Card
+          className={
+            failing ? "border-terracotta/40 bg-terracotta/[0.04]" : "border-mint/40 bg-mint-tint/40"
+          }
+        >
+          <CardBody className="flex items-start gap-3">
+            {failing ? (
+              <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-terracotta" aria-hidden />
+            ) : (
+              <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-mint-ink" aria-hidden />
+            )}
+            <div className="space-y-1">
+              <p className="font-semibold text-ink">
+                {failing ? "Something needs attention" : "Everything looks operational"}
+              </p>
+              <p className="text-sm text-ink-soft">
+                {live.stuck.length > 0 && `${live.stuck.length} run(s) stuck in flight. `}
+                {live.failures.length > 0 &&
+                  `${live.failures.length} distinct run failure${live.failures.length === 1 ? "" : "s"}. `}
+                {!failing &&
+                  (live.runs24h.total === 0
+                    ? `No runs in the last ${win.label} — nothing has failed, but nothing has been exercised either.`
+                    : `${live.runs24h.completed} of ${live.runs24h.completed + live.runs24h.failed} runs completed.`)}
+              </p>
+              {live.degraded && (
+                <p className="text-sm text-terracotta-dark">
+                  Some figures could not be loaded ({live.degraded}) — treat the numbers below as
+                  incomplete rather than as zero.
+                </p>
+              )}
+            </div>
+          </CardBody>
+        </Card>
+      </div>
 
       <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
         <StatCard
-          label="Run success (24h)"
+          label="Run success"
           value={live.successRate === null ? "—" : `${live.successRate}%`}
           hint={
             live.successRate === null
@@ -123,166 +150,63 @@ export default async function AdminPage() {
           accent={live.stuck.length > 0 ? "terracotta" : "teal"}
         />
         <StatCard
-          label="Signups (24h)"
+          label="Signups"
           value={live.signups24h.toLocaleString()}
           hint={`${live.totalUsers.toLocaleString()} total`}
           accent="butter"
         />
         <StatCard
-          label="Failed actions (24h)"
+          label="Failed actions"
           value={live.apiErrors24h.toLocaleString()}
           hint="from the activity log"
           accent={live.apiErrors24h > 0 ? "terracotta" : "sand"}
         />
       </div>
 
-      {/* ---- Stuck runs: the failure nothing else reports ------------------- */}
-      {live.stuck.length > 0 && (
-        <section className="space-y-3">
-          <h3 className="flex items-center gap-2 text-lg font-semibold text-ink">
-            <Clock className="h-4 w-4 text-terracotta" />
-            Stuck runs
-          </h3>
-          <p className="text-sm text-ink-faint">
-            Still marked running after 30 minutes. Usually an invocation that died without writing a
-            status — the run will never finish on its own.
-          </p>
-          <Card>
-            <CardBody className="divide-y divide-ink/5 p-0">
-              {live.stuck.map((r) => (
-                <div key={r.id} className="flex items-center justify-between gap-4 px-6 py-3">
-                  <div className="min-w-0">
-                    <p className="truncate text-sm text-ink">
-                      {r.provider}/{r.model}
-                    </p>
-                    <p className="font-mono text-xs text-ink-faint">{r.id.slice(0, 8)}</p>
-                  </div>
-                  <div className="shrink-0 text-right">
-                    <p className="text-sm font-medium text-terracotta-dark">{r.minutes}m</p>
-                    <p className="text-xs text-ink-faint">
-                      {r.done}/{r.planned} answers
-                    </p>
-                  </div>
-                </div>
-              ))}
-            </CardBody>
-          </Card>
-        </section>
-      )}
+      <Telemetry
+        stuck={live.stuck}
+        failures={live.failures}
+        problems={ops.problems}
+        telemetryOn={ops.enabled}
+      />
 
-      {/* ---- What is failing, grouped ---------------------------------------- */}
-      <section className="space-y-3">
-        <h3 className="flex items-center gap-2 text-lg font-semibold text-ink">
-          <XCircle className="h-4 w-4 text-terracotta" />
-          Run failures
-        </h3>
-        {live.failures.length === 0 ? (
-          <Card>
-            <CardBody className="flex items-center gap-2 text-sm text-ink-faint">
-              <CheckCircle2 className="h-4 w-4 text-mint-ink" />
-              No failed runs in the last 24 hours.
-            </CardBody>
-          </Card>
-        ) : (
-          <Card>
-            <CardBody className="divide-y divide-ink/5 p-0">
-              {live.failures.map((f) => (
-                <div key={f.signature} className="space-y-1 px-6 py-4">
-                  <div className="flex items-start justify-between gap-4">
-                    <p className="min-w-0 flex-1 text-sm text-ink">{f.example}</p>
-                    <Badge tone="terracotta">
-                      {f.count}
-                      {f.count === 1 ? " run" : " runs"}
-                    </Badge>
-                  </div>
-                  <p className="text-xs text-ink-faint">
-                    {f.engines.join(", ")} · last {timeAgo(f.lastSeen)}
-                  </p>
-                </div>
-              ))}
-            </CardBody>
-          </Card>
-        )}
-      </section>
-
-      {/* ---- Per engine, so "is it us or them" is answerable ------------------ */}
+      {/* ---- Per engine: is it us or them ----------------------------------- */}
       {live.engines.length > 0 && (
-        <section className="space-y-3">
-          <h3 className="text-lg font-semibold text-ink">By engine</h3>
-          <p className="text-sm text-ink-faint">
+        <section className="space-y-2">
+          <div className="flex flex-wrap items-baseline gap-x-3">
+            <h3 className="text-lg font-semibold text-ink">By engine</h3>
+            <span className="text-sm tabular-nums text-ink-faint">{live.engines.length}</span>
+          </div>
+          <p className="max-w-3xl text-sm text-ink-faint">
             Where a failure sits. One engine failing while the rest succeed is a provider problem,
             not ours.
           </p>
           <Card>
-            <CardBody className="divide-y divide-ink/5 p-0">
+            <div className="max-h-72 divide-y divide-ink/5 overflow-y-auto">
               {live.engines.map((e) => (
-                <div key={e.engine} className="flex items-center justify-between gap-4 px-6 py-3">
+                <div
+                  key={e.engine}
+                  className="flex items-center justify-between gap-4 px-6 py-3 transition hover:bg-ink/[0.02]"
+                >
                   <p className="truncate font-mono text-sm text-ink">{e.engine}</p>
                   <div className="flex shrink-0 items-center gap-3">
-                    <span className="text-xs text-ink-faint">
+                    <span className="text-xs tabular-nums text-ink-faint">
                       {e.completed} ok · {e.failed} failed
                     </span>
                     <Badge tone={e.rate !== null && e.rate < 90 ? "terracotta" : "mint"}>
-                      {e.rate === null ? "—" : `${e.rate}%`}
+                      <span className="tabular-nums">{e.rate === null ? "—" : `${e.rate}%`}</span>
                     </Badge>
                   </div>
                 </div>
               ))}
-            </CardBody>
+            </div>
           </Card>
         </section>
       )}
 
-      {/* ---- Errors from outside the run lifecycle ---------------------------- */}
-      <section className="space-y-3">
-        <h3 className="flex items-center gap-2 text-lg font-semibold text-ink">
-          <Activity className="h-4 w-4 text-ink-faint" />
-          Recorded errors
-        </h3>
-        {!ops.enabled ? (
-          <Card>
-            <CardBody className="flex items-start gap-2 text-sm text-ink-faint">
-              <CircleSlash className="mt-0.5 h-4 w-4 shrink-0" />
-              <span>
-                Telemetry is off, so errors outside the run lifecycle — API routes, background jobs,
-                and individual provider calls within a run — are not being recorded. Set{" "}
-                <code className="font-mono text-xs">OPS_TELEMETRY=1</code> and redeploy to collect
-                them. It must literally be <code className="font-mono text-xs">1</code> or{" "}
-                <code className="font-mono text-xs">true</code>: the variable existing but holding an
-                empty string reads as off, which looks identical to never having set it. Everything
-                above is read from run history and does not depend on this.
-              </span>
-            </CardBody>
-          </Card>
-        ) : ops.problems.length === 0 ? (
-          <Card>
-            <CardBody className="flex items-center gap-2 text-sm text-ink-faint">
-              <CheckCircle2 className="h-4 w-4 text-mint-ink" />
-              Nothing recorded in the last 24 hours.
-            </CardBody>
-          </Card>
-        ) : (
-          <Card>
-            <CardBody className="divide-y divide-ink/5 p-0">
-              {ops.problems.map((p) => (
-                <div key={p.signature} className="space-y-1 px-6 py-4">
-                  <div className="flex items-start justify-between gap-4">
-                    <p className="min-w-0 flex-1 break-words text-sm text-ink">{p.signature}</p>
-                    <Badge tone="terracotta">{p.occurrences}×</Badge>
-                  </div>
-                  <p className="text-xs text-ink-faint">
-                    {p.source} · last {timeAgo(p.lastSeen)}
-                  </p>
-                </div>
-              ))}
-            </CardBody>
-          </Card>
-        )}
-      </section>
-
       <p className="text-xs text-ink-faint">
-        Last run {timeAgo(live.lastRunAt)}. Nothing on this page records or displays customer content —
-        prompts, answers and brand names are never written to telemetry.{" "}
+        Last run {timeAgo(live.lastRunAt)}. Nothing on this page records or displays customer
+        content — prompts, answers and brand names are never written to telemetry.{" "}
         <Link href="/dashboard" className="underline">
           Back to dashboard
         </Link>

--- a/app/admin/telemetry.tsx
+++ b/app/admin/telemetry.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Activity, CheckCircle2, Clock, Search, XCircle } from "lucide-react";
+import { Badge, Card } from "@/components/ui";
+import type { StuckRun, FailureGroup } from "@/lib/ops-live";
+import type { Problem } from "@/lib/ops-report";
+import { timeAgo } from "@/lib/utils";
+
+/**
+ * The searchable half of the dashboard: stuck runs, run failures, recorded
+ * issues.
+ *
+ * Three decisions shape this, all of them about what a long list does to a
+ * page you open during an incident.
+ *
+ * SCROLL, DON'T GROW. Each list is bounded and scrolls inside itself. A bad
+ * afternoon can produce dozens of distinct failures, and a page that grows to
+ * match buries the summary figures under them — the moment you most need the
+ * headline is the moment the page is least able to show it. Bounded lists mean
+ * the shape of the page never changes, however bad things get.
+ *
+ * ONE SEARCH, NOT THREE. The question is "what do I know about X", where X is
+ * a model, an error phrase or a route — and you rarely know which list holds
+ * the answer. A single box filters all of them at once, and each section says
+ * how many of its rows survived, so an empty section reads as "nothing here
+ * matched" rather than "nothing here".
+ *
+ * COUNTS STAY HONEST. Section headings show the unfiltered total; the filtered
+ * count appears beside it only while a filter is active. A heading that
+ * silently reported the filtered number would let someone conclude an incident
+ * had shrunk when they had merely typed something.
+ */
+
+type LevelFilter = "all" | "error" | "warn";
+
+const matches = (needle: string, ...fields: (string | number | null | undefined)[]) =>
+  fields.some((f) => String(f ?? "").toLowerCase().includes(needle));
+
+export function Telemetry({
+  stuck,
+  failures,
+  problems,
+  telemetryOn,
+}: {
+  stuck: StuckRun[];
+  failures: FailureGroup[];
+  problems: Problem[];
+  telemetryOn: boolean;
+}) {
+  const [q, setQ] = useState("");
+  const [level, setLevel] = useState<LevelFilter>("all");
+  const needle = q.trim().toLowerCase();
+  const filtering = needle.length > 0;
+
+  const shownStuck = useMemo(
+    () =>
+      !filtering ? stuck : stuck.filter((r) => matches(needle, r.provider, r.model, r.id)),
+    [stuck, needle, filtering],
+  );
+  const shownFailures = useMemo(
+    () =>
+      !filtering
+        ? failures
+        : failures.filter((f) => matches(needle, f.example, f.signature, f.engines.join(" "))),
+    [failures, needle, filtering],
+  );
+  const shownProblems = useMemo(() => {
+    const byLevel = level === "all" ? problems : problems.filter((p) => p.level === level);
+    return !filtering
+      ? byLevel
+      : byLevel.filter((p) => matches(needle, p.signature, p.source, JSON.stringify(p.sample)));
+  }, [problems, needle, filtering, level]);
+
+  const totalShown = shownStuck.length + shownFailures.length + shownProblems.length;
+  const errorCount = problems.filter((p) => p.level === "error").length;
+  const warnCount = problems.filter((p) => p.level === "warn").length;
+
+  return (
+    <div className="space-y-4">
+      {/* ---- Toolbar ------------------------------------------------------- */}
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="relative min-w-0 flex-1">
+          <Search
+            className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-ink-faint"
+            aria-hidden
+          />
+          <input
+            type="search"
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="Search failures, engines, routes…"
+            aria-label="Search telemetry"
+            className="w-full rounded border border-ink/15 bg-surface py-2 pl-9 pr-3 text-sm text-ink placeholder:text-ink-faint focus:border-ink/30 focus:outline-none"
+          />
+        </div>
+        {problems.length > 0 && (
+          <div className="flex shrink-0 items-center gap-1 rounded border border-ink/10 bg-surface p-1">
+            {(
+              [
+                ["all", `All ${problems.length}`],
+                ["error", `Errors ${errorCount}`],
+                ["warn", `Warnings ${warnCount}`],
+              ] as [LevelFilter, string][]
+            ).map(([value, label]) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => setLevel(value)}
+                aria-pressed={level === value}
+                className={`rounded-sm px-2.5 py-1 text-xs tabular-nums transition ${
+                  level === value
+                    ? "bg-ink/[0.08] font-medium text-ink"
+                    : "text-ink-faint hover:text-ink-soft"
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {filtering && (
+        <p className="text-xs text-ink-faint">
+          {totalShown === 0
+            ? `Nothing matches “${q}”.`
+            : `${totalShown} match${totalShown === 1 ? "" : "es"} for “${q}”.`}
+        </p>
+      )}
+
+      {/* ---- Stuck runs ---------------------------------------------------- */}
+      {stuck.length > 0 && (
+        <Section
+          icon={<Clock className="h-4 w-4 text-terracotta" aria-hidden />}
+          title="Stuck runs"
+          total={stuck.length}
+          shown={shownStuck.length}
+          filtering={filtering}
+          hint="Still running after 30 minutes — an invocation that died without writing a status. These never finish on their own."
+        >
+          {shownStuck.map((r) => (
+            <Row key={r.id} accent>
+              <div className="min-w-0">
+                <p className="truncate font-mono text-sm text-ink">
+                  {r.provider}/{r.model}
+                </p>
+                <p className="truncate font-mono text-xs text-ink-faint">{r.id.slice(0, 8)}</p>
+              </div>
+              <div className="shrink-0 text-right">
+                <p className="text-sm font-medium tabular-nums text-terracotta-dark">{r.minutes}m</p>
+                <p className="text-xs tabular-nums text-ink-faint">
+                  {r.done}/{r.planned} answers
+                </p>
+              </div>
+            </Row>
+          ))}
+        </Section>
+      )}
+
+      {/* ---- Run failures --------------------------------------------------- */}
+      <Section
+        icon={<XCircle className="h-4 w-4 text-terracotta" aria-hidden />}
+        title="Run failures"
+        total={failures.length}
+        shown={shownFailures.length}
+        filtering={filtering}
+        empty={
+          failures.length === 0 ? "No failed runs in the window." : `Nothing matches “${q}”.`
+        }
+      >
+        {shownFailures.map((f) => (
+          <Row key={f.signature} accent>
+            <div className="min-w-0 flex-1">
+              <p className="text-sm text-ink">{f.example}</p>
+              <p className="mt-0.5 truncate font-mono text-xs text-ink-faint">
+                {f.engines.join(", ")} · {timeAgo(f.lastSeen)}
+              </p>
+            </div>
+            <Badge tone="terracotta">
+              <span className="tabular-nums">{f.count}</span>
+            </Badge>
+          </Row>
+        ))}
+      </Section>
+
+      {/* ---- Recorded issues ------------------------------------------------ */}
+      <Section
+        icon={<Activity className="h-4 w-4 text-ink-faint" aria-hidden />}
+        title="Recorded issues"
+        total={problems.length}
+        shown={shownProblems.length}
+        filtering={filtering || level !== "all"}
+        empty={
+          problems.length === 0
+            ? telemetryOn
+              ? "Nothing recorded in the window."
+              : // Only when the list is empty. Printed above a populated list it
+                // contradicted the rows directly beneath it.
+                "Telemetry is off — errors outside the run lifecycle are not recorded. Set OPS_TELEMETRY=1 and redeploy. Everything else on this page comes from run history and does not depend on it."
+            : "Nothing matches the current filter."
+        }
+      >
+        {shownProblems.map((p) => (
+          <Row key={p.signature} accent={p.level === "error"}>
+            <div className="min-w-0 flex-1">
+              <p className="break-words font-mono text-sm text-ink">{p.signature}</p>
+              <p className="mt-0.5 truncate text-xs text-ink-faint">
+                {p.source} · {timeAgo(p.lastSeen)}
+              </p>
+            </div>
+            <Badge tone={p.level === "error" ? "terracotta" : "butter"}>
+              <span className="tabular-nums">{p.occurrences}×</span>
+            </Badge>
+          </Row>
+        ))}
+      </Section>
+    </div>
+  );
+}
+
+/**
+ * A bounded list. The scroll container is the body only, so the heading and its
+ * counts stay put while the rows move — during an incident you want to keep
+ * seeing how many there are while you read them.
+ */
+function Section({
+  icon,
+  title,
+  total,
+  shown,
+  filtering,
+  hint,
+  empty,
+  children,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  total: number;
+  shown: number;
+  filtering: boolean;
+  hint?: string;
+  empty?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="space-y-2">
+      <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+        <h3 className="flex items-center gap-2 text-lg font-semibold text-ink">
+          {icon}
+          {title}
+        </h3>
+        <span className="text-sm tabular-nums text-ink-faint">
+          {/* The unfiltered total is the truth; the filtered count is a view of
+              it, and is labelled as such rather than replacing it. */}
+          {filtering && shown !== total ? `${shown} of ${total}` : total}
+        </span>
+      </div>
+      {hint && <p className="max-w-3xl text-sm text-ink-faint">{hint}</p>}
+      <Card>
+        {shown === 0 ? (
+          <div className="flex items-center gap-2 px-6 py-4 text-sm text-ink-faint">
+            <CheckCircle2 className="h-4 w-4 text-mint-ink" aria-hidden />
+            {empty}
+          </div>
+        ) : (
+          <div className="max-h-80 overflow-y-auto">{children}</div>
+        )}
+      </Card>
+    </section>
+  );
+}
+
+function Row({ children, accent = false }: { children: React.ReactNode; accent?: boolean }) {
+  return (
+    <div
+      className={`flex items-start justify-between gap-4 border-t border-t-ink/5 px-6 py-3 transition first:border-t-0 hover:bg-ink/[0.02] ${
+        // A severity stripe, so scanning the list does not depend on reading it.
+        //
+        // Deliberately NOT inside a `divide-y divide-ink/5` parent: that emits
+        // `border-color` (all four sides) on every child after the first, which
+        // repainted this stripe and left only the first row marked. Separating
+        // the row rule into border-t-* and border-l-* keeps them independent.
+        accent ? "border-l-2 border-l-terracotta/60" : "border-l-2 border-l-transparent"
+      }`}
+    >
+      {children}
+    </div>
+  );
+}

--- a/lib/ops-report.ts
+++ b/lib/ops-report.ts
@@ -25,6 +25,8 @@ export interface OpsRow {
 export interface Problem {
   signature: string;
   kind: string;
+  /** Carried through so the view can separate "broken" from "worth knowing". */
+  level: "warn" | "error";
   occurrences: number;
   lastSeen: string;
   source: string;
@@ -67,8 +69,12 @@ export function shapeOps(rows: OpsRow[], hours: number, enabled: boolean): OpsRe
     else if (r.kind === "run.failed") failed += n;
     else if (r.kind === "run.abandoned") abandoned += n;
 
-    if (r.level === "error") {
-      errors += n;
+    // Warnings are included, not just errors. A warn is something the code
+    // deliberately chose to report; dropping it here would mean it could never
+    // be seen anywhere, which makes recording it pointless. Only `errors`
+    // counts strictly errors, since that is what the headline figure means.
+    if (r.level === "error" || r.level === "warn") {
+      if (r.level === "error") errors += n;
       const existing = problems.get(r.signature);
       const sample = asRecord(r.sample);
       const source = String(sample.source ?? r.kind);
@@ -79,6 +85,7 @@ export function shapeOps(rows: OpsRow[], hours: number, enabled: boolean): OpsRe
         problems.set(r.signature, {
           signature: r.signature,
           kind: r.kind,
+          level: r.level === "error" ? "error" : "warn",
           occurrences: n,
           lastSeen: r.last_seen_at,
           source,
@@ -112,7 +119,10 @@ export function shapeOps(rows: OpsRow[], hours: number, enabled: boolean): OpsRe
     },
     errors,
     problems: [...problems.values()].sort(
-      (a, b) => b.occurrences - a.occurrences || b.lastSeen.localeCompare(a.lastSeen),
+      (a, b) =>
+        Number(b.level === "error") - Number(a.level === "error") ||
+        b.occurrences - a.occurrences ||
+        b.lastSeen.localeCompare(a.lastSeen),
     ),
     engines: [...engines.entries()]
       .map(([engine, v]) => ({ engine, ...v }))

--- a/lib/ops.test.ts
+++ b/lib/ops.test.ts
@@ -109,10 +109,36 @@ describe("shapeOps", () => {
     expect(r.problems.map((p) => p.signature)).toEqual(["loud", "quiet"]);
   });
 
-  it("counts only error rows as problems", () => {
+  it("ignores info rows, which are volume rather than problems", () => {
     const r = shapeOps([opsRow({ level: "info", occurrences: 5 })], 24, true);
     expect(r.problems).toHaveLength(0);
     expect(r.errors).toBe(0);
+  });
+
+  it("surfaces warnings as problems but does not count them as errors", () => {
+    // A warn is something the code deliberately chose to report. Dropping it
+    // would mean it could never be seen anywhere, which makes recording it
+    // pointless — but the headline "errors" figure must stay strictly errors.
+    const r = shapeOps(
+      [opsRow({ kind: "warn", level: "warn", signature: "slow provider", occurrences: 3 })],
+      24,
+      true,
+    );
+    expect(r.problems).toHaveLength(1);
+    expect(r.problems[0].level).toBe("warn");
+    expect(r.errors).toBe(0);
+  });
+
+  it("ranks any error above any warning, however loud the warning", () => {
+    const r = shapeOps(
+      [
+        opsRow({ kind: "warn", level: "warn", signature: "noisy warn", occurrences: 900 }),
+        opsRow({ kind: "error", level: "error", signature: "one error", occurrences: 1 }),
+      ],
+      24,
+      true,
+    );
+    expect(r.problems.map((p) => p.signature)).toEqual(["one error", "noisy warn"]);
   });
 
   it("survives a malformed sample without throwing", () => {


### PR DESCRIPTION
Three problems with the previous page, all of which only show up once something is actually wrong.

**Lists grew the page.** A bad afternoon produces dozens of distinct failures, and the page grew to match — burying the summary figures under them. The moment you most need the headline was the moment the page was least able to show it. Every list is now bounded and scrolls inside itself, so the shape of the page never changes however bad things get.

**Nothing was findable.** One search box filters stuck runs, run failures and recorded issues *together*, because the question is "what do I know about X" — a model, an error phrase, a route — and you rarely know which list holds the answer. Section headings keep showing the **unfiltered** total with the filtered count beside it (`1 of 10`), so nobody concludes an incident shrank when they merely typed something.

**Warnings were invisible.** `shapeOps` kept only error-level rows, so a `warn` could be recorded and then never seen anywhere — which makes recording it pointless. Warnings are now surfaced and filterable (`All / Errors / Warnings`), ranked below any error however loud, and still excluded from the headline error count.

Also adds a **1h / 24h / 7d** window, since "is this a spike or normal" cannot be answered from one window.

## Two fixes that came from looking at the rendered page

- **The severity stripe was on the first error row only.** A parent `divide-y divide-ink/5` emits `border-color` for all four sides on every child after the first, silently repainting the left border. Computed styles showed row 1 at `rgba(224,120,80,0.5)` and rows 2-10 at `rgba(244,243,239,0.05)`. Rows now carry `border-t-*` and `border-l-*` separately, which cannot collide.
- **The "telemetry is off" note rendered above a populated list** of recorded errors, contradicting the rows underneath it. It is the empty state now.

Neither was visible in the source; both were obvious in the DOM.

## Verification

Signed in against a seeded fixture set of 10 issues (7 errors, 3 warnings):

| Check | Result |
|---|---|
| Page height with 10 rows | 1287px — bounded |
| Scroll containment | 320px viewport over 629px of content |
| Horizontal overflow | none |
| Search "rate limit" | `1 match`, heading `1 of 10` |
| Severity stripes | 7 error rows striped, 8th (warning) transparent |

Fixtures and the temp operator were deleted afterwards, scoped by marker so the one real `run.completed` row survived. 612 tests pass (2 new), typecheck/lint/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)