### PR TITLE
Fit full-size runs inside the invocation ceiling; sweep dead runs from /admin

### DIFF
--- a/app/api/cron/run/route.ts
+++ b/app/api/cron/run/route.ts
@@ -1,13 +1,7 @@
 import crypto from "node:crypto";
 import { NextResponse } from "next/server";
 import { createServiceClient } from "@/lib/supabase/server";
-import type { SupabaseClient } from "@supabase/supabase-js";
-import {
-  executeRun,
-  settleAbandonedRun,
-  ABANDONED_RUN_MS,
-  INTERRUPTED_RUN_ERROR,
-} from "@/lib/engine";
+import { executeRun, sweepAbandonedRuns } from "@/lib/engine";
 import { resolveRunKey } from "@/lib/trial";
 import type { Project } from "@/lib/types";
 
@@ -31,36 +25,6 @@ interface ProjectResult {
   reason?: string;
   runId?: string;
   totalResponses?: number;
-}
-
-/**
- * Settle runs that nothing is executing any more.
- *
- * A run row is written "running" up front and settled by the code that executes
- * it — so if that process dies mid-flight, nothing ever settles it. Background
- * runs made this reachable in normal operation: they outlive the response but
- * not the invocation, so a portfolio large enough to exceed maxDuration leaves
- * the row "running" permanently, and GET /v1/runs/:id/status reports that to a
- * poller forever.
- *
- * This is the only place that can fix a row whose executor is already gone, so
- * it runs on every tick regardless of whether any project is due. Returns what
- * it settled so an operator can see it in the response rather than inferring it
- * from a client complaint.
- */
-async function sweepAbandonedRuns(supabase: SupabaseClient): Promise<string[]> {
-  const cutoff = new Date(Date.now() - ABANDONED_RUN_MS).toISOString();
-  const { data } = await supabase
-    .from("runs")
-    .select("id")
-    .eq("status", "running")
-    .lt("started_at", cutoff);
-
-  const settled: string[] = [];
-  for (const row of (data ?? []) as { id: string }[]) {
-    if (await settleAbandonedRun(supabase, row.id, INTERRUPTED_RUN_ERROR)) settled.push(row.id);
-  }
-  return settled;
 }
 
 // Scheduler entrypoint. Runs every due project. Supports POST (manual curl)

--- a/lib/engine.test.ts
+++ b/lib/engine.test.ts
@@ -4,6 +4,7 @@ import {
   isOwnedDomain,
   isAbandoned,
   settleAbandonedRun,
+  sweepAbandonedRuns,
   ABANDONED_RUN_MS,
 } from "@/lib/engine";
 
@@ -141,5 +142,67 @@ describe("settleAbandonedRun", () => {
     const { db, updated } = fakeDb([{ id: "run-1" }]);
     await settleAbandonedRun(db, "run-1", "interrupted");
     expect(Object.keys(updated() ?? {})).not.toContain("completed_count");
+  });
+});
+
+describe("sweepAbandonedRuns", () => {
+  /** Serves one read of stale running rows; records which of them the
+   *  per-row settle actually won (rows outside `settleable` lost the race). */
+  function fakeDb(staleRows: { id: string }[], settleable = staleRows) {
+    const cutoffs: string[] = [];
+    const db = {
+      from: () => ({
+        select: () => {
+          const chain = {
+            eq: () => chain,
+            lt: (_col: string, val: string) => {
+              cutoffs.push(val);
+              return Promise.resolve({ data: staleRows });
+            },
+          };
+          return chain;
+        },
+        update: () => {
+          let id: unknown;
+          const chain = {
+            eq: (col: string, val: unknown) => {
+              if (col === "id") id = val;
+              return chain;
+            },
+            select: async () => ({
+              data: settleable.some((r) => r.id === id) ? [{ id }] : [],
+            }),
+          };
+          return chain;
+        },
+      }),
+    };
+    return { db: db as never, cutoffs };
+  }
+
+  it("settles every stale row and reports which", async () => {
+    const { db } = fakeDb([{ id: "run-1" }, { id: "run-2" }]);
+    expect(await sweepAbandonedRuns(db)).toEqual(["run-1", "run-2"]);
+  });
+
+  it("asks only for rows older than the abandonment threshold", async () => {
+    const { db, cutoffs } = fakeDb([]);
+    const before = Date.now();
+    await sweepAbandonedRuns(db);
+    const cutoff = new Date(cutoffs[0]).getTime();
+    expect(cutoff).toBeGreaterThanOrEqual(before - ABANDONED_RUN_MS - 1000);
+    expect(cutoff).toBeLessThanOrEqual(Date.now() - ABANDONED_RUN_MS);
+  });
+
+  it("does not report a row that settled itself between read and write", async () => {
+    // The guard inside settleAbandonedRun is what actually protects the row;
+    // the sweep must simply not count the ones the guard turned away.
+    const { db } = fakeDb([{ id: "run-1" }, { id: "run-2" }], [{ id: "run-2" }]);
+    expect(await sweepAbandonedRuns(db)).toEqual(["run-2"]);
+  });
+
+  it("settles nothing on a quiet table", async () => {
+    const { db } = fakeDb([]);
+    expect(await sweepAbandonedRuns(db)).toEqual([]);
   });
 });

--- a/lib/engine.ts
+++ b/lib/engine.ts
@@ -29,8 +29,17 @@ export interface RunContext {
   actorLabel?: string | null;
 }
 
-// Run at most this many queries at once to stay under provider rate limits.
-const CONCURRENCY = 4;
+// Run at most this many queries at once. Low enough to stay under provider
+// rate limits, high enough that a full-size run finishes inside the 300s
+// invocation ceiling: 60 answers with web search on a slow engine run ~20s
+// each, and at 4-wide that exact workload was killed at the cap three times,
+// seconds short of done. 8-wide it clears the ceiling with half left over.
+const CONCURRENCY = 8;
+
+// Flush the progress counter every few answers rather than every answer — the
+// row is a checkpoint, not a log. Fixed rather than tied to CONCURRENCY so a
+// wider pool doesn't make completed_count staler for whoever reads it mid-run.
+const PROGRESS_EVERY = 4;
 
 // The brand's registrable web host, e.g. "notion.so" from a messy domain entry.
 export function hostOf(domain: string | null): string {
@@ -157,6 +166,32 @@ export async function settleAbandonedRun(
  *  endpoint and the background catch can't describe it three different ways. */
 export const INTERRUPTED_RUN_ERROR =
   "The run was interrupted before it finished — the server stopped executing it. Answers stored before that point were kept. Run it again to collect the rest.";
+
+/**
+ * Settle every run that nothing is executing any more.
+ *
+ * A run row is written "running" up front and settled by the code that executes
+ * it — so if that process dies mid-flight, nothing ever settles it. This is the
+ * batch form of settleAbandonedRun, shared by the cron tick and the admin page:
+ * cron because it needs no one watching, the admin page because an operator
+ * looking at deployment health shouldn't wait a day for the next tick to be
+ * shown a failure as a failure. Returns what it settled so callers can report
+ * it rather than have it inferred from a client complaint.
+ */
+export async function sweepAbandonedRuns(supabase: SupabaseClient): Promise<string[]> {
+  const cutoff = new Date(Date.now() - ABANDONED_RUN_MS).toISOString();
+  const { data } = await supabase
+    .from("runs")
+    .select("id")
+    .eq("status", "running")
+    .lt("started_at", cutoff);
+
+  const settled: string[] = [];
+  for (const row of (data ?? []) as { id: string }[]) {
+    if (await settleAbandonedRun(supabase, row.id, INTERRUPTED_RUN_ERROR)) settled.push(row.id);
+  }
+  return settled;
+}
 
 export interface ExecuteRunParams {
   supabase: SupabaseClient;
@@ -495,7 +530,7 @@ export async function resumeRun(prepared: PreparedRun, params: ExecuteRunParams)
     } finally {
       processed++;
       // Periodic progress checkpoint, completed_count reflects stored answers.
-      if (processed % CONCURRENCY === 0 || processed === jobs.length) {
+      if (processed % PROGRESS_EVERY === 0 || processed === jobs.length) {
         await supabase.from("runs").update({ completed_count: succeeded }).eq("id", runId);
       }
     }

--- a/lib/ops-live.ts
+++ b/lib/ops-live.ts
@@ -1,5 +1,6 @@
 import { createServiceClient } from "@/lib/supabase/service";
 import { signatureOf } from "@/lib/ops";
+import { sweepAbandonedRuns } from "@/lib/engine";
 
 /**
  * The half of the operations picture that does not need telemetry.
@@ -165,6 +166,13 @@ export async function liveHealth(hours = 24): Promise<LiveHealth> {
   const sinceIso = new Date(Date.now() - hours * 60 * 60 * 1000).toISOString();
   try {
     const admin = createServiceClient();
+    // Settle provably-dead runs before reading. The cron tick does the same,
+    // but it fires once a day — an operator looking at this page right now
+    // should see a dead run as the failure it is, not as "running" for up to
+    // 24 hours. Guarded and idempotent, so racing the cron (or another admin
+    // tab) is harmless. Failure to sweep must not cost the page: the numbers
+    // are the product here, the sweep is a courtesy.
+    await sweepAbandonedRuns(admin).catch(() => {});
     const [runsRes, signupRes, usersRes, apiErrRes] = await Promise.all([
       admin
         .from("runs")


### PR DESCRIPTION
## What happened

Three consecutive runs on one project (60 answers, web search, `claude-opus-4-8`) were killed by Vercel at the `maxDuration = 300` ceiling, each seconds short of finishing. DB timestamps: each invocation spent ~16s on setup, answered steadily for ~283s, and died at the 300s mark with 57-59 of 60 answers stored. At `CONCURRENCY = 4` and ~20s/answer, that workload needs ~305s — deterministically just over the cap, so every retry died in the same spot. Each kill stranded a `"running"` row that nothing settled until the once-daily cron tick or a status poll.

## Changes

- **`CONCURRENCY` 4 -> 8** (`lib/engine.ts`): the failing workload now finishes in ~150s, leaving half the ceiling as headroom. Comment records both constraints (rate limits above, invocation ceiling below).
- **`PROGRESS_EVERY = 4`**: `completed_count` used to flush every `CONCURRENCY` answers, so the killed runs read 56/60 on the ops dashboard while actually holding 59. Flush cadence is now fixed, decoupled from pool width.
- **Sweep abandoned runs from `/admin`**: `sweepAbandonedRuns` moved from the cron route into `lib/engine.ts` and is now also called by `liveHealth()` on admin page load. Previously a stranded row could sit on the "stuck runs" card for up to 24h (cron is daily); now looking at the page settles anything provably dead. Guarded + idempotent, and a sweep failure can't take down the page.
- Tests for `sweepAbandonedRuns` (settles stale rows, respects the threshold cutoff, doesn't double-count race losers).

`vercel.json`'s daily cron is deliberately untouched — hourly crons are plan-gated, and the admin-page sweep closes the gap without deploy risk.

## Verification

- `tsc --noEmit` clean; `vitest run` 617/617 across 32 files; lint has only pre-existing warnings.
- The three dead runs from today confirmed via response-row timestamps (283s answer span + ~16s setup = the 300s kill, all three attempts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
