### PR TITLE
Add Merge Gateway as an LLM router

### DIFF
--- a/app/dashboard/settings/routers-manager.tsx
+++ b/app/dashboard/settings/routers-manager.tsx
@@ -26,6 +26,7 @@ import type { Provider, RouterId, RouterKeyPublic } from "@/lib/types";
 const ROUTER_MARK: Record<RouterId, { mark: string; markClass: string }> = {
   concentrate: { mark: "◎", markClass: "bg-teal/15 text-teal-dark" },
   openrouter: { mark: "⇄", markClass: "bg-butter-tint text-butter-ink" },
+  merge: { mark: "⌥", markClass: "bg-mint-tint text-mint-ink" },
 };
 
 /** One engine's verdict on a saved credential, as returned by the save call. */

--- a/lib/routers.test.ts
+++ b/lib/routers.test.ts
@@ -19,6 +19,7 @@ describe("router registry", () => {
   it("narrows only known routers", () => {
     expect(isRouterId("concentrate")).toBe(true);
     expect(isRouterId("openrouter")).toBe(true);
+    expect(isRouterId("merge")).toBe(true);
     expect(isRouterId("litellm")).toBe(false);
     expect(parseRouterId(42)).toBeNull();
     expect(parseRouterId("concentrate")).toBe("concentrate");
@@ -37,12 +38,14 @@ describe("router registry", () => {
   it("serves only the engines whose measurement survives a gateway", () => {
     expect(routerProviders("concentrate")).toEqual(["anthropic", "openai", "google"]);
     expect(routerProviders("openrouter")).toEqual(["anthropic", "openai", "google"]);
+    expect(routerProviders("merge")).toEqual(["anthropic", "openai", "google"]);
     // Perplexity stays out: its search is always on and inseparable from the
     // answer, so a routed Perplexity call cannot be the ungrounded fallback the
     // `search: "none"` tier relies on. Gemini earns its place only in that
     // tier — reachable, never grounded (see the routed Gemini cases below).
     expect(routerSupport("concentrate", "perplexity")).toBeNull();
     expect(routerSupport("openrouter", "perplexity")).toBeNull();
+    expect(routerSupport("merge", "perplexity")).toBeNull();
   });
 
   // Both of these are the provider's OWN wire format, which is what preserves
@@ -60,6 +63,10 @@ describe("router registry", () => {
   it("records the auth header for each Anthropic surface", () => {
     expect(ROUTERS.concentrate.anthropicAuth).toBe("bearer");
     expect(ROUTERS.openrouter.anthropicAuth).toBe("x-api-key");
+    // Merge is a docs-based guess, not a probe — see the NOT YET PROBED note in
+    // lib/routers.ts. This pin exists so a probe that finds bearer changes the
+    // registry and the test together, on purpose.
+    expect(ROUTERS.merge.anthropicAuth).toBe("x-api-key");
   });
 
   // Probed 2026-07-31 against a live key. OpenRouter carries Claude's forced
@@ -72,6 +79,12 @@ describe("router registry", () => {
     expect(routerSupport("openrouter", "openai")?.search).toBe("none");
     expect(routerSupport("concentrate", "anthropic")?.search).toBe("passthrough");
     expect(routerSupport("concentrate", "openai")?.search).toBe("passthrough");
+    // Merge is unprobed (2026-08-03): its docs show no Responses surface, so
+    // GPT stays ungrounded-only until a live probe proves a forcing
+    // `tool_choice` works. Claude is 'passthrough' in the expressible sense —
+    // no monitored run happens until a saved key's probe returns sources.
+    expect(routerSupport("merge", "anthropic")?.search).toBe("passthrough");
+    expect(routerSupport("merge", "openai")?.search).toBe("none");
   });
 
   it("still serves ungrounded work on the engine it cannot ground", () => {
@@ -317,8 +330,8 @@ describe("coveredProviders", () => {
 // ---------------------------------------------------------------------------
 
 describe("routed Gemini", () => {
-  it("is reachable through both routers", () => {
-    for (const router of ["openrouter", "concentrate"] as const) {
+  it("is reachable through every router", () => {
+    for (const router of ["openrouter", "concentrate", "merge"] as const) {
       expect(routerProviders(router)).toContain("google");
     }
   });
@@ -359,5 +372,6 @@ describe("routed Gemini", () => {
     // is nothing on a router that could stand in for it.
     expect(routerSlug("openrouter", "google", GOOGLE_AI_OVERVIEWS_MODEL)).toBeNull();
     expect(routerSlug("concentrate", "google", GOOGLE_AI_OVERVIEWS_MODEL)).toBeNull();
+    expect(routerSlug("merge", "google", GOOGLE_AI_OVERVIEWS_MODEL)).toBeNull();
   });
 });

--- a/lib/routers.test.ts
+++ b/lib/routers.test.ts
@@ -63,9 +63,7 @@ describe("router registry", () => {
   it("records the auth header for each Anthropic surface", () => {
     expect(ROUTERS.concentrate.anthropicAuth).toBe("bearer");
     expect(ROUTERS.openrouter.anthropicAuth).toBe("x-api-key");
-    // Merge is a docs-based guess, not a probe — see the NOT YET PROBED note in
-    // lib/routers.ts. This pin exists so a probe that finds bearer changes the
-    // registry and the test together, on purpose.
+    // Probed 2026-08-03: x-api-key authenticated a grounded Claude call.
     expect(ROUTERS.merge.anthropicAuth).toBe("x-api-key");
   });
 
@@ -79,10 +77,11 @@ describe("router registry", () => {
     expect(routerSupport("openrouter", "openai")?.search).toBe("none");
     expect(routerSupport("concentrate", "anthropic")?.search).toBe("passthrough");
     expect(routerSupport("concentrate", "openai")?.search).toBe("passthrough");
-    // Merge is unprobed (2026-08-03): its docs show no Responses surface, so
-    // GPT stays ungrounded-only until a live probe proves a forcing
-    // `tool_choice` works. Claude is 'passthrough' in the expressible sense —
-    // no monitored run happens until a saved key's probe returns sources.
+    // Merge, probed 2026-08-03: Claude's forced search survived the gateway
+    // (9 sources). GPT is held at 'none' not because the surface is missing —
+    // a Responses route exists — but because Merge's OpenAI vendor was
+    // circuit-broken throughout the probe, and grounding must be OBSERVED
+    // before it is claimed. See the registry entry for the promotion recipe.
     expect(routerSupport("merge", "anthropic")?.search).toBe("passthrough");
     expect(routerSupport("merge", "openai")?.search).toBe("none");
   });

--- a/lib/routers.ts
+++ b/lib/routers.ts
@@ -253,17 +253,12 @@ export const ROUTERS: Record<RouterId, RouterInfo> = {
       },
     },
   },
-  // NOT YET PROBED (2026-08-03). Every entry below rests on Merge's docs
-  // (docs.merge.dev/merge-gateway/get-started), which is exactly the footing
-  // this registry exists to distrust. Before this router serves anyone, run
-  //   npx tsx scripts/probe-router.ts merge
-  // with a live key and correct what it disagrees with. The three facts most
-  // likely to be wrong, in order: the auth header on the Anthropic surface,
-  // whether the Anthropic-Messages skin lives at <base>/v1/messages, and
-  // whether a Responses endpoint exists that honours a forcing `tool_choice`
-  // (if it does, the openai entry below should be raised to match). Until a
-  // credential's save-time probe has SEEN sources come back, monitored
-  // web-search runs stay closed regardless of what this table claims.
+  // Probed 2026-08-03 with a live key. The Anthropic skin is confirmed
+  // end-to-end: forced web_search returned 9 cited sources on a question
+  // answerable from memory, through the base URL and auth header recorded
+  // below. Gemini's slug resolves on the chat surface (utility-tier only, as
+  // everywhere). The one open question is GPT grounding — see the openai
+  // entry for what was observed and what would raise it.
   merge: {
     id: "merge",
     label: "Merge Gateway",
@@ -275,30 +270,31 @@ export const ROUTERS: Record<RouterId, RouterInfo> = {
     // Per-provider surfaces under one host: the docs name /v1/openai,
     // /v1/anthropic, /v1/ai-sdk. The OpenAI SDK appends /chat/completions.
     openaiBaseUrl: "https://api-gateway.merge.dev/v1/openai",
-    // The Anthropic SDK appends /v1/messages, so the skin must answer at
-    // /v1/anthropic/v1/messages. The docs demonstrate the surface only through
-    // SDKs and never show the raw path — unverified until probed.
+    // The Anthropic SDK appends /v1/messages itself. Probed 2026-08-03: this
+    // base plus that suffix answered a forced-search request with real sources.
     anthropicBaseUrl: "https://api-gateway.merge.dev/v1/anthropic",
-    // Undocumented. x-api-key is what the Anthropic SDK sends unprompted, so it
-    // is the guess with fewer moving parts; a 401 at save time says otherwise.
+    // Undocumented but probed: x-api-key (the Anthropic SDK's default)
+    // authenticated the grounded probe above.
     anthropicAuth: "x-api-key",
     providers: {
       anthropic: {
-        // Native-shape skin per the docs. 'passthrough' here means expressible,
-        // not proven: no monitored web-search run happens until a saved key's
-        // probe returns real sources through this path.
+        // Native-shape skin, probed 2026-08-03: the forced web_search tool
+        // survived the gateway and returned 9 cited sources. As always,
+        // 'passthrough' still gates per credential at save time.
         shape: "anthropic",
         search: "passthrough",
         slugPrefix: "anthropic",
       },
       openai: {
-        // The docs document chat-completions only; their native SDK mentions a
-        // responses.create() with no raw endpoint given. Without a Responses
-        // surface that honours a forcing `tool_choice` — the thing that makes a
-        // routed GPT answer comparable to a direct one (see Concentrate above) —
-        // GPT through Merge serves ungrounded projects and utility work only.
-        // If the probe finds a working Responses endpoint, raise this to
-        // 'openai-responses' + 'passthrough' with the probe date.
+        // Held at ungrounded-only, but for a different reason than OpenRouter.
+        // Probed 2026-08-03: a Responses route EXISTS at <openaiBaseUrl>/responses
+        // and parses a forced `web_search_preview` — but Merge's OpenAI vendor
+        // was circuit-broken the whole session (503 "model_vendor_unhealthy" on
+        // gpt-4o-mini, bare 502s on gpt-4o), so grounding was never OBSERVED,
+        // and observation is the bar. When their OpenAI path is healthy, re-run
+        //   npx tsx scripts/probe-router.ts merge --provider openai
+        // with this entry set to 'openai-responses' + 'passthrough'; if sources
+        // come back, that promotion is correct and should land with the date.
         shape: "openai-chat",
         search: "none",
         slugPrefix: "openai",
@@ -306,9 +302,8 @@ export const ROUTERS: Record<RouterId, RouterInfo> = {
       google: {
         // Same stance as both routers above: routable for ungrounded runs,
         // refused for grounded ones — no router has shown us Google's native
-        // grounding intact. Slugs assume Merge resolves the same
-        // `google/gemini-2.5-*` names the others do; a wrong guess fails the
-        // save-time probe for this provider only, it cannot corrupt a run.
+        // grounding intact. Probed 2026-08-03: `google/gemini-2.5-flash`
+        // resolves on the chat surface (HTTP 200), so the slug scheme holds.
         shape: "openai-chat",
         search: "none",
         slugPrefix: "google",

--- a/lib/routers.ts
+++ b/lib/routers.ts
@@ -253,6 +253,73 @@ export const ROUTERS: Record<RouterId, RouterInfo> = {
       },
     },
   },
+  // NOT YET PROBED (2026-08-03). Every entry below rests on Merge's docs
+  // (docs.merge.dev/merge-gateway/get-started), which is exactly the footing
+  // this registry exists to distrust. Before this router serves anyone, run
+  //   npx tsx scripts/probe-router.ts merge
+  // with a live key and correct what it disagrees with. The three facts most
+  // likely to be wrong, in order: the auth header on the Anthropic surface,
+  // whether the Anthropic-Messages skin lives at <base>/v1/messages, and
+  // whether a Responses endpoint exists that honours a forcing `tool_choice`
+  // (if it does, the openai entry below should be raised to match). Until a
+  // credential's save-time probe has SEEN sources come back, monitored
+  // web-search runs stay closed regardless of what this table claims.
+  merge: {
+    id: "merge",
+    label: "Merge Gateway",
+    blurb: "Every major provider behind one endpoint, with routing and spend controls.",
+    keyUrl: "https://gateway.merge.dev/",
+    docsUrl: "https://docs.merge.dev/merge-gateway/get-started",
+    // Merge's docs show keys only through SDK `apiKey` params, no prefix shown.
+    keyPrefix: "",
+    // Per-provider surfaces under one host: the docs name /v1/openai,
+    // /v1/anthropic, /v1/ai-sdk. The OpenAI SDK appends /chat/completions.
+    openaiBaseUrl: "https://api-gateway.merge.dev/v1/openai",
+    // The Anthropic SDK appends /v1/messages, so the skin must answer at
+    // /v1/anthropic/v1/messages. The docs demonstrate the surface only through
+    // SDKs and never show the raw path — unverified until probed.
+    anthropicBaseUrl: "https://api-gateway.merge.dev/v1/anthropic",
+    // Undocumented. x-api-key is what the Anthropic SDK sends unprompted, so it
+    // is the guess with fewer moving parts; a 401 at save time says otherwise.
+    anthropicAuth: "x-api-key",
+    providers: {
+      anthropic: {
+        // Native-shape skin per the docs. 'passthrough' here means expressible,
+        // not proven: no monitored web-search run happens until a saved key's
+        // probe returns real sources through this path.
+        shape: "anthropic",
+        search: "passthrough",
+        slugPrefix: "anthropic",
+      },
+      openai: {
+        // The docs document chat-completions only; their native SDK mentions a
+        // responses.create() with no raw endpoint given. Without a Responses
+        // surface that honours a forcing `tool_choice` — the thing that makes a
+        // routed GPT answer comparable to a direct one (see Concentrate above) —
+        // GPT through Merge serves ungrounded projects and utility work only.
+        // If the probe finds a working Responses endpoint, raise this to
+        // 'openai-responses' + 'passthrough' with the probe date.
+        shape: "openai-chat",
+        search: "none",
+        slugPrefix: "openai",
+      },
+      google: {
+        // Same stance as both routers above: routable for ungrounded runs,
+        // refused for grounded ones — no router has shown us Google's native
+        // grounding intact. Slugs assume Merge resolves the same
+        // `google/gemini-2.5-*` names the others do; a wrong guess fails the
+        // save-time probe for this provider only, it cannot corrupt a run.
+        shape: "openai-chat",
+        search: "none",
+        slugPrefix: "google",
+        slugOverrides: {
+          "gemini-pro-latest": "google/gemini-2.5-pro",
+          "gemini-flash-latest": "google/gemini-2.5-flash",
+          "gemini-flash-lite-latest": "google/gemini-2.5-flash-lite",
+        },
+      },
+    },
+  },
 };
 
 /** OpenRouter's upstream-provider names, for the pinning above. */
@@ -266,7 +333,7 @@ const OPENROUTER_UPSTREAM: Record<Provider, string> = {
 export const ROUTER_LIST: RouterInfo[] = Object.values(ROUTERS);
 
 export function isRouterId(value: string): value is RouterId {
-  return value === "concentrate" || value === "openrouter";
+  return value === "concentrate" || value === "openrouter" || value === "merge";
 }
 
 /** Narrow an untrusted router value, or null. */

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -6,7 +6,7 @@ export type Provider = "anthropic" | "openai" | "google" | "perplexity";
 // LLM routers are credentials, not providers, so they get their own union and
 // stay out of `Provider` — which is what keeps `runs.provider` meaning "whose
 // answer was this" rather than "who billed us". See lib/routers.ts.
-export type RouterId = "concentrate" | "openrouter";
+export type RouterId = "concentrate" | "openrouter" | "merge";
 
 export type RunStatus = "pending" | "running" | "completed" | "failed";
 

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -150,7 +150,7 @@ alter table public.provider_keys
 create table if not exists public.router_keys (
   id uuid primary key default gen_random_uuid(),
   user_id uuid not null references auth.users (id) on delete cascade,
-  router text not null check (router in ('concentrate', 'openrouter')),
+  router text not null check (router in ('concentrate', 'openrouter', 'merge')),
   label text,
   -- Only for a self-hosted deployment of a router; null uses the registry's URL.
   base_url text,
@@ -165,7 +165,7 @@ create table if not exists public.router_keys (
 -- no-op once the table exists). Safe to re-run.
 alter table public.router_keys drop constraint if exists router_keys_router_check;
 alter table public.router_keys
-  add constraint router_keys_router_check check (router in ('concentrate', 'openrouter'));
+  add constraint router_keys_router_check check (router in ('concentrate', 'openrouter', 'merge'));
 
 -- ---------- projects -------------------------------------------------
 create table if not exists public.projects (


### PR DESCRIPTION
Adds merge.dev's Merge Gateway to the router registry, live-probed 2026-08-03.

**Probed and confirmed:**
- Claude: fully grounded — forced `web_search` returned 9 cited sources through `x-api-key` auth at `/v1/anthropic` + the SDK's `/v1/messages`.
- Gemini: `google/gemini-2.5-flash` resolves on the chat surface; utility-tier (ungrounded-only), as on every router.

**Held back, with the promotion recipe in the entry:**
- GPT: a Responses route exists at `/v1/openai/responses` and parses a forced `web_search_preview`, but Merge's OpenAI vendor was circuit-broken throughout the probe (503 `model_vendor_unhealthy` / 502), so grounding was never observed and GPT stays ungrounded-only until it is.

Also widens the `router_keys` check constraint to accept `'merge'` (schema block already re-run against the live DB).

Typecheck clean; all 612 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)