### PR TITLE
fix(runs): give runs time to finish (maxDuration 300 -> 800s)

### DIFF
--- a/app/api/cron/run/route.ts
+++ b/app/api/cron/run/route.ts
@@ -11,7 +11,7 @@ import {
 import { resolveRunKey } from "@/lib/trial";
 import type { Project } from "@/lib/types";
 
-export const maxDuration = 300;
+export const maxDuration = 800;
 export const dynamic = "force-dynamic";
 
 const DAY_MS = 24 * 60 * 60 * 1000;

--- a/app/api/runs/route.ts
+++ b/app/api/runs/route.ts
@@ -13,7 +13,7 @@ import {
   engineKeyMessage,
 } from "@/lib/trial";
 
-export const maxDuration = 300;
+export const maxDuration = 800;
 export const dynamic = "force-dynamic";
 
 // POST /api/runs, execute a monitoring run now for the signed-in user's project.

--- a/app/api/v1/projects/[id]/runs/route.ts
+++ b/app/api/v1/projects/[id]/runs/route.ts
@@ -6,7 +6,7 @@ import { isProvider, PROVIDERS } from "@/lib/models";
 import { humanError } from "@/lib/llm";
 import type { Provider } from "@/lib/types";
 
-export const maxDuration = 300;
+export const maxDuration = 800;
 export const dynamic = "force-dynamic";
 
 // GET /api/v1/projects/:id/runs — recent runs for a project (?limit=20).

--- a/lib/engine.test.ts
+++ b/lib/engine.test.ts
@@ -86,9 +86,10 @@ describe("isAbandoned", () => {
   });
 
   // The threshold has to sit above the platform ceiling every run route caps
-  // at (maxDuration = 300s), or the sweeper starts killing live runs.
+  // at (maxDuration = 800s), or the sweeper starts killing live runs that are
+  // simply using their full budget.
   it("is comfortably above the longest an invocation can last", () => {
-    expect(ABANDONED_RUN_MS).toBeGreaterThan(300_000);
+    expect(ABANDONED_RUN_MS).toBeGreaterThan(800_000);
   });
 });
 

--- a/lib/engine.ts
+++ b/lib/engine.ts
@@ -97,12 +97,12 @@ export interface RunResult {
  * How long a run may sit in "running" before it is treated as abandoned.
  *
  * A run cannot outlive the invocation executing it, and every route that starts
- * one caps at maxDuration = 300s. So anything still "running" well past that is
- * not slow, it is gone: the process was killed mid-flight and the code that
- * settles the row never got to run. Three times the ceiling leaves room for a
- * platform that is more generous than ours without ever racing a live run.
+ * one caps at maxDuration = 800s (≈13.3m). So anything still "running" well past
+ * that is not slow, it is gone: the process was killed mid-flight and the code
+ * that settles the row never got to run. The threshold sits comfortably above
+ * the ceiling so it never races a live run that is simply using its full budget.
  */
-export const ABANDONED_RUN_MS = 15 * 60 * 1000;
+export const ABANDONED_RUN_MS = 20 * 60 * 1000;
 
 /** True when a "running" row has outlived any invocation that could still be
  *  working on it. Exported for tests and for callers that only want to report. */


### PR DESCRIPTION
## Bug
Brevy's Claude Opus 4.8 runs die at **exactly 56/60 every time** (three runs in a row), while GPT-4o completes 60/60. That consistency = the **300s function cap**, not a random failure: at `CONCURRENCY = 4`, ~56 slow Opus+web-search answers fit in 300s before the invocation is killed. `#96` made the status honest ("failed · interrupted"), but re-running just repeats 56/60.

## Why not other levers
- **Retry**: there is none — a 429 loses that answer.
- **Concurrency**: `CONCURRENCY = 4` is deliberately low "to stay under provider rate limits" (no retry to catch the 429s), so raising it trades timeouts for lost answers.
- **Resume**: `resumeRun` reprocesses the *whole* job list — it's the back half of `executeRun`, not a real continuation — so it can't pick up where a run left off.

The safe lever is **time**.

## Fix
- `maxDuration` **300 → 800s** on the run-executing routes (`/api/v1/projects/[id]/runs`, `/api/runs`, `/api/cron/run`). Fluid Compute supports it; a 60-answer run (~320s at concurrency 4) now finishes with wide headroom. *(The Vercel deploy check validates the plan allows 800s.)*
- `ABANDONED_RUN_MS` **15 → 20m** so the abandoned-run sweeper still sits above the new ceiling and never races a run using its full budget.

## Scope
Fixes runs up to ~150 answers. A portfolio large enough to exceed 800s still needs **genuine chunked/resumable execution** (process in sub-cap batches across invocations, skipping already-answered prompts) — a separate, larger change I can take next if you want the fleet bulletproofed.

Verified: typecheck + 627 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)