### PR TITLE
feat(report): competitor breakdown at the prompt level

### DIFF
--- a/app/api/mcp/[transport]/route.ts
+++ b/app/api/mcp/[transport]/route.ts
@@ -178,7 +178,7 @@ const handler = createMcpHandler(
 
     server.tool(
       "get_share_of_voice_report",
-      "Share-of-voice report for a monitoring run: how often the brand and each competitor are mentioned in AI assistant answers, with share of voice, prominence, sentiment, and recommendation rate. Pass run_id, or just project_id for the latest completed run.",
+      "Share-of-voice report for a monitoring run: how often the brand and each competitor are mentioned in AI assistant answers, with share of voice, prominence, sentiment, and recommendation rate. Also breaks this down per prompt (promptEntities: who gets named for each question) and reports which competitor domains the answers cited per prompt (competitorCitations) — use these to find questions rivals win that you don't. Pass run_id, or just project_id for the latest completed run.",
       {
         run_id: z
           .string()

--- a/app/api/v1/v1-routes.test.ts
+++ b/app/api/v1/v1-routes.test.ts
@@ -551,6 +551,8 @@ describe("GET /api/v1/runs/:id", () => {
       verdict: "healthy",
       pages: [],
       topics: [],
+      promptEntities: [],
+      competitorCitations: [],
     });
     const res = await getReportRoute(req("/api/v1/runs/r1"), { params: { id: "r1" } });
     expect(res.status).toBe(200);

--- a/app/dashboard/runs/[id]/page.tsx
+++ b/app/dashboard/runs/[id]/page.tsx
@@ -4,8 +4,22 @@ import { createClient } from "@/lib/supabase/server";
 import { getProject } from "@/lib/data";
 import { modelLabel } from "@/lib/models";
 import { pct, timeAgo } from "@/lib/utils";
-import { computeEntityStats, SENTIMENT_COLORS } from "@/lib/metrics";
-import type { Mention, Prompt, Response, Run, RunStatus, Sentiment, Source } from "@/lib/types";
+import {
+  computeEntityStats,
+  computePromptEntityStats,
+  computeCompetitorCitations,
+  SENTIMENT_COLORS,
+} from "@/lib/metrics";
+import type {
+  Competitor,
+  Mention,
+  Prompt,
+  Response,
+  Run,
+  RunStatus,
+  Sentiment,
+  Source,
+} from "@/lib/types";
 import {
   Card,
   CardBody,
@@ -88,6 +102,12 @@ export default async function RunDetailPage({ params }: { params: { id: string }
   const prompts = (promptRows ?? []) as Prompt[];
   const promptText = new Map(prompts.map((p) => [p.id, p.text]));
 
+  const { data: competitorRows } = await supabase
+    .from("competitors")
+    .select("id, name, domain")
+    .eq("project_id", project.id);
+  const competitors = (competitorRows ?? []) as Pick<Competitor, "id" | "name" | "domain">[];
+
   const mentionsByResponse = new Map<string, Mention[]>();
   for (const m of mentions) {
     const list = mentionsByResponse.get(m.response_id) ?? [];
@@ -105,6 +125,70 @@ export default async function RunDetailPage({ params }: { params: { id: string }
   const stats = computeEntityStats(mentions, responses.length, project.brand_name);
   const brand = stats.find((s) => s.type === "brand");
   const topCompetitor = stats.find((s) => s.type === "competitor");
+
+  // Competitors per QUESTION, aggregated across replicates — the view the
+  // per-answer list below can't give: for each question, who gets named (and
+  // whose site gets cited), and where the brand is missing entirely. The two
+  // signals are separate events: named in the prose vs. cited as a source.
+  const citedRateByPrompt = new Map<string, Map<string, number>>();
+  for (const pc of computeCompetitorCitations(sources, competitors, responses, prompts)) {
+    citedRateByPrompt.set(
+      pc.promptId,
+      new Map(pc.competitors.map((c) => [c.name.toLowerCase(), c.citedRate])),
+    );
+  }
+  const competitorName = new Map(competitors.map((c) => [c.name.toLowerCase(), c.name]));
+  const competitionByPrompt = computePromptEntityStats(
+    mentions,
+    responses,
+    prompts,
+    project.brand_name,
+  )
+    .map((ps) => {
+      const cited = citedRateByPrompt.get(ps.promptId);
+      const brandRow = ps.entities.find((e) => e.type === "brand");
+      const rivals = ps.entities
+        .filter((e) => e.type === "competitor")
+        .map((e) => ({
+          name: e.name,
+          mentionRate: e.mentionRate,
+          citedRate: cited?.get(e.name.toLowerCase()) ?? 0,
+        }));
+      // Rivals cited but never named must still show — being read is a real signal.
+      if (cited) {
+        for (const [nameLower, citedRate] of cited) {
+          if (!rivals.some((r) => r.name.toLowerCase() === nameLower)) {
+            rivals.push({
+              name: competitorName.get(nameLower) ?? nameLower,
+              mentionRate: 0,
+              citedRate,
+            });
+          }
+        }
+      }
+      rivals.sort(
+        (a, b) => Math.max(b.mentionRate, b.citedRate) - Math.max(a.mentionRate, a.citedRate),
+      );
+      return {
+        promptId: ps.promptId,
+        promptText: ps.promptText,
+        totalResponses: ps.totalResponses,
+        brandMentionRate: brandRow?.mentionRate ?? 0,
+        rivals,
+        // The brand is absent while a rival shows up strongly — the ground to build.
+        gap:
+          (brandRow?.mentionRate ?? 0) === 0 &&
+          rivals.some((r) => Math.max(r.mentionRate, r.citedRate) >= 0.3),
+      };
+    })
+    .filter((p) => p.rivals.length > 0)
+    // Gaps first, then the questions rivals win hardest.
+    .sort((a, b) => {
+      if (a.gap !== b.gap) return a.gap ? -1 : 1;
+      const at = Math.max(0, ...a.rivals.map((r) => Math.max(r.mentionRate, r.citedRate)));
+      const bt = Math.max(0, ...b.rivals.map((r) => Math.max(r.mentionRate, r.citedRate)));
+      return bt - at;
+    });
 
   // Was the brand's own site cited? A leading indicator independent of mentions.
   const ownedResponseIds = new Set(sources.filter((s) => s.is_owned).map((s) => s.response_id));
@@ -174,6 +258,53 @@ export default async function RunDetailPage({ params }: { params: { id: string }
               pulled across {responses.length} answers.
             </p>
           )}
+        </div>
+      )}
+
+      {competitionByPrompt.length > 0 && (
+        <div className="space-y-3">
+          <SectionHeading
+            title="Competitors by question"
+            description="Across all replicates: who gets named — and whose site gets cited — for each question. “You’re missing” flags where a competitor shows up and your brand doesn’t."
+          />
+          <div className="space-y-3">
+            {competitionByPrompt.map((p) => (
+              <Card key={p.promptId}>
+                <CardBody className="space-y-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <p className="font-serif text-base text-ink">{p.promptText ?? "(prompt removed)"}</p>
+                    {p.gap && <Badge tone="terracotta">You&apos;re missing</Badge>}
+                  </div>
+                  <p className="text-xs text-ink-faint">
+                    You:{" "}
+                    <span className={p.brandMentionRate > 0 ? "text-terracotta-dark" : "text-ink"}>
+                      named {pct(p.brandMentionRate)}
+                    </span>{" "}
+                    of {p.totalResponses} answers
+                  </p>
+                  <ul className="space-y-1.5">
+                    {p.rivals.map((r) => (
+                      <li key={r.name} className="flex items-center gap-3 text-sm">
+                        <span className="w-40 shrink-0 truncate font-medium text-ink">{r.name}</span>
+                        <div className="h-1.5 flex-1 overflow-hidden rounded bg-paper-shade">
+                          <div
+                            className="h-full rounded bg-teal"
+                            style={{ width: `${Math.round(r.mentionRate * 100)}%` }}
+                          />
+                        </div>
+                        <span className="w-40 shrink-0 text-right text-xs tabular-nums text-ink-faint">
+                          named {pct(r.mentionRate)}
+                          {r.citedRate > 0 && (
+                            <span className="text-teal-dark"> · cited {pct(r.citedRate)}</span>
+                          )}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                </CardBody>
+              </Card>
+            ))}
+          </div>
         </div>
       )}
 

--- a/lib/api-service.test.ts
+++ b/lib/api-service.test.ts
@@ -314,9 +314,15 @@ describe("getRunReport", () => {
         ],
       }),
       prompts: () => ({
-        data: [{ id: "prompt-1", target_url: "https://blog.example.com/posts/guide" }],
+        data: [{ id: "prompt-1", target_url: "https://blog.example.com/posts/guide", text: "guide?" }],
       }),
-      competitors: () => ({ count: 3 }),
+      competitors: () => ({
+        data: [
+          { id: "comp-1", name: "Rival", domain: "rival.com" },
+          { id: "comp-2", name: "Foil", domain: "foil.com" },
+          { id: "comp-3", name: "Nemesis", domain: "nemesis.com" },
+        ],
+      }),
     });
 
     const report = await getRunReport(db as never, "user-1", "run-1");

--- a/lib/api-service.ts
+++ b/lib/api-service.ts
@@ -18,12 +18,16 @@ import {
   computeTopicStats,
   measurementVerdict,
   computePageStats,
+  computePromptEntityStats,
+  computeCompetitorCitations,
   pageKey,
   type CitationStat,
   type EntityStat,
   type MeasurementQuality,
   type MeasurementVerdict,
   type PageStat,
+  type PromptEntityStats,
+  type PromptCompetitorCitations,
   type RunSummary,
   type TopicStat,
 } from "@/lib/metrics";
@@ -852,6 +856,15 @@ export interface RunReport {
   /** Per-topic brand visibility. Content is usually planned by topic, so this is the
    *  join between "we published about X" and "are we surfacing for X". */
   topics: (TopicStat & { topic: string | null })[];
+  /** Per-prompt entity breakdown — who gets NAMED for each question, brand and
+   *  competitors, scoped to that question's answers. The run's entities[] says
+   *  who owns the category; this says which specific questions competitors win
+   *  and we don't — the build-for-it queue. */
+  promptEntities: PromptEntityStats[];
+  /** Per-prompt competitor CITATIONS — whose domain the answers actually cited
+   *  for each question. The other half of "showing up": named vs. read. Only
+   *  competitors with a resolvable domain appear. */
+  competitorCitations: PromptCompetitorCitations[];
 }
 
 /** The most recent completed run for a project, if any. */
@@ -903,21 +916,39 @@ export async function getRunReport(
       (f, t) => supabase.from("responses").select("id, topic_id, prompt_id").eq("run_id", runId).range(f, t),
     ),
     topics: supabase.from("topics").select("id, name").eq("project_id", run.project_id),
-    promptTargets: selectAll<{ id: string; target_url: string | null }>((f, t) =>
-      supabase.from("prompts").select("id, target_url").eq("project_id", run.project_id).range(f, t),
+    prompts: selectAll<{ id: string; target_url: string | null; text: string | null }>((f, t) =>
+      supabase
+        .from("prompts")
+        .select("id, target_url, text")
+        .eq("project_id", run.project_id)
+        .range(f, t),
     ),
-    competitors: supabase
-      .from("competitors")
-      .select("id", { count: "exact", head: true })
-      .eq("project_id", run.project_id),
+    // Loaded as rows (not just a head count) so their domains can attribute
+    // cited sources; competitorCount below is derived from the same list.
+    competitors: selectAll<{ id: string; name: string; domain: string | null }>((f, t) =>
+      supabase
+        .from("competitors")
+        .select("id, name, domain")
+        .eq("project_id", run.project_id)
+        .range(f, t),
+    ),
   });
   const { count } = results.responseCount;
   const mentionRows = results.mentions;
   const sourceRows = results.sources;
   const responseTopicRows = results.responseTopics;
   const { data: topicRows } = results.topics;
-  const promptTargetRows = results.promptTargets;
-  const { count: competitorCount } = results.competitors;
+  const promptRows = (results.prompts ?? []) as {
+    id: string;
+    target_url: string | null;
+    text: string | null;
+  }[];
+  const competitorRows = (results.competitors ?? []) as {
+    id: string;
+    name: string;
+    domain: string | null;
+  }[];
+  const competitorCount = competitorRows.length;
 
   const mentions = (mentionRows ?? []) as Mention[];
   const sources = (sourceRows ?? []) as Pick<Source, "response_id" | "url" | "is_owned">[];
@@ -949,9 +980,7 @@ export async function getRunReport(
   // (summary/entities/citations keep the full run — only naming quality has a
   // reduced basis, and quality.totalResponses reports that basis.)
   const pagePromptIds = new Set(
-    ((promptTargetRows ?? []) as { id: string; target_url: string | null }[])
-      .filter((p) => p.target_url)
-      .map((p) => p.id),
+    promptRows.filter((p) => p.target_url).map((p) => p.id),
   );
   const pageResponseIds = new Set(
     responseRows.filter((r) => r.prompt_id && pagePromptIds.has(r.prompt_id)).map((r) => r.id),
@@ -975,15 +1004,23 @@ export async function getRunReport(
       totalResponses,
       informativeRate: quality.informativeRate,
       brandMentioned: summary.brandResponsesMentioned > 0,
-      competitorsTracked: competitorCount ?? 0,
+      competitorsTracked: competitorCount,
       informativeBasis: quality.totalResponses,
     }),
-    pages: computePageStats(
-      (promptTargetRows ?? []) as { id: string; target_url: string | null }[],
-      responseRows,
-      sources,
-    ),
+    pages: computePageStats(promptRows, responseRows, sources),
     topics: topicStats,
+    promptEntities: computePromptEntityStats(
+      mentions,
+      responseRows,
+      promptRows,
+      project.brand_name,
+    ),
+    competitorCitations: computeCompetitorCitations(
+      sources,
+      competitorRows,
+      responseRows,
+      promptRows,
+    ),
   };
 }
 

--- a/lib/metrics.test.ts
+++ b/lib/metrics.test.ts
@@ -9,6 +9,9 @@ import {
   LOW_INFORMATIVE_RATE,
   computePageStats,
   pageKey,
+  computePromptEntityStats,
+  computeCompetitorCitations,
+  hostKey,
 } from "@/lib/metrics";
 import type { Mention } from "@/lib/types";
 
@@ -340,5 +343,110 @@ describe("computePageStats", () => {
 
   it("returns [] when no prompt is mapped to a page", () => {
     expect(computePageStats([{ id: "p1", target_url: null }], responses, sources)).toEqual([]);
+  });
+});
+
+describe("computePromptEntityStats", () => {
+  // Two questions. On p1 a competitor is named in both answers and the brand in
+  // neither — the build-for-it case. On p2 the brand wins.
+  const responses = [
+    { id: "r1", prompt_id: "p1", topic_id: "t1" },
+    { id: "r2", prompt_id: "p1", topic_id: "t1" },
+    { id: "r3", prompt_id: "p2", topic_id: "t2" },
+    { id: "r4", prompt_id: null }, // orphan — no prompt, must be ignored
+  ];
+  const prompts = [
+    { id: "p1", text: "best CRM for startups" },
+    { id: "p2", text: "what is Acme" },
+  ];
+  const mentions = [
+    mention({ response_id: "r1", entity_type: "competitor", competitor_id: "c1", entity_name: "Rival", mention_count: 2 }),
+    mention({ response_id: "r2", entity_type: "competitor", competitor_id: "c1", entity_name: "Rival", mention_count: 1 }),
+    mention({ response_id: "r3", entity_type: "brand", entity_name: "Acme", mention_count: 1 }),
+    mention({ response_id: "r4", entity_type: "competitor", competitor_id: "c1", entity_name: "Rival" }),
+  ];
+
+  it("scopes entity stats to each prompt and always reports the brand", () => {
+    const stats = computePromptEntityStats(mentions, responses, prompts, "Acme");
+    const p1 = stats.find((s) => s.promptId === "p1")!;
+    expect(p1.promptText).toBe("best CRM for startups");
+    expect(p1.topicId).toBe("t1");
+    expect(p1.totalResponses).toBe(2);
+    const brand = p1.entities.find((e) => e.type === "brand")!;
+    const rival = p1.entities.find((e) => e.name === "Rival")!;
+    // The finding: they show up here, we don't.
+    expect(brand.mentionRate).toBe(0);
+    expect(rival.mentionRate).toBe(1);
+    // Brand-then-competitor ordering is preserved.
+    expect(p1.entities[0].type).toBe("brand");
+  });
+
+  it("ranks questions competitors win hardest first", () => {
+    const stats = computePromptEntityStats(mentions, responses, prompts, "Acme");
+    expect(stats[0].promptId).toBe("p1"); // 100% competitor rate beats p2's 0%
+  });
+
+  it("ignores mentions whose response has no prompt", () => {
+    const stats = computePromptEntityStats(mentions, responses, prompts, "Acme");
+    // r4 is orphaned, so no third prompt group is created.
+    expect(stats.map((s) => s.promptId).sort()).toEqual(["p1", "p2"]);
+  });
+});
+
+describe("hostKey", () => {
+  it("reduces urls and bare domains to a comparable host", () => {
+    expect(hostKey("https://www.Acme.com/blog/x?y=1")).toBe("acme.com");
+    expect(hostKey("acme.com")).toBe("acme.com");
+    expect(hostKey("BLOG.Acme.com")).toBe("blog.acme.com");
+  });
+
+  it("returns null for something it can't parse as a host", () => {
+    expect(hostKey("not a url")).toBeNull();
+  });
+});
+
+describe("computeCompetitorCitations", () => {
+  const responses = [
+    { id: "r1", prompt_id: "p1" },
+    { id: "r2", prompt_id: "p1" },
+    { id: "r3", prompt_id: "p2" },
+  ];
+  const prompts = [
+    { id: "p1", text: "best CRM" },
+    { id: "p2", text: "what is Acme" },
+  ];
+  const competitors = [
+    { id: "c1", name: "Rival", domain: "rival.com" },
+    { id: "c2", name: "NoDomain", domain: null }, // unattributable
+  ];
+  const sources = [
+    { response_id: "r1", url: "https://www.rival.com/best-crm?utm_source=openai" },
+    { response_id: "r1", url: "https://blog.rival.com/guide" }, // subdomain, same answer
+    { response_id: "r2", url: "https://someoneelse.com/post" }, // untracked host
+    { response_id: "r3", url: "https://rival.com/about" }, // different prompt
+  ];
+
+  it("attributes cited hosts to competitors per prompt, counting distinct answers", () => {
+    const out = computeCompetitorCitations(sources, competitors, responses, prompts);
+    const p1 = out.find((o) => o.promptId === "p1")!;
+    expect(p1.promptText).toBe("best CRM");
+    const rival = p1.competitors.find((c) => c.competitorId === "c1")!;
+    // r1 cited rival twice (apex + subdomain) but that's ONE answer citing them.
+    expect(rival.responsesCiting).toBe(1);
+    expect(rival.totalResponses).toBe(2);
+    expect(rival.citedRate).toBeCloseTo(0.5);
+    expect(rival.domain).toBe("rival.com");
+  });
+
+  it("drops competitors without a resolvable domain", () => {
+    const out = computeCompetitorCitations(sources, competitors, responses, prompts);
+    const named = out.flatMap((o) => o.competitors.map((c) => c.name));
+    expect(named).not.toContain("NoDomain");
+  });
+
+  it("returns [] when no tracked competitor has a domain", () => {
+    expect(
+      computeCompetitorCitations(sources, [{ id: "c2", name: "NoDomain", domain: null }], responses, prompts),
+    ).toEqual([]);
   });
 });

--- a/lib/metrics.ts
+++ b/lib/metrics.ts
@@ -425,6 +425,195 @@ export function computeTopicStats(
   return out.sort((a, b) => b.mentionRate - a.mentionRate);
 }
 
+// ------------------------------------------------------------------
+// Per-prompt entity breakdown — "who shows up for THIS question".
+//
+// The run-level entities[] answers "who owns the category". This answers the
+// more actionable question a content team acts on: for a specific question, do
+// competitors get named while we don't? A prompt where three rivals are named
+// in every answer and the brand in none is a build-for-it target, and it's
+// invisible in the run aggregate that averages it against questions nobody
+// contests. Same math as the run report (computeEntityStats), scoped to one
+// prompt's answers.
+// ------------------------------------------------------------------
+
+export interface PromptEntityStats {
+  promptId: string;
+  /** The question as asked, when the caller supplied it. */
+  promptText: string | null;
+  topicId: string | null;
+  /** Answers to this prompt this run — the denominator behind every rate. */
+  totalResponses: number;
+  /** Brand first, then competitors by share of voice — the run's ordering,
+   *  scoped to this one question. Brand row is always present (a zero when the
+   *  brand went unnamed here) so "they show up, we don't" reads directly. */
+  entities: EntityStat[];
+}
+
+export function computePromptEntityStats(
+  mentions: Mention[],
+  responses: { id: string; prompt_id: string | null; topic_id?: string | null }[],
+  prompts: { id: string; text: string | null }[],
+  brandName?: string,
+): PromptEntityStats[] {
+  const promptText = new Map(prompts.map((p) => [p.id, p.text]));
+  // prompt_id -> its answers (the per-question denominator) and topic.
+  const byPrompt = new Map<string, { ids: Set<string>; topicId: string | null }>();
+  const promptByResponse = new Map<string, string>();
+  for (const r of responses) {
+    if (!r.prompt_id) continue;
+    promptByResponse.set(r.id, r.prompt_id);
+    const g = byPrompt.get(r.prompt_id) ?? { ids: new Set<string>(), topicId: r.topic_id ?? null };
+    g.ids.add(r.id);
+    byPrompt.set(r.prompt_id, g);
+  }
+
+  const mentionsByPrompt = new Map<string, Mention[]>();
+  for (const m of mentions) {
+    const pid = promptByResponse.get(m.response_id);
+    if (!pid) continue;
+    const list = mentionsByPrompt.get(pid) ?? [];
+    list.push(m);
+    mentionsByPrompt.set(pid, list);
+  }
+
+  const out: PromptEntityStats[] = [];
+  for (const [promptId, { ids, topicId }] of byPrompt) {
+    out.push({
+      promptId,
+      promptText: promptText.get(promptId) ?? null,
+      topicId,
+      totalResponses: ids.size,
+      entities: computeEntityStats(mentionsByPrompt.get(promptId) ?? [], ids.size, brandName),
+    });
+  }
+
+  // Questions where competitors show up strongest first — the build-for-it
+  // queue. Rank by the top competitor's mention rate, then by sample size.
+  const topCompetitorRate = (p: PromptEntityStats) =>
+    p.entities
+      .filter((e) => e.type === "competitor")
+      .reduce((mx, e) => Math.max(mx, e.mentionRate), 0);
+  return out.sort(
+    (a, b) => topCompetitorRate(b) - topCompetitorRate(a) || b.totalResponses - a.totalResponses,
+  );
+}
+
+// ------------------------------------------------------------------
+// Per-prompt competitor CITATIONS — "whose site did the model read for this".
+//
+// Being named in the prose and having your page cited as a source are separate
+// events (see the citation-stat note above). This is the citation half, split by
+// competitor: for a question, which tracked rivals' domains did the answers
+// actually cite? A domain the model keeps reaching for is a page worth
+// out-writing. Only competitors with a resolvable domain can be attributed;
+// names alone can't be matched to a URL.
+// ------------------------------------------------------------------
+
+/** A host reduced to its registrable form: no scheme, no www, lower-cased.
+ *  Accepts either a full URL or a bare domain ("acme.com"). */
+export function hostKey(value: string): string | null {
+  try {
+    const u = new URL(/^https?:\/\//i.test(value) ? value : `https://${value}`);
+    return u.hostname.toLowerCase().replace(/^www\./, "");
+  } catch {
+    return null;
+  }
+}
+
+export interface CompetitorCitationStat {
+  competitorId: string;
+  name: string;
+  /** The matched host (registrable form), so the UI can show what was cited. */
+  domain: string;
+  /** Distinct answers to this prompt that cited a page on this domain. */
+  responsesCiting: number;
+  totalResponses: number;
+  citedRate: number;
+  citedRateInterval: Interval;
+}
+
+export interface PromptCompetitorCitations {
+  promptId: string;
+  promptText: string | null;
+  totalResponses: number;
+  competitors: CompetitorCitationStat[];
+}
+
+export function computeCompetitorCitations(
+  sources: { response_id: string; url: string }[],
+  competitors: { id: string; name: string; domain: string | null }[],
+  responses: { id: string; prompt_id: string | null }[],
+  prompts: { id: string; text: string | null }[] = [],
+): PromptCompetitorCitations[] {
+  const tracked = competitors
+    .map((c) => ({ ...c, host: c.domain ? hostKey(c.domain) : null }))
+    .filter((c): c is (typeof c) & { host: string } => !!c.host);
+  if (tracked.length === 0) return [];
+
+  const promptText = new Map(prompts.map((p) => [p.id, p.text]));
+  const promptByResponse = new Map<string, string>();
+  const responsesByPrompt = new Map<string, Set<string>>();
+  for (const r of responses) {
+    if (!r.prompt_id) continue;
+    promptByResponse.set(r.id, r.prompt_id);
+    const set = responsesByPrompt.get(r.prompt_id) ?? new Set<string>();
+    set.add(r.id);
+    responsesByPrompt.set(r.prompt_id, set);
+  }
+
+  // prompt -> competitor host -> distinct responses that cited it.
+  const hits = new Map<string, Map<string, Set<string>>>();
+  for (const s of sources) {
+    const pid = promptByResponse.get(s.response_id);
+    if (!pid) continue;
+    const host = hostKey(s.url);
+    if (!host) continue;
+    for (const c of tracked) {
+      // A subdomain (blog.acme.com) counts as the competitor's site too.
+      if (host === c.host || host.endsWith(`.${c.host}`)) {
+        const perComp = hits.get(pid) ?? new Map<string, Set<string>>();
+        const set = perComp.get(c.host) ?? new Set<string>();
+        set.add(s.response_id);
+        perComp.set(c.host, set);
+        hits.set(pid, perComp);
+      }
+    }
+  }
+  if (hits.size === 0) return [];
+
+  const byHost = new Map(tracked.map((c) => [c.host, c]));
+  const out: PromptCompetitorCitations[] = [];
+  for (const [promptId, perComp] of hits) {
+    const total = responsesByPrompt.get(promptId)?.size ?? 0;
+    const stats: CompetitorCitationStat[] = [];
+    for (const [host, respSet] of perComp) {
+      const c = byHost.get(host)!;
+      const citing = respSet.size;
+      stats.push({
+        competitorId: c.id,
+        name: c.name,
+        domain: host,
+        responsesCiting: citing,
+        totalResponses: total,
+        citedRate: total ? citing / total : 0,
+        citedRateInterval: wilsonInterval(citing, total),
+      });
+    }
+    stats.sort((a, b) => b.responsesCiting - a.responsesCiting);
+    out.push({
+      promptId,
+      promptText: promptText.get(promptId) ?? null,
+      totalResponses: total,
+      competitors: stats,
+    });
+  }
+  // Most-cited-against questions first.
+  return out.sort(
+    (a, b) => (b.competitors[0]?.responsesCiting ?? 0) - (a.competitors[0]?.responsesCiting ?? 0),
+  );
+}
+
 // A single color per sentiment, matching the brand palette.
 export const SENTIMENT_COLORS: Record<Sentiment, string> = {
   positive: "#82EAD1", // aqua-mint


### PR DESCRIPTION
Adds per-prompt competitor views to the run report — "who shows up for this question, and are we missing?" — the actionable companion to run-level share of voice.

## What's here
- **`computePromptEntityStats`** — who gets **named** for each question (brand + competitors, scoped to that question's answers), reusing `computeEntityStats`.
- **`computeCompetitorCitations`** — whose domain the answers **cited** per question, host-matched to tracked competitor domains (subdomains + tracking-params safe).
- **`getRunReport`** now returns `promptEntities` + `competitorCitations` — flows through the v1 API (`GET /api/v1/runs/:id`) and the MCP `get_share_of_voice_report` tool automatically.
- **Dashboard run page** — new "Competitors by question" section: named % and cited % per question across replicates, with a "you're missing" gap flag.

## Notes
- **No migration** — `mentions.competitor_id`, `responses.prompt_id`, and `sources.url` already carry the data; this is purely additive to the report.
- Verified: typecheck clean, 621 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)