### PR TITLE
Hygiene pass from the open-source exposure sweep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,10 +20,18 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-# local env files
-.env
-.env.local
-.env*.local
+# env files: every variant is a leak risk except the documented example
+.env*
+!.env.example
+
+# editor and tool state
+.vscode/
+.idea/
+.claude/settings.local.json
+
+# test/debug output
+coverage/
+*.log
 
 # vercel
 .vercel

--- a/lib/mask.ts
+++ b/lib/mask.ts
@@ -13,7 +13,7 @@
  * theirs and spot the id they just pasted.
  */
 
-/** casey@letterbrace.com -> ca•••@letterbrace.com */
+/** avery@example.com -> av•••y@example.com */
 export function maskEmail(email: string | null | undefined): string {
   const value = email?.trim();
   if (!value) return "—";

--- a/lib/notify.test.ts
+++ b/lib/notify.test.ts
@@ -27,7 +27,7 @@ describe("sendAdminAlert", () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch");
     expect(await sendAdminAlert({ subject: "s", body: "b" })).toBe("not-configured");
 
-    process.env.ADMIN_ALERT_EMAIL = "mathew@letterstory.com";
+    process.env.ADMIN_ALERT_EMAIL = "ops@example.com";
     expect(await sendAdminAlert({ subject: "s", body: "b" })).toBe("not-configured");
 
     delete process.env.ADMIN_ALERT_EMAIL;
@@ -37,9 +37,9 @@ describe("sendAdminAlert", () => {
   });
 
   it("posts the alert to the configured address", async () => {
-    process.env.ADMIN_ALERT_EMAIL = "mathew@letterstory.com";
+    process.env.ADMIN_ALERT_EMAIL = "ops@example.com";
     process.env.RESEND_API_KEY = "re_x";
-    process.env.ADMIN_ALERT_FROM = "Lettertrace <alerts@letterstory.com>";
+    process.env.ADMIN_ALERT_FROM = "Lettertrace <alerts@example.com>";
     const fetchSpy = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValue(new Response("{}", { status: 200 }));
@@ -49,8 +49,8 @@ describe("sendAdminAlert", () => {
     expect(String(url)).toContain("api.resend.com");
     const sent = JSON.parse(String((init as RequestInit).body));
     expect(sent).toMatchObject({
-      to: ["mathew@letterstory.com"],
-      from: "Lettertrace <alerts@letterstory.com>",
+      to: ["ops@example.com"],
+      from: "Lettertrace <alerts@example.com>",
       subject: "New signup",
       text: "hello",
     });
@@ -79,8 +79,8 @@ describe("sendAdminAlert", () => {
 
   it("reads the address from the environment", () => {
     expect(adminAlertEmail()).toBeNull();
-    process.env.ADMIN_ALERT_EMAIL = "  mathew@letterstory.com  ";
-    expect(adminAlertEmail()).toBe("mathew@letterstory.com");
+    process.env.ADMIN_ALERT_EMAIL = "  ops@example.com  ";
+    expect(adminAlertEmail()).toBe("ops@example.com");
   });
 });
 
@@ -135,7 +135,7 @@ describe("alertNewSignup", () => {
   });
 
   it("claims the alert with a guarded write, then sends", async () => {
-    process.env.ADMIN_ALERT_EMAIL = "mathew@letterstory.com";
+    process.env.ADMIN_ALERT_EMAIL = "ops@example.com";
     process.env.RESEND_API_KEY = "re_x";
     const fetchSpy = vi
       .spyOn(globalThis, "fetch")
@@ -156,7 +156,7 @@ describe("alertNewSignup", () => {
   // older schema has no admin_alerted_at column, every claim errors, and reading
   // that as "already claimed" would mean alerts silently never fire again.
   it("reports a failed claim rather than mistaking it for a duplicate", async () => {
-    process.env.ADMIN_ALERT_EMAIL = "mathew@letterstory.com";
+    process.env.ADMIN_ALERT_EMAIL = "ops@example.com";
     process.env.RESEND_API_KEY = "re_x";
     const fetchSpy = vi.spyOn(globalThis, "fetch");
     vi.spyOn(console, "error").mockImplementation(() => {});
@@ -167,7 +167,7 @@ describe("alertNewSignup", () => {
   });
 
   it("sends nothing when another request already claimed it", async () => {
-    process.env.ADMIN_ALERT_EMAIL = "mathew@letterstory.com";
+    process.env.ADMIN_ALERT_EMAIL = "ops@example.com";
     process.env.RESEND_API_KEY = "re_x";
     const fetchSpy = vi.spyOn(globalThis, "fetch");
     const { db } = fakeDb(true);

--- a/lib/ops.test.ts
+++ b/lib/ops.test.ts
@@ -269,19 +269,19 @@ describe("isAdminEmail", () => {
   });
 
   it("matches case-insensitively and ignores surrounding space", () => {
-    process.env.ADMIN_EMAILS = " Casey@Letterstory.com , mathew@letterstory.com";
-    expect(isAdminEmail("casey@letterstory.com")).toBe(true);
-    expect(isAdminEmail("  MATHEW@letterstory.com ")).toBe(true);
+    process.env.ADMIN_EMAILS = " Avery@Example.com , blake@example.com";
+    expect(isAdminEmail("avery@example.com")).toBe(true);
+    expect(isAdminEmail("  BLAKE@example.com ")).toBe(true);
   });
 
   it("does not match on substrings", () => {
-    process.env.ADMIN_EMAILS = "casey@letterstory.com";
-    expect(isAdminEmail("casey@letterstory.com.attacker.test")).toBe(false);
-    expect(isAdminEmail("notcasey@letterstory.com")).toBe(false);
+    process.env.ADMIN_EMAILS = "avery@example.com";
+    expect(isAdminEmail("avery@example.com.attacker.test")).toBe(false);
+    expect(isAdminEmail("notavery@example.com")).toBe(false);
   });
 
   it("rejects null and undefined", () => {
-    process.env.ADMIN_EMAILS = "casey@letterstory.com";
+    process.env.ADMIN_EMAILS = "avery@example.com";
     expect(isAdminEmail(null)).toBe(false);
     expect(isAdminEmail(undefined)).toBe(false);
   });
@@ -305,7 +305,7 @@ describe("adminGate", () => {
     // A union would keep exactly the weakness ids exist to remove: the email
     // half would still admit anyone who registered an unclaimed address.
     process.env.ADMIN_USER_IDS = "11111111-1111-1111-1111-111111111111";
-    process.env.ADMIN_EMAILS = "casey@letterstory.com";
+    process.env.ADMIN_EMAILS = "avery@example.com";
     expect(adminGate()).toBe("user-id");
     expect(isAdminUserId("11111111-1111-1111-1111-111111111111")).toBe(true);
     expect(isAdminUserId("22222222-2222-2222-2222-222222222222")).toBe(false);
@@ -313,7 +313,7 @@ describe("adminGate", () => {
 
   it("falls back to email only when no ids are set", () => {
     delete process.env.ADMIN_USER_IDS;
-    process.env.ADMIN_EMAILS = "casey@letterstory.com";
+    process.env.ADMIN_EMAILS = "avery@example.com";
     expect(adminGate()).toBe("email");
   });
 
@@ -332,13 +332,13 @@ describe("adminGate", () => {
 
 describe("masking", () => {
   it("keeps the domain but hides the person", () => {
-    expect(maskEmail("casey@letterbrace.com")).toBe("ca•••y@letterbrace.com");
+    expect(maskEmail("avery@example.com")).toBe("av•••y@example.com");
     // Enough survives to tell two operators apart, which is the whole job of
     // the list. These two share their first two characters, so a head-only
     // mask collapsed them into the same row — the reason a tail is kept.
-    expect(maskEmail("mahir@letterstory.com")).toBe("ma•••r@letterstory.com");
-    expect(maskEmail("mathew@letterstory.com")).toBe("ma•••w@letterstory.com");
-    expect(maskEmail("mahir@letterstory.com")).not.toBe(maskEmail("mathew@letterstory.com"));
+    expect(maskEmail("marlon@example.com")).toBe("ma•••n@example.com");
+    expect(maskEmail("marley@example.com")).toBe("ma•••y@example.com");
+    expect(maskEmail("marlon@example.com")).not.toBe(maskEmail("marley@example.com"));
   });
 
   it("keeps both ends of a uuid so a pasted id is still recognisable", () => {

--- a/scripts/oauth-login.mjs
+++ b/scripts/oauth-login.mjs
@@ -195,8 +195,11 @@ async function loginFlow() {
   });
 
   saveCredentials(tokens);
+  // Truncated, matching the refresh path: the full token lives only in the
+  // credentials file. Printing it whole puts a live bearer token in terminal
+  // scrollback and any log that captures this run.
   console.log(`\nAccess token (expires in ${tokens.expires_in}s, scope "${tokens.scope}"):`);
-  console.log(`  ${tokens.access_token}`);
+  console.log(`  ${tokens.access_token.slice(0, 18)}…`);
   if (tokens.refresh_token) console.log("Refresh token stored for silent re-auth.");
 
   // 4. Prove it works against the surface it was bound to.
@@ -210,9 +213,13 @@ async function loginFlow() {
         (Array.isArray(body.projects) ? ` (${body.projects.length} organization(s))` : ""),
     );
   } else {
+    // The command is shown with a shell substitution rather than the literal
+    // token, so pasting it never lands the credential in shell history.
     console.log("\nToken is bound to MCP. Add it to an MCP client with:");
     console.log(`  claude mcp add --transport http lettertrace ${BASE}/api/mcp/mcp \\`);
-    console.log(`    -H "Authorization: Bearer ${tokens.access_token}"`);
+    console.log(
+      `    -H "Authorization: Bearer $(node -p 'JSON.parse(require("fs").readFileSync("${CRED_FILE}","utf8")).access_token')"`,
+    );
   }
 }
 


### PR DESCRIPTION
Follow-ups from the post-open-sourcing exposure sweep. Nothing here was exploitable; all three are insurance:

- **`.gitignore`**: block every `.env` variant (`.env.production` was not covered and one `git add -A` from committable), with an explicit `!.env.example` carve-out; add editor state, `.claude/settings.local.json`, `coverage/`, and `*.log` — previously protected only by one developer's global gitignore, which forks don't inherit.
- **`scripts/oauth-login.mjs`**: stop printing a live bearer token. The login path now truncates like `--refresh` already did, and the copy-pasteable MCP command reads the token from `~/.lettertrace/credentials.json` via shell substitution instead of embedding it in scrollback.
- **Fixtures**: test files and the `mask.ts` doc example now use `example.com` identities instead of real team addresses — the old fixtures published exactly the candidate list that the claimable-email warning in `lib/admin.ts` describes. (Production is gated on `ADMIN_USER_IDS`, so this was roster disclosure, not access.)

Typecheck, lint, and all 612 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)