### PR TITLE
feat(runs): surface untracked companies named in the answers

### DIFF
--- a/app/dashboard/runs/[id]/page.tsx
+++ b/app/dashboard/runs/[id]/page.tsx
@@ -28,7 +28,9 @@ import {
   StatCard,
   EmptyState,
 } from "@/components/ui";
+import { discoverCompanies, untrackedNamesInAnswer } from "@/lib/discover";
 import { MarkResultsSeen } from "./mark-seen";
+import { TrackUntrackedCompanies } from "./track-companies";
 
 export const dynamic = "force-dynamic";
 
@@ -104,9 +106,27 @@ export default async function RunDetailPage({ params }: { params: { id: string }
 
   const { data: competitorRows } = await supabase
     .from("competitors")
-    .select("id, name, domain")
+    .select("id, name, domain, aliases")
     .eq("project_id", project.id);
-  const competitors = (competitorRows ?? []) as Pick<Competitor, "id" | "name" | "domain">[];
+  const competitors = (competitorRows ?? []) as Pick<
+    Competitor,
+    "id" | "name" | "domain" | "aliases"
+  >[];
+
+  // Everything already accounted for — the brand, its aliases, and every tracked
+  // competitor's name and aliases. discoverCompanies / untrackedNamesInAnswer
+  // subtract this, so what's left is genuinely untracked.
+  const trackedTerms = [
+    project.brand_name,
+    ...(project.brand_aliases ?? []),
+    ...competitors.flatMap((c) => [c.name, ...(c.aliases ?? [])]),
+  ];
+  // Companies THIS run named that aren't tracked, most-named first (candidates).
+  const untrackedInRun = discoverCompanies(
+    responses.map((r) => r.response_text),
+    trackedTerms,
+    { limit: 12 },
+  );
 
   const mentionsByResponse = new Map<string, Mention[]>();
   for (const m of mentions) {
@@ -261,6 +281,10 @@ export default async function RunDetailPage({ params }: { params: { id: string }
         </div>
       )}
 
+      {/* The field the tracked numbers can't see — companies the answers named
+          that aren't on the competitor list. One click adds them. */}
+      <TrackUntrackedCompanies companies={untrackedInRun} />
+
       {competitionByPrompt.length > 0 && (
         <div className="space-y-3">
           <SectionHeading
@@ -320,6 +344,9 @@ export default async function RunDetailPage({ params }: { params: { id: string }
             const question = promptText.get(response.prompt_id) ?? "(prompt removed)";
             const rMentions = mentionsByResponse.get(response.id) ?? [];
             const rSources = sourcesByResponse.get(response.id) ?? [];
+            // Companies this answer named that aren't tracked — so an answer full
+            // of untracked rivals reads as that, not as "named nobody".
+            const rUntracked = untrackedNamesInAnswer(response.response_text, trackedTerms);
             return (
               <Card key={response.id}>
                 <CardBody className="space-y-4">
@@ -339,12 +366,8 @@ export default async function RunDetailPage({ params }: { params: { id: string }
                     </div>
                   </div>
 
-                  <div>
-                    {rMentions.length === 0 ? (
-                      <p className="text-sm text-ink-faint">
-                        No brand or competitor mentioned.
-                      </p>
-                    ) : (
+                  <div className="space-y-2">
+                    {rMentions.length > 0 && (
                       <div className="flex flex-wrap items-center gap-2">
                         {rMentions.map((m) => (
                           <div key={m.id} className="flex items-center gap-1.5">
@@ -357,6 +380,16 @@ export default async function RunDetailPage({ params }: { params: { id: string }
                           </div>
                         ))}
                       </div>
+                    )}
+                    {rUntracked.length > 0 ? (
+                      <p className="text-xs text-ink-faint">
+                        {rMentions.length > 0 ? "Also named" : "Named, but not tracked"}:{" "}
+                        <span className="text-ink-soft">{rUntracked.join(", ")}</span>
+                      </p>
+                    ) : (
+                      rMentions.length === 0 && (
+                        <p className="text-sm text-ink-faint">No companies named.</p>
+                      )
                     )}
                   </div>
 

--- a/app/dashboard/runs/[id]/track-companies.tsx
+++ b/app/dashboard/runs/[id]/track-companies.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button, Card, CardBody } from "@/components/ui";
+
+export interface UntrackedCompany {
+  name: string;
+  /** How many of this run's answers named it. */
+  answers: number;
+}
+
+/**
+ * The companies THIS run's answers named that the project doesn't track yet.
+ *
+ * Mention detection only looks for the brand and its listed competitors, so a
+ * project with a thin competitor list reads as "named nobody" while its answers
+ * are full of rivals — the exact confusion this panel resolves. Tracking one
+ * adds it as a competitor (same endpoint the Competitors page uses), so every
+ * FUTURE run measures it deterministically; this past run isn't re-scored.
+ */
+export function TrackUntrackedCompanies({ companies }: { companies: UntrackedCompany[] }) {
+  const router = useRouter();
+  const [remaining, setRemaining] = useState(companies);
+  const [tracking, setTracking] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  if (remaining.length === 0) return null;
+
+  async function track(name: string) {
+    if (tracking) return;
+    setTracking(name);
+    setError(null);
+    try {
+      const res = await fetch("/api/competitors", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, aliases: [], domain: null }),
+      });
+      if (!res.ok) {
+        const json = await res.json().catch(() => ({}));
+        // A 409 (already tracked) is a fine outcome — drop it from the list too.
+        if (res.status !== 409) {
+          setError(json.error ?? "Could not track this company.");
+          return;
+        }
+      }
+      setRemaining((prev) => prev.filter((c) => c.name !== name));
+      router.refresh();
+    } catch {
+      setError("Network error. Please try again.");
+    } finally {
+      setTracking(null);
+    }
+  }
+
+  return (
+    <Card>
+      <CardBody className="space-y-3">
+        <div>
+          <p className="text-sm font-medium text-ink">
+            Companies these answers named that you don&apos;t track ({remaining.length})
+          </p>
+          <p className="mt-0.5 text-xs text-ink-faint">
+            We only measure the brand and competitors you&apos;ve added, so these show up in the answers
+            but not in your numbers. Track one to measure it from the next run on.
+          </p>
+        </div>
+        {error && <p className="text-xs text-terracotta-dark">{error}</p>}
+        <div className="flex flex-wrap gap-2">
+          {remaining.map((c) => (
+            <span
+              key={c.name}
+              className="inline-flex items-center gap-2 rounded border border-ink/10 bg-paper-shade/60 py-1 pl-3 pr-1 text-sm"
+            >
+              <span className="text-ink">{c.name}</span>
+              <span className="text-xs text-ink-faint">
+                {c.answers} answer{c.answers === 1 ? "" : "s"}
+              </span>
+              <Button
+                variant="secondary"
+                size="sm"
+                className="h-7 px-2.5 text-xs"
+                loading={tracking === c.name}
+                loadingText="Adding…"
+                onClick={() => track(c.name)}
+              >
+                Track
+              </Button>
+            </span>
+          ))}
+        </div>
+      </CardBody>
+    </Card>
+  );
+}

--- a/lib/discover.test.ts
+++ b/lib/discover.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { discoverCompanies, looksLikeCompanyName, namesInAnswer } from "@/lib/discover";
+import {
+  discoverCompanies,
+  looksLikeCompanyName,
+  namesInAnswer,
+  untrackedNamesInAnswer,
+} from "@/lib/discover";
 
 describe("looksLikeCompanyName", () => {
   it("accepts the shapes real vendor names take", () => {
@@ -144,5 +149,31 @@ describe("discoverCompanies", () => {
 
   it("returns nothing for answers that named no company", () => {
     expect(discoverCompanies(["**Why this matters**", ""], [])).toEqual([]);
+  });
+});
+
+describe("untrackedNamesInAnswer", () => {
+  const answer = "The leaders are **Galileo** and **Fiddler**, alongside **Runlayer**.";
+
+  it("returns named companies minus the brand and tracked competitors", () => {
+    // Runlayer is the brand, Fiddler is tracked → only Galileo is left.
+    const out = untrackedNamesInAnswer(answer, ["Runlayer", "Fiddler"]);
+    expect(out).toEqual(["Galileo"]);
+  });
+
+  it("drops a tracked company's own product line (extends a tracked name)", () => {
+    const text = "**Cloudflare** ships **Cloudflare Workers** for edge compute.";
+    const out = untrackedNamesInAnswer(text, ["Cloudflare"]);
+    expect(out).toEqual([]);
+  });
+
+  it("matches tracked terms case-insensitively", () => {
+    expect(untrackedNamesInAnswer(answer, ["runlayer", "GALILEO", "fiddler"])).toEqual([]);
+  });
+
+  it("is the same filter discoverCompanies aggregates over", () => {
+    // Two answers each naming Galileo once → discoverCompanies counts 2 answers.
+    const rollup = discoverCompanies([answer, answer], ["Runlayer", "Fiddler"]);
+    expect(rollup).toEqual([{ name: "Galileo", answers: 2 }]);
   });
 });

--- a/lib/discover.ts
+++ b/lib/discover.ts
@@ -155,6 +155,25 @@ export function namesInAnswer(text: string): string[] {
 }
 
 /**
+ * Candidate names in one answer that AREN'T the brand, a tracked competitor, or
+ * a product line of one — the untracked companies a single answer named. This
+ * is what lets the run view say "these companies showed up and you don't track
+ * them" instead of a flat "named nobody". `tracked` should carry the brand, its
+ * aliases, and every tracked competitor's name and aliases.
+ */
+export function untrackedNamesInAnswer(text: string, tracked: string[]): string[] {
+  const known = new Set(tracked.map((t) => t.trim().toLowerCase()).filter(Boolean));
+  // A candidate that merely EXTENDS a tracked name is that company's own product
+  // line, not a rival: "Cloudflare Workers" is Cloudflare.
+  const extendsTracked = (key: string) =>
+    [...known].some((t) => key.startsWith(`${t} `) || key.startsWith(`${t}(`));
+  return namesInAnswer(text).filter((n) => {
+    const key = n.toLowerCase();
+    return !known.has(key) && !extendsTracked(key);
+  });
+}
+
+/**
  * Companies named across these answers that aren't already accounted for.
  *
  * `tracked` should include the brand, its aliases, and every tracked
@@ -170,19 +189,14 @@ export function discoverCompanies(
   tracked: string[],
   options: { limit?: number } = {},
 ): DiscoveredCompany[] {
-  const known = [...new Set(tracked.map((t) => t.trim().toLowerCase()).filter(Boolean))];
-  const knownSet = new Set(known);
-  // A candidate that merely EXTENDS a tracked name is that company's own
-  // product line, not a rival: "Cloudflare Workers" and "Cloudflare (1.1.1.1)"
-  // are Cloudflare. Offering them as competitors would be nonsense.
-  const extendsTracked = (key: string) =>
-    known.some((t) => key.startsWith(`${t} `) || key.startsWith(`${t}(`));
   const counts = new Map<string, { name: string; answers: number }>();
 
   for (const answer of answers) {
-    for (const name of namesInAnswer(answer || "")) {
+    // untrackedNamesInAnswer drops the brand, tracked competitors, and their
+    // product lines — the shared filter both this rollup and the per-answer view
+    // read from, so they can't disagree about what "untracked" means.
+    for (const name of untrackedNamesInAnswer(answer || "", tracked)) {
       const key = name.toLowerCase();
-      if (knownSet.has(key) || extendsTracked(key)) continue;
       const row = counts.get(key) ?? { name, answers: 0 };
       row.answers++;
       counts.set(key, row);


### PR DESCRIPTION
## The problem
A project with a thin competitor list reads as **"No brand or competitor mentioned"** on answers that are actually full of rivals — because detection only looks for the brand + *tracked* competitors, and everyone else is discarded. Seen live on a project whose answers named AgilePoint, Galileo, Fiddler, Braintrust, Zuplo… none of which were tracked, so the whole competitive field was invisible (and share-of-voice / competitors-by-question had nothing to show).

## The fix
Surface the companies the answers *did* name that aren't tracked, with one-click **Track** — reusing the existing deterministic extractor, so there's no model call and no migration.

- **`untrackedNamesInAnswer(text, tracked)`** — a single answer's named companies minus the brand, tracked competitors, and their product lines. `discoverCompanies` now aggregates over it, so the run-level rollup and the per-answer view share one filter (single source of truth).
- **Run page** — a run-level "companies you don't track" panel with Track buttons (same `POST /api/competitors` the Competitors page uses), plus per-answer **"Named, but not tracked: …"** instead of the flat empty state.

Tracking adds the competitor so every **future** run measures it deterministically (this past run isn't re-scored).

Verified: typecheck clean, 625 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)