### PR TITLE
List Merge Gateway first among the routers

### DIFF
--- a/lib/routers.test.ts
+++ b/lib/routers.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { GOOGLE_AI_OVERVIEWS_MODEL } from "@/lib/models";
 import {
   ROUTERS,
+  ROUTER_LIST,
   coveredProviders,
   engineCoverage,
   isRouterId,
@@ -23,6 +24,13 @@ describe("router registry", () => {
     expect(isRouterId("litellm")).toBe(false);
     expect(parseRouterId(42)).toBeNull();
     expect(parseRouterId("concentrate")).toBe("concentrate");
+  });
+
+  it("lists every registered router, Merge first", () => {
+    // ROUTER_LIST is hand-ordered for display, which means a new registry
+    // entry can be silently forgotten from it — this catches that.
+    expect(ROUTER_LIST.map((r) => r.id)).toEqual(["merge", "concentrate", "openrouter"]);
+    expect(new Set(ROUTER_LIST.map((r) => r.id))).toEqual(new Set(Object.keys(ROUTERS)));
   });
 
   // The whole design rests on a router never becoming a Provider. If one ever

--- a/lib/routers.ts
+++ b/lib/routers.ts
@@ -322,7 +322,8 @@ const OPENROUTER_UPSTREAM: Record<Provider, string> = {
   perplexity: "perplexity",
 };
 
-export const ROUTER_LIST: RouterInfo[] = Object.values(ROUTERS);
+/** Display order for the settings cards and CLI listing: Merge leads. */
+export const ROUTER_LIST: RouterInfo[] = [ROUTERS.merge, ROUTERS.concentrate, ROUTERS.openrouter];
 
 export function isRouterId(value: string): value is RouterId {
   return value === "concentrate" || value === "openrouter" || value === "merge";


### PR DESCRIPTION
`ROUTER_LIST` becomes a hand-ordered display list (Merge, Concentrate, OpenRouter) rather than the registry's insertion order. A new test pins the order and guards that every registered router still appears in the list, so a future registry entry can't be silently dropped from the settings cards or the CLI listing.

Verified rendered with a signed-in headless browser; all 613 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)