### PR TITLE
Scope RB2B pixel to marketing pages + privacy disclosure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,9 +35,11 @@ NEXT_PUBLIC_SITE_URL=http://localhost:3000
 # Slack. Two independent pieces, both inert unless their vars are set:
 #
 # 1) The pixel. Public snippet key from the RB2B dashboard (Settings -> Install).
-#    Loaded on every page by components/rb2b-pixel.tsx. Not a secret — it ships
-#    to the browser (hence NEXT_PUBLIC), so only set it in the deployment that
-#    actually serves lettertrace.com.
+#    Loaded by components/rb2b-pixel.tsx ONLY on public marketing pages (/, /privacy,
+#    /terms) — never on the authenticated product (/dashboard, /login, /auth, etc.),
+#    since RB2B de-anonymizes visitors via a third party and self-hosters should get
+#    zero tracking. Not a secret — it ships to the browser (hence NEXT_PUBLIC), so
+#    only set it in the deployment that actually serves lettertrace.com.
 NEXT_PUBLIC_RB2B_KEY=
 
 # 2) The webhook -> Slack forwarder (app/api/rb2b/route.ts). Only needed for the

--- a/README.md
+++ b/README.md
@@ -107,6 +107,13 @@ openssl rand -base64 32   # -> ENCRYPTION_KEY
 openssl rand -hex 32      # -> CRON_SECRET
 ```
 
+> **No third-party tracking by default.** The hosted lettertrace.com runs the
+> [RB2B](https://rb2b.com) business-visitor identification pixel on its **public
+> marketing pages only** (`/`, `/privacy`, `/terms`), gated on
+> `NEXT_PUBLIC_RB2B_KEY`. Leave that unset — as `.env.example` does — and a
+> self-hosted deployment ships **zero** third-party tracking. It never runs on
+> the authenticated app (`/dashboard`, `/login`, …).
+
 ### 4. Install & run
 
 Use **Node 22 LTS** (see [`.nvmrc`](./.nvmrc)). Node 23+ has an `undici`

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
     "How Lettertrace collects, uses, and protects your data, including your bring-your-own-key provider credentials.",
 };
 
-const UPDATED = "July 27, 2026";
+const UPDATED = "August 4, 2026";
 
 export default function PrivacyPage() {
   return (
@@ -23,7 +23,8 @@ export default function PrivacyPage() {
         <p><strong>Provider API keys.</strong> If you bring your own Anthropic or OpenAI key, we store it encrypted (see §5) so scheduled runs can use it. We also store a short hint such as <code>sk-…4a9c</code> so you can tell your keys apart.</p>
         <p><strong>Lettertrace API keys.</strong> Stored only as SHA-256 hashes. The full key is shown once at creation and cannot be recovered by us or by you afterwards.</p>
         <p><strong>Usage counters.</strong> If you use trial runs on our shared provider keys, we count the runs and tokens consumed so we can apply the free-run limit.</p>
-        <p>We do not use advertising trackers, and we do not build behavioural profiles of you.</p>
+        <p><strong>Marketing-site visitor identification.</strong> On our public marketing pages only — the homepage and legal pages, never while you are signed in to the product — we use a third-party service, RB2B, to identify the business behind a visit and, for some US-based visitors, the individual (typically name, job title, company, LinkedIn profile, and business email), inferred from network and device signals. We use this for business-to-business sales and marketing. It does not run inside the authenticated app, and it is disabled entirely on separately operated (self-hosted) deployments of the software.</p>
+        <p>We do not use advertising trackers, we do not sell your information, and we do not build behavioural profiles of you as an account holder.</p>
       </Section>
 
       <Section n={2} title="What we send to AI providers">
@@ -63,6 +64,7 @@ export default function PrivacyPage() {
           <li><strong>Vercel</strong>: application hosting and request logs.</li>
           <li><strong>Anthropic</strong> and <strong>OpenAI</strong>: the AI models queried during runs, as described in §2.</li>
           <li><strong>Google</strong> and <strong>GitHub</strong>: optional sign-in. They tell us your email, name, and profile picture; we tell them nothing about your usage.</li>
+          <li><strong>RB2B</strong>: business-visitor identification on our public marketing pages, as described in §1. It does not run within the authenticated product.</li>
         </ul>
         <p>We may also disclose information where legally required, or to protect the rights and safety of our users or the service.</p>
       </Section>
@@ -85,7 +87,7 @@ export default function PrivacyPage() {
       </Section>
 
       <Section n={9} title="Cookies">
-        <p>We use cookies only for authentication, keeping you signed in and refreshing your session. We do not use advertising or cross-site tracking cookies. Clearing them signs you out.</p>
+        <p>Within the app we use cookies only for authentication — keeping you signed in and refreshing your session. On our public marketing pages, the RB2B service described in §1 also uses cookies and similar device identifiers to recognise returning business visitors. We do not use advertising cookies. Clearing your cookies signs you out.</p>
       </Section>
 
       <Section n={10} title="Children">

--- a/components/rb2b-pixel.tsx
+++ b/components/rb2b-pixel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Script from "next/script";
+import { usePathname } from "next/navigation";
 
 /**
  * RB2B website-visitor identification pixel.
@@ -9,13 +10,29 @@ import Script from "next/script";
  * inert in local dev and in any deployment that hasn't opted in. The key is the
  * public snippet key from the RB2B dashboard (Settings -> Install), NOT a secret.
  *
- * This is the standard RB2B loader snippet with the key injected from the env.
- * If RB2B changes the snippet they hand you in the dashboard, paste the new body
- * here verbatim — the only moving part is the reb2b.load("<KEY>") call at the end.
+ * Scoped to PUBLIC marketing pages only (see PUBLIC_PATHS). RB2B de-anonymizes
+ * visitors via a third party, so it has no business firing on the authenticated
+ * product (/dashboard, /login, /auth, /oauth, /admin) — we already know who those
+ * people are, and tracking them there would be invasive and pointless. This is an
+ * allowlist, not a denylist, on purpose: a new private route is never tracked by
+ * accident; a new marketing route must be added here deliberately.
+ *
+ * The snippet body below is RB2B's dashboard snippet verbatim, with only the key
+ * injected from the env. If RB2B changes the snippet they hand you, paste the new
+ * body here — the only moving part is the ("<KEY>") argument at the end.
  */
+
+// Public, unauthenticated marketing surface. Matched as exact "/" plus prefixes.
+const PUBLIC_PATHS = ["/privacy", "/terms"];
+
+function isPublicPath(pathname: string): boolean {
+  return pathname === "/" || PUBLIC_PATHS.some((p) => pathname.startsWith(p));
+}
+
 export function RB2BPixel() {
   const key = process.env.NEXT_PUBLIC_RB2B_KEY;
-  if (!key) return null;
+  const pathname = usePathname();
+  if (!key || !isPublicPath(pathname)) return null;
 
   return (
     <Script id="rb2b-pixel" strategy="afterInteractive">


### PR DESCRIPTION
Follow-up to #88, hardening the RB2B integration for the open-source release.

## Changes
- **Scope the pixel to public marketing pages** (`components/rb2b-pixel.tsx`): a `usePathname` allowlist (`/`, `/privacy`, `/terms`) so it never fires on the authenticated product (`/dashboard`, `/login`, `/auth`, `/oauth`, `/admin`). Allowlist, not denylist — new private routes are never tracked by accident. Still gated on `NEXT_PUBLIC_RB2B_KEY`, so self-hosters get nothing.
- **Privacy policy** (`app/privacy/page.tsx`): disclose RB2B (marketing-site visitor identification clause + processor entry) and correct the §1 "no advertising trackers" and §9 "cookies only for authentication" lines that RB2B would otherwise contradict. Bumped the "last updated" date.
- **README**: note that self-hosted deployments ship zero third-party tracking by default.
- **.env.example**: clarify the pixel is marketing-pages-only.

⚠️ The privacy-policy edits are legal text — please have someone review the wording. I'm not a lawyer; these aim to keep the policy factually accurate now that RB2B is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)