### PR TITLE
Promote GPT through Merge Gateway to fully measurable

### DIFF
--- a/lib/routers.test.ts
+++ b/lib/routers.test.ts
@@ -77,13 +77,12 @@ describe("router registry", () => {
     expect(routerSupport("openrouter", "openai")?.search).toBe("none");
     expect(routerSupport("concentrate", "anthropic")?.search).toBe("passthrough");
     expect(routerSupport("concentrate", "openai")?.search).toBe("passthrough");
-    // Merge, probed 2026-08-03: Claude's forced search survived the gateway
-    // (9 sources). GPT is held at 'none' not because the surface is missing —
-    // a Responses route exists — but because Merge's OpenAI vendor was
-    // circuit-broken throughout the probe, and grounding must be OBSERVED
-    // before it is claimed. See the registry entry for the promotion recipe.
+    // Merge, probed 2026-08-03 (Claude: 9 sources) and 2026-08-04 (GPT: forced
+    // web_search_preview executed with url_citation annotations, once Merge
+    // fixed the Responses tool passthrough that had been returning bare 502s).
     expect(routerSupport("merge", "anthropic")?.search).toBe("passthrough");
-    expect(routerSupport("merge", "openai")?.search).toBe("none");
+    expect(routerSupport("merge", "openai")?.search).toBe("passthrough");
+    expect(routerSupport("merge", "openai")?.shape).toBe("openai-responses");
   });
 
   it("still serves ungrounded work on the engine it cannot ground", () => {

--- a/lib/routers.ts
+++ b/lib/routers.ts
@@ -286,17 +286,14 @@ export const ROUTERS: Record<RouterId, RouterInfo> = {
         slugPrefix: "anthropic",
       },
       openai: {
-        // Held at ungrounded-only, but for a different reason than OpenRouter.
-        // Probed 2026-08-03: a Responses route EXISTS at <openaiBaseUrl>/responses
-        // and parses a forced `web_search_preview` — but Merge's OpenAI vendor
-        // was circuit-broken the whole session (503 "model_vendor_unhealthy" on
-        // gpt-4o-mini, bare 502s on gpt-4o), so grounding was never OBSERVED,
-        // and observation is the bar. When their OpenAI path is healthy, re-run
-        //   npx tsx scripts/probe-router.ts merge --provider openai
-        // with this entry set to 'openai-responses' + 'passthrough'; if sources
-        // come back, that promotion is correct and should land with the date.
-        shape: "openai-chat",
-        search: "none",
+        // Probed 2026-08-04 after Merge fixed their Responses tool passthrough
+        // (any web-search tool drew a bare 502 the day before): the forced
+        // `web_search_preview` now executes — the reply carries a completed
+        // `web_search_call` and `url_citation` annotations on a question
+        // answerable from memory. Same Responses shape as a direct OpenAI key,
+        // so the citation parsers read it unchanged.
+        shape: "openai-responses",
+        search: "passthrough",
         slugPrefix: "openai",
       },
       google: {


### PR DESCRIPTION
Merge fixed the Responses tool passthrough that was returning bare 502s whenever a web-search tool was attached. Re-probed 2026-08-04 through `scripts/probe-router.ts`:

- **GPT**: forced `web_search_preview` now executes — completed `web_search_call` plus `url_citation` annotations on a question answerable from memory, in the same Responses shape a direct OpenAI key produces, so the citation parsers read it unchanged. Raised to `openai-responses` + `passthrough`.
- **Claude**: still grounded (9 sources), unchanged.
- **Gemini**: stays utility-tier (`none`), as on every router.

Per-credential save-time verification still gates each saved key before it may serve monitored web-search runs. Existing Merge keys need a re-check in Settings to pick up GPT verification.

All 612 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)