### PR TITLE
fix(runs): settle abandoned runs on read in the dashboard

### DIFF
--- a/app/dashboard/runs/[id]/page.tsx
+++ b/app/dashboard/runs/[id]/page.tsx
@@ -29,6 +29,7 @@ import {
   EmptyState,
 } from "@/components/ui";
 import { discoverCompanies, untrackedNamesInAnswer } from "@/lib/discover";
+import { isAbandoned, settleAbandonedRun, INTERRUPTED_RUN_ERROR } from "@/lib/engine";
 import { MarkResultsSeen } from "./mark-seen";
 import { TrackUntrackedCompanies } from "./track-companies";
 
@@ -77,6 +78,15 @@ export default async function RunDetailPage({ params }: { params: { id: string }
     .maybeSingle();
   if (!runRow) notFound();
   const run = runRow as Run;
+
+  // Self-heal a provably-dead run on read, like the runs list and the status
+  // endpoint — so opening a stuck run shows "failed" with its partial answers,
+  // not a phantom "running".
+  if (isAbandoned(run) && (await settleAbandonedRun(supabase, run.id, INTERRUPTED_RUN_ERROR))) {
+    run.status = "failed";
+    run.error = INTERRUPTED_RUN_ERROR;
+    run.finished_at = new Date().toISOString();
+  }
 
   const { data: responseRows } = await supabase
     .from("responses")

--- a/app/dashboard/runs/page.tsx
+++ b/app/dashboard/runs/page.tsx
@@ -5,6 +5,7 @@ import { resolveRunKey, engineKeyMessage, nextRunMessage } from "@/lib/trial";
 import { PROVIDERS, modelLabel } from "@/lib/models";
 import { ROUTERS } from "@/lib/routers";
 import { timeAgo } from "@/lib/utils";
+import { isAbandoned, settleAbandonedRun, INTERRUPTED_RUN_ERROR } from "@/lib/engine";
 import type { Run, RunStatus } from "@/lib/types";
 import {
   Button,
@@ -70,6 +71,24 @@ export default async function RunsPage() {
     .eq("project_id", project.id)
     .order("created_at", { ascending: false });
   const runs = (runRows ?? []) as Run[];
+
+  // Settle provably-dead runs on the way past — the same self-heal GET
+  // /v1/runs/:id/status does. A run row is written "running" up front and settled
+  // by whatever executes it; if that process dies (a 60-answer run can outlive the
+  // 300s function cap), nothing settles it until the daily cron. This list is the
+  // first place an operator looks, so it shouldn't show a phantom "running" for a
+  // run nothing is executing. The write is guarded + idempotent — safe against the
+  // cron and concurrent viewers.
+  await Promise.all(
+    runs.map(async (run) => {
+      if (!isAbandoned(run)) return;
+      if (await settleAbandonedRun(supabase, run.id, INTERRUPTED_RUN_ERROR)) {
+        run.status = "failed";
+        run.error = INTERRUPTED_RUN_ERROR;
+        run.finished_at = new Date().toISOString();
+      }
+    }),
+  );
 
   return (
     <div className="space-y-8">


### PR DESCRIPTION
## Bug
A run sat at **"running · 56/60 answers · 37m ago"** in the dashboard and never resolved.

## Cause
A run row is written `running` up front and settled by whatever executes it. If that process dies mid-flight — a 60-answer run (esp. a slower model + web search) can outlive the **300s serverless cap** — nothing settles it. There *is* a 15-min reaper (`settleAbandonedRun` → `failed`), and it self-heals on the **v1 status poll**, the **next run trigger**, and the **daily 08:00 UTC cron** — but the **dashboard pages just read `runs.status`**, so a dead run shows "running" until one of those fires (up to ~a day).

## Fix
Settle provably-dead runs (`isAbandoned`: >15m in `running`) on read in the runs **list** and **detail** pages, mirroring exactly what `GET /v1/runs/:id/status` already does. The write is guarded + idempotent, so it races the cron and concurrent viewers harmlessly. A stuck run now shows **"failed"** with its partial answers instead of a phantom "running".

## Scope
This makes the **state honest** — it does not recover the missing answers. Runs that outrun the function cap still stop short; **completing them reliably** (auto-resume the remaining prompts, or smaller batches) is a separate, larger change — happy to take that next.

Verified: typecheck + lint clean, 627 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)