### PR TITLE
Give Gemini the same off-white plate in light mode

### DIFF
--- a/app/dashboard/settings/keys-manager.tsx
+++ b/app/dashboard/settings/keys-manager.tsx
@@ -42,7 +42,7 @@ const PROVIDER_STYLE: Record<
   google: {
     title: "Gemini",
     subtitle: "Google AI key · also powers AI Overviews",
-    chipClass: "bg-butter-tint chip-gemini",
+    chipClass: "chip-gemini border border-ink/10",
     logo: "/providers/google.png",
   },
   perplexity: {

--- a/app/globals.css
+++ b/app/globals.css
@@ -163,12 +163,12 @@
   display: none;
 }
 
-/* Provider-chip plates that flip with the theme (see settings/keys-manager).
-   In dark mode Gemini's rainbow mark gets a barely-off-white plate (the ink
-   token) so its colors read on the dark canvas, and OpenAI's knot sits on
-   plain near-black rather than a green tint. Light mode keeps each card's
-   tinted chip utility. */
-:root:not([data-theme="light"]) .chip-gemini {
+/* Provider-chip plates (see settings/keys-manager). Gemini's rainbow mark
+   sits on the same barely-off-white plate in both themes — on light paper the
+   plate is near-invisible without its hairline border, which the chip class
+   carries. OpenAI's knot sits on plain near-black in dark mode rather than a
+   green tint; light mode keeps its tinted chip utility. */
+.chip-gemini {
   background: rgb(244 243 239);
 }
 :root:not([data-theme="light"]) .chip-openai {


### PR DESCRIPTION
Follow-up to #85: the Gemini chip now uses the off-white plate in both themes rather than only dark mode. On light paper the plate is near-invisible (245 244 240 vs 244 243 239), so the chip carries the same hairline border the Merge router tile uses. Verified rendered in both themes with a signed-in headless browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)