### PR TITLE
Add floating Product Hunt badge to landing page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -399,6 +399,22 @@ export default function LandingPage() {
           </div>
         </div>
       </footer>
+
+      {/* Floating Product Hunt badge */}
+      <a
+        href="https://www.producthunt.com/products/lettertrace?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-lettertrace"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="fixed bottom-5 right-5 z-50 shadow-lift transition hover:-translate-y-0.5"
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          alt="Lettertrace - Free, open-source AI visibility tracking for coding agents | Product Hunt"
+          width={250}
+          height={54}
+          src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1213444&theme=light&t=1785826485100"
+        />
+      </a>
     </div>
   );
 }


### PR DESCRIPTION
Adds a Product Hunt "featured" badge that floats fixed in the bottom-right corner of the landing page, above all page content, with a subtle lift-on-hover. The embed HTML was converted to JSX (className, self-closing img, numeric dimensions, &amp; unescaped in URLs) and given an eslint-disable line since the SVG is served from Product Hunt's own domain rather than through next/image.