### PR TITLE
feat(web-mentions): schema, search-provider interface, and BYOK search keys

### DIFF
--- a/lib/search-keys.ts
+++ b/lib/search-keys.ts
@@ -1,0 +1,187 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { ConfigurationError, decryptSecret, encryptSecret, keyHint } from "@/lib/crypto";
+import { ENCRYPTION_UNAVAILABLE_MESSAGE } from "@/lib/provider-keys";
+import { SEARCH_PROVIDERS, SEARCH_PROVIDER_LIST, isSearchProvider } from "@/lib/search";
+import type { SearchProviderId } from "@/lib/search";
+
+// ==================================================================
+// The single write path for BYOK web-search keys (search_keys table).
+//
+// Deliberately the same contract as lib/provider-keys, for the same reason
+// that module exists: verify the key against the provider FIRST, encrypt it
+// SECOND, and only ever persist the ciphertext plus a non-reversible hint.
+// A separate module rather than a widening of provider-keys because a search
+// engine is not an answer engine — the two allow-lists must never bleed into
+// each other (see the search_keys schema note).
+//
+// Every function takes userId explicitly rather than leaning on RLS, because
+// the collector reaches this through the service-role client.
+//
+// Nothing in this module ever returns, logs, or echoes the plaintext key
+// except decryptedSearchKey, whose only caller is the collector handing the
+// key straight to the provider adapter.
+// ==================================================================
+
+/** A search_keys row trimmed to what any surface may show. No ciphertext. */
+export interface SearchKeySummary {
+  id: string;
+  provider: SearchProviderId;
+  label: string | null;
+  key_hint: string;
+  created_at: string;
+}
+
+export type SetSearchKeyOutcome =
+  | { ok: true; key: SearchKeySummary }
+  | {
+      ok: false;
+      code: "invalid" | "unverified" | "misconfigured" | "failed";
+      message: string;
+    };
+
+/** Narrow an untrusted provider value, or null. */
+export function parseSearchProvider(value: unknown): SearchProviderId | null {
+  return typeof value === "string" && isSearchProvider(value) ? value : null;
+}
+
+export function unknownSearchProviderMessage(): string {
+  return `Unknown search provider. Supported: ${SEARCH_PROVIDER_LIST.map((p) => p.id).join(", ")}.`;
+}
+
+const SUMMARY_COLUMNS = "id, provider, label, key_hint, created_at";
+
+/** The caller's stored search keys, hints only. Throws on a query error —
+ *  an empty list is a meaningful answer ("no key stored"), so it must never
+ *  double as a failure signal. */
+export async function listSearchKeys(
+  supabase: SupabaseClient,
+  userId: string,
+): Promise<SearchKeySummary[]> {
+  const { data, error } = await supabase
+    .from("search_keys")
+    .select(SUMMARY_COLUMNS)
+    .eq("user_id", userId)
+    .order("provider");
+  if (error) throw error;
+  return (data as SearchKeySummary[] | null) ?? [];
+}
+
+/**
+ * Verify a search key, encrypt it, and store it as the account's key for
+ * that provider (one per provider — an existing key is replaced; "set" and
+ * "rotate" are the same operation). The ordering is the reason this function
+ * exists: a key the provider rejects must never reach the database, and an
+ * encryption failure must be distinguishable from a rejected key.
+ */
+export async function setSearchKey(
+  supabase: SupabaseClient,
+  userId: string,
+  input: { provider: unknown; apiKey: unknown; label?: unknown },
+): Promise<SetSearchKeyOutcome> {
+  const provider = parseSearchProvider(input.provider);
+  if (!provider) {
+    return { ok: false, code: "invalid", message: unknownSearchProviderMessage() };
+  }
+  if (typeof input.apiKey !== "string" || input.apiKey.trim().length === 0) {
+    return { ok: false, code: "invalid", message: "An API key is required" };
+  }
+
+  const key = input.apiKey.trim();
+  const label =
+    typeof input.label === "string" && input.label.trim().length > 0
+      ? input.label.trim()
+      : null;
+
+  const verified = await SEARCH_PROVIDERS[provider].verifyKey(key);
+  if (!verified.ok) {
+    return {
+      ok: false,
+      code: "unverified",
+      message: verified.error || "Key verification failed",
+    };
+  }
+
+  let encrypted_key: string;
+  const key_hint = keyHint(key);
+  try {
+    encrypted_key = encryptSecret(key);
+  } catch (e) {
+    if (e instanceof ConfigurationError) {
+      console.error("[search-keys] deployment misconfigured:", e.message);
+      return {
+        ok: false,
+        code: "misconfigured",
+        message: ENCRYPTION_UNAVAILABLE_MESSAGE,
+      };
+    }
+    return {
+      ok: false,
+      code: "failed",
+      message: e instanceof Error ? e.message : "Could not store the key.",
+    };
+  }
+
+  const { data, error } = await supabase
+    .from("search_keys")
+    .upsert(
+      { user_id: userId, provider, label, encrypted_key, key_hint },
+      { onConflict: "user_id,provider" },
+    )
+    .select(SUMMARY_COLUMNS)
+    .single();
+
+  if (error || !data) {
+    return {
+      ok: false,
+      code: "failed",
+      message: error?.message || "Could not store the key.",
+    };
+  }
+  return { ok: true, key: data as SearchKeySummary };
+}
+
+/**
+ * Delete the account's key for one search provider. Returns the removed
+ * row's summary, or null when nothing was stored (caller answers 404, so a
+ * typo'd provider never reads as "removed"). A query error throws: this is
+ * a revocation path, and "no key is stored" after a failed delete leaves
+ * the user believing a live credential is gone.
+ */
+export async function removeSearchKey(
+  supabase: SupabaseClient,
+  userId: string,
+  provider: SearchProviderId,
+): Promise<SearchKeySummary | null> {
+  const { data, error } = await supabase
+    .from("search_keys")
+    .delete()
+    .eq("user_id", userId)
+    .eq("provider", provider)
+    .select(SUMMARY_COLUMNS)
+    .maybeSingle();
+  if (error) throw error;
+  return (data as SearchKeySummary | null) ?? null;
+}
+
+/**
+ * The collector's read path: the user's stored key for a provider, decrypted,
+ * or null when none is stored. Throws ConfigurationError when a key exists
+ * but this deployment can't decrypt it (missing/rotated ENCRYPTION_KEY) —
+ * that is an operator problem and must not be reported as "enable the signal
+ * by adding a key", which the user already did.
+ */
+export async function decryptedSearchKey(
+  supabase: SupabaseClient,
+  userId: string,
+  provider: SearchProviderId,
+): Promise<string | null> {
+  const { data, error } = await supabase
+    .from("search_keys")
+    .select("encrypted_key")
+    .eq("user_id", userId)
+    .eq("provider", provider)
+    .maybeSingle();
+  if (error) throw error;
+  if (!data?.encrypted_key) return null;
+  return decryptSecret(data.encrypted_key);
+}

--- a/lib/search/brave.test.ts
+++ b/lib/search/brave.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { braveProvider } from "@/lib/search/brave";
+import { SearchRateLimitError } from "@/lib/search/types";
+
+function mockFetch(status: number, body: unknown = {}) {
+  const fn = vi.fn(async () => ({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  })) as unknown as typeof fetch;
+  vi.stubGlobal("fetch", fn);
+  return fn as unknown as ReturnType<typeof vi.fn>;
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("braveProvider.search", () => {
+  it("normalizes results with 1-based ranks and trims empty fields", async () => {
+    mockFetch(200, {
+      web: {
+        results: [
+          { url: "https://reddit.com/r/seo/1", title: "Thread", description: "snippet" },
+          { url: "https://reddit.com/r/seo/2", title: "", description: "  " },
+          { title: "no url — dropped" },
+        ],
+      },
+    });
+    const results = await braveProvider.search("key", "site:reddit.com acme");
+    expect(results).toEqual([
+      { url: "https://reddit.com/r/seo/1", title: "Thread", snippet: "snippet", rank: 1 },
+      { url: "https://reddit.com/r/seo/2", title: null, snippet: null, rank: 2 },
+    ]);
+  });
+
+  it("returns empty for a payload with no web results", async () => {
+    mockFetch(200, {});
+    expect(await braveProvider.search("key", "q")).toEqual([]);
+  });
+
+  it("passes the freshness window through as Brave's code", async () => {
+    const fn = mockFetch(200, {});
+    await braveProvider.search("key", "q", { freshness: "week" });
+    expect(String(fn.mock.calls[0][0])).toContain("freshness=pw");
+    await braveProvider.search("key", "q", { freshness: "year" });
+    expect(String(fn.mock.calls[1][0])).toContain("freshness=py");
+  });
+
+  it("clamps count to Brave's page-size ceiling instead of 422ing", async () => {
+    const fn = mockFetch(200, {});
+    await braveProvider.search("key", "q", { count: 50 });
+    expect(String(fn.mock.calls[0][0])).toContain("count=20");
+  });
+
+  it("throws the distinct rate-limit error on 429", async () => {
+    mockFetch(429);
+    await expect(braveProvider.search("key", "q")).rejects.toBeInstanceOf(SearchRateLimitError);
+  });
+
+  it("throws a key error on 401", async () => {
+    mockFetch(401);
+    await expect(braveProvider.search("key", "q")).rejects.toThrow(/rejected the API key/);
+  });
+});
+
+describe("braveProvider.verifyKey", () => {
+  it("accepts a key the API accepts", async () => {
+    mockFetch(200, {});
+    expect(await braveProvider.verifyKey("key")).toEqual({ ok: true });
+  });
+
+  it("rejects a key the API rejects", async () => {
+    mockFetch(401);
+    const out = await braveProvider.verifyKey("bad");
+    expect(out.ok).toBe(false);
+    expect(out.error).toMatch(/rejected/);
+  });
+
+  // An invalid key can't be rate-limited; refusing to store it on a 429
+  // would blame the user's key for our probe timing.
+  it("treats a 429 during verification as a valid key", async () => {
+    mockFetch(429);
+    expect(await braveProvider.verifyKey("key")).toEqual({ ok: true });
+  });
+
+  it("reports unreachable rather than rejecting the key on network failure", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => Promise.reject(new Error("ECONNRESET"))));
+    const out = await braveProvider.verifyKey("key");
+    expect(out.ok).toBe(false);
+    expect(out.error).toMatch(/reach/i);
+  });
+});

--- a/lib/search/brave.ts
+++ b/lib/search/brave.ts
@@ -1,0 +1,107 @@
+import type { SearchOptions, SearchProvider, SearchResult } from "./types";
+import { SearchRateLimitError } from "./types";
+
+// Brave Search API adapter. Independent index, flat per-query pricing, and a
+// free tier that covers development and pilots. Docs:
+// https://api-dashboard.search.brave.com/app/documentation/web-search
+const API_URL = "https://api.search.brave.com/res/v1/web/search";
+
+// One query should never hang a collection tick: the weekly window means a
+// lost query costs nothing, so fail fast and move on.
+const TIMEOUT_MS = 15_000;
+
+// Brave's own page-size ceiling; asking for more is a 422, not extra results.
+const MAX_COUNT = 20;
+
+const FRESHNESS: Record<NonNullable<SearchOptions["freshness"]>, string> = {
+  week: "pw",
+  year: "py",
+};
+
+/** The shape of the Brave response we actually read. Everything else in the
+ *  payload (mixed results, videos, infoboxes) is deliberately ignored. */
+interface BraveResponse {
+  web?: {
+    results?: { url?: string; title?: string; description?: string }[];
+  };
+}
+
+function requestInit(apiKey: string): RequestInit {
+  return {
+    headers: {
+      Accept: "application/json",
+      "X-Subscription-Token": apiKey,
+    },
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  };
+}
+
+async function search(
+  apiKey: string,
+  query: string,
+  opts: SearchOptions = {},
+): Promise<SearchResult[]> {
+  const params = new URLSearchParams({
+    q: query,
+    count: String(Math.min(Math.max(opts.count ?? MAX_COUNT, 1), MAX_COUNT)),
+  });
+  if (opts.freshness) params.set("freshness", FRESHNESS[opts.freshness]);
+
+  const res = await fetch(`${API_URL}?${params}`, requestInit(apiKey));
+
+  if (res.status === 429) throw new SearchRateLimitError("Brave Search");
+  if (res.status === 401 || res.status === 403) {
+    throw new Error("Brave Search rejected the API key.");
+  }
+  if (!res.ok) {
+    // 422s carry a useful message (bad freshness value, count too high) that
+    // names our bug, not the user's — surface it rather than a bare status.
+    const detail = await res.text().catch(() => "");
+    throw new Error(`Brave Search error ${res.status}${detail ? `: ${detail.slice(0, 200)}` : ""}`);
+  }
+
+  const payload = (await res.json()) as BraveResponse;
+  const results: SearchResult[] = [];
+  for (const [i, r] of (payload.web?.results ?? []).entries()) {
+    if (!r.url) continue;
+    results.push({
+      url: r.url,
+      title: r.title?.trim() || null,
+      snippet: r.description?.trim() || null,
+      rank: i + 1,
+    });
+  }
+  return results;
+}
+
+/** A real (billable) one-result query, because Brave has no dedicated
+ *  key-validation endpoint. Cheapest possible probe: one query at the
+ *  smallest page size. */
+async function verifyKey(apiKey: string): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const params = new URLSearchParams({ q: "test", count: "1" });
+    const res = await fetch(`${API_URL}?${params}`, requestInit(apiKey));
+    if (res.ok) return { ok: true };
+    if (res.status === 401 || res.status === 403) {
+      return { ok: false, error: "Brave Search rejected this key." };
+    }
+    if (res.status === 429) {
+      // The key IS valid — an invalid key can't be rate-limited. Refusing to
+      // store it here would tell the user their key is bad when the only
+      // problem is that we probed too fast.
+      return { ok: true };
+    }
+    return { ok: false, error: `Brave Search verification failed (HTTP ${res.status}).` };
+  } catch {
+    return { ok: false, error: "Couldn't reach Brave Search to verify the key. Please try again." };
+  }
+}
+
+export const braveProvider: SearchProvider = {
+  id: "brave",
+  label: "Brave Search",
+  keyUrl: "https://api-dashboard.search.brave.com/app/keys",
+  keyPrefix: "BSA",
+  search,
+  verifyKey,
+};

--- a/lib/search/index.ts
+++ b/lib/search/index.ts
@@ -1,0 +1,36 @@
+// ==================================================================
+// Web-search providers, behind one interface.
+//
+// The web-mentions signal discovers third-party chatter (Reddit threads,
+// forum posts) by running scoped queries through a general web-search API —
+// deliberately NOT the official Reddit API, which requires pre-approval,
+// has no comment or date-range search, and treats commercial use as a paid
+// agreement. Any site is reachable the same way: `site:` scoping is the
+// only per-site integration.
+//
+// Brave is the first provider. The interface exists so a second provider
+// (a Google-backed index, say) is one adapter file and a registry entry —
+// never a rewrite of the collector.
+// ==================================================================
+
+import { braveProvider } from "./brave";
+import type { SearchProvider, SearchProviderId } from "./types";
+
+export type {
+  SearchFreshness,
+  SearchOptions,
+  SearchProvider,
+  SearchProviderId,
+  SearchResult,
+} from "./types";
+export { SearchRateLimitError } from "./types";
+
+export const SEARCH_PROVIDERS: Record<SearchProviderId, SearchProvider> = {
+  brave: braveProvider,
+};
+
+export const SEARCH_PROVIDER_LIST: SearchProvider[] = Object.values(SEARCH_PROVIDERS);
+
+export function isSearchProvider(value: string): value is SearchProviderId {
+  return value in SEARCH_PROVIDERS;
+}

--- a/lib/search/query.test.ts
+++ b/lib/search/query.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { brandQueries, topicQuery, sitesForTick } from "@/lib/search/query";
+
+describe("brandQueries", () => {
+  it("builds one site-scoped OR-group for a brand with few aliases", () => {
+    expect(brandQueries("reddit.com", "Acme", ["AcmeHQ", "Acme Labs"])).toEqual([
+      'site:reddit.com ("Acme" OR "AcmeHQ" OR "Acme Labs")',
+    ]);
+  });
+
+  it("chunks three terms per query — the cost model depends on it", () => {
+    const queries = brandQueries("reddit.com", "Acme", ["A1", "A2", "A3", "A4"]);
+    expect(queries).toHaveLength(2);
+    expect(queries[0]).toBe('site:reddit.com ("Acme" OR "A1" OR "A2")');
+    expect(queries[1]).toBe('site:reddit.com ("A3" OR "A4")');
+  });
+
+  it("dedupes case-insensitively and drops blank aliases", () => {
+    expect(brandQueries("news.ycombinator.com", "Acme", ["acme", "  ", "ACME"])).toEqual([
+      'site:news.ycombinator.com ("Acme")',
+    ]);
+  });
+
+  it("returns no queries for a blank brand — zero queries, zero spend", () => {
+    expect(brandQueries("reddit.com", "  ", [])).toEqual([]);
+  });
+});
+
+describe("topicQuery", () => {
+  it("keeps topic terms unquoted — recall first, precision downstream", () => {
+    expect(topicQuery("reddit.com", "best crm for freelancers")).toBe(
+      "site:reddit.com best crm for freelancers",
+    );
+  });
+
+  it("appends deduped extra keywords", () => {
+    expect(topicQuery("reddit.com", "crm", ["pricing", "CRM", "pricing"])).toBe(
+      "site:reddit.com crm pricing",
+    );
+  });
+});
+
+describe("sitesForTick", () => {
+  const sites = ["reddit.com", "news.ycombinator.com", "indiehackers.com"];
+
+  it("always includes the primary site", () => {
+    for (const tick of [0, 1, 2, 3]) {
+      expect(sitesForTick(sites, tick)[0]).toBe("reddit.com");
+    }
+  });
+
+  it("rotates exactly one secondary per tick, round-robin", () => {
+    expect(sitesForTick(sites, 0)).toEqual(["reddit.com", "news.ycombinator.com"]);
+    expect(sitesForTick(sites, 1)).toEqual(["reddit.com", "indiehackers.com"]);
+    expect(sitesForTick(sites, 2)).toEqual(["reddit.com", "news.ycombinator.com"]);
+  });
+
+  it("keeps cost flat: never more than two sites per tick", () => {
+    const many = ["a.com", "b.com", "c.com", "d.com", "e.com", "f.com"];
+    expect(sitesForTick(many, 7)).toHaveLength(2);
+  });
+
+  it("handles a single watched site and an empty list", () => {
+    expect(sitesForTick(["reddit.com"], 5)).toEqual(["reddit.com"]);
+    expect(sitesForTick([], 5)).toEqual([]);
+  });
+});

--- a/lib/search/query.ts
+++ b/lib/search/query.ts
@@ -1,0 +1,71 @@
+// Query construction for the web-mentions collector. Pure functions, because
+// every query is money: the collector's cost model is exactly the length of
+// the arrays these return, so they must be predictable enough to unit-test
+// against the budget math.
+
+/** Brave treats long OR-chains unevenly; three quoted terms per query is the
+ *  chunk size that keeps recall without splitting one brand into five bills. */
+const TERMS_PER_QUERY = 3;
+
+/** `"Acme" OR "AcmeHQ"` — quoted, exact-ish matching. The re-verification
+ *  pass (word-boundary matcher on title+snippet) is what actually decides
+ *  whether a result counts; the quotes just keep the search engine honest. */
+function orGroup(terms: string[]): string {
+  return `(${terms.map((t) => `"${t}"`).join(" OR ")})`;
+}
+
+/** Dedup + drop blanks, preserving order. Case-insensitive: "Acme" and
+ *  "acme" are the same query term to a search engine. */
+function cleanTerms(terms: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of terms) {
+    const t = raw.trim();
+    const key = t.toLowerCase();
+    if (!t || seen.has(key)) continue;
+    seen.add(key);
+    out.push(t);
+  }
+  return out;
+}
+
+/**
+ * Brand queries for one site: name + aliases, chunked three-per-query.
+ *   brandQueries("reddit.com", "Acme", ["AcmeHQ", "Acme Labs"])
+ *   → ['site:reddit.com ("Acme" OR "AcmeHQ" OR "Acme Labs")']
+ * A brand with 5 aliases costs 2 queries, not 6.
+ */
+export function brandQueries(site: string, brandName: string, aliases: string[] = []): string[] {
+  const terms = cleanTerms([brandName, ...aliases]);
+  if (terms.length === 0) return [];
+  const queries: string[] = [];
+  for (let i = 0; i < terms.length; i += TERMS_PER_QUERY) {
+    queries.push(`site:${site} ${orGroup(terms.slice(i, i + TERMS_PER_QUERY))}`);
+  }
+  return queries;
+}
+
+/**
+ * The topic query for one site: topic name plus its extra keywords, unquoted.
+ * Recall first — precision is recovered downstream, where results that don't
+ * re-verify against a brand term are stored as kind='topic', not dropped.
+ */
+export function topicQuery(site: string, topicName: string, extraKeywords: string[] = []): string {
+  const terms = cleanTerms([topicName, ...extraKeywords]);
+  return `site:${site} ${terms.join(" ")}`;
+}
+
+/**
+ * Which watched sites to query this tick. The primary site (first entry —
+ * reddit.com by default) is queried every tick; secondaries rotate one per
+ * tick round-robin, so cost stays flat no matter how many sites a client
+ * watches. `tick` is any monotonic-ish counter; the collector passes weeks
+ * since epoch, so the rotation advances once per weekly collection.
+ */
+export function sitesForTick(sites: string[], tick: number): string[] {
+  const list = cleanTerms(sites);
+  if (list.length <= 1) return list;
+  const [primary, ...rest] = list;
+  const secondary = rest[((tick % rest.length) + rest.length) % rest.length];
+  return [primary, secondary];
+}

--- a/lib/search/types.ts
+++ b/lib/search/types.ts
@@ -1,0 +1,50 @@
+// Shared contracts for web-search providers. Kept apart from the registry in
+// index.ts so an adapter never has to import the module that imports it.
+
+export type SearchProviderId = "brave";
+
+/** One organic result, normalized across providers. */
+export interface SearchResult {
+  url: string;
+  title: string | null;
+  snippet: string | null;
+  /** 1-based position on the result page — recorded as a rough salience
+   *  signal, compared across sightings by keeping the best. */
+  rank: number;
+}
+
+/** How far back the query looks. "week" is the steady-state collection
+ *  window (a weekly tick with a past-week window misses nothing); "year" is
+ *  the one-time seed run when a project enables the signal, so the feed
+ *  isn't empty for its first week. */
+export type SearchFreshness = "week" | "year";
+
+export interface SearchOptions {
+  freshness?: SearchFreshness;
+  /** Max results to return (provider page-size cap applies, 20 for Brave). */
+  count?: number;
+}
+
+export interface SearchProvider {
+  id: SearchProviderId;
+  label: string;
+  keyUrl: string;
+  keyPrefix: string;
+  /** Run one query. Throws SearchRateLimitError on 429 so the collector can
+   *  back off; throws Error with a human-readable message otherwise. */
+  search(apiKey: string, query: string, opts?: SearchOptions): Promise<SearchResult[]>;
+  /** True when the key is accepted by the provider. Same contract as
+   *  lib/llm's verifyKey: called before a key may be stored. */
+  verifyKey(apiKey: string): Promise<{ ok: boolean; error?: string }>;
+}
+
+/** Thrown on provider 429s. A distinct class because the collector treats
+ *  rate limits differently from every other failure: back off and retry
+ *  once, then stop the tick — the weekly freshness window guarantees the
+ *  next tick loses nothing. */
+export class SearchRateLimitError extends Error {
+  constructor(providerLabel: string) {
+    super(`${providerLabel} rate-limited the request.`);
+    this.name = "SearchRateLimitError";
+  }
+}

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1045,3 +1045,129 @@ $$;
 
 revoke all on function public.record_ops_event(text, text, text, jsonb) from public, anon, authenticated;
 grant execute on function public.record_ops_event(text, text, text, jsonb) to service_role;
+
+-- ---------- web mentions (fourth signal: third-party chatter) --------
+-- Mentions of the brand and its topics on Reddit and other third-party
+-- sites, sourced from a web-search API (Brave first, behind a provider
+-- interface) — NOT the official Reddit API. Named "web mentions" throughout:
+-- `mentions` above already means "brand named inside an LLM answer", and
+-- overloading that word would hurt for years.
+--
+-- Collection is WEEKLY by design (a past-week freshness window on the search
+-- side means a weekly tick loses nothing a daily one would catch), and the
+-- signal is opt-in per project: it spends real search-API money.
+
+-- One watch config per project. `sites` is the per-client watch list — any
+-- third-party host is just an entry here, no per-site integrations.
+-- `exclude_terms` is the name-collision guard (clients named after common
+-- words). `query_budget` caps queries per collection tick: it exists to stop
+-- a runaway config (100 topics x 10 sites), not to shave dollars.
+create table if not exists public.web_mention_watch (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid not null references public.projects (id) on delete cascade,
+  enabled boolean not null default false,
+  sites text[] not null default '{reddit.com}',
+  extra_keywords text[] not null default '{}',
+  exclude_terms text[] not null default '{}',
+  query_budget integer not null default 60,
+  -- Set by the collector on every attempt; the weekly scheduler's due check
+  -- (>= 7 days) reads this, mirroring projects.last_run_at.
+  last_collected_at timestamptz,
+  created_at timestamptz not null default now(),
+  unique (project_id)
+);
+
+-- Collection events. A sibling of `runs`, not a reuse: `runs` has LLM
+-- provider/model baked into NOT NULL checks that make no sense here.
+-- `query_count` is the billing truth — monthly search-API spend is one
+-- aggregate over it.
+create table if not exists public.web_mention_runs (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid not null references public.projects (id) on delete cascade,
+  status text not null default 'running' check (status in ('running', 'completed', 'failed')),
+  query_count integer not null default 0,
+  new_count integer not null default 0,
+  seen_count integer not null default 0,
+  error text,
+  started_at timestamptz not null default now(),
+  finished_at timestamptz,
+  created_at timestamptz not null default now()
+);
+
+-- One row per (project, page). Repeated sightings UPDATE the row
+-- (last_seen_at, seen_count, best rank) instead of duplicating it; the topic
+-- trend is derived from first_seen_at — new mentions per day — which stays
+-- honest because a re-sighting isn't new chatter. `metadata` absorbs future
+-- enrichment (v2: live Reddit scores) without migrations.
+create table if not exists public.web_mentions (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid not null references public.projects (id) on delete cascade,
+  page_key text not null,        -- pageKey(url): host+path, the dedup identity
+  url text not null,
+  domain text not null,          -- e.g. 'reddit.com'
+  title text,
+  snippet text,                  -- search-engine capture at crawl time, goes stale
+  kind text not null check (kind in ('brand', 'topic')),
+  topic_id uuid references public.topics (id) on delete set null,
+  matched_terms text[] not null default '{}',
+  search_rank integer,
+  seen_count integer not null default 1,
+  first_seen_at timestamptz not null default now(),
+  last_seen_at timestamptz not null default now(),
+  discovered_via text not null default 'search' check (discovered_via in ('search', 'llm_citation')),
+  metadata jsonb not null default '{}'::jsonb,
+  unique (project_id, page_key)
+);
+
+-- ---------- search_keys (BYOK web-search credential, encrypted) ------
+-- Same contract as provider_keys: verify against the API first, encrypt
+-- second, persist ciphertext + non-reversible hint only. A separate table
+-- rather than more provider_keys rows for the same reason router_keys is:
+-- a search engine is not an answer engine, and must never widen the LLM
+-- provider allow-list or become a project's default_provider.
+create table if not exists public.search_keys (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users (id) on delete cascade,
+  provider text not null check (provider in ('brave')),
+  label text,
+  encrypted_key text not null,
+  key_hint text not null,
+  created_at timestamptz not null default now(),
+  unique (user_id, provider)
+);
+
+create index if not exists idx_web_mention_watch_project on public.web_mention_watch (project_id);
+create index if not exists idx_web_mention_runs_project on public.web_mention_runs (project_id, created_at desc);
+-- The feed reads newest-activity-first; the summary groups by topic.
+create index if not exists idx_web_mentions_project_seen on public.web_mentions (project_id, last_seen_at desc);
+create index if not exists idx_web_mentions_project_topic on public.web_mentions (project_id, topic_id);
+-- The trend derives from first_seen_at.
+create index if not exists idx_web_mentions_project_first on public.web_mentions (project_id, first_seen_at desc);
+
+alter table public.web_mention_watch enable row level security;
+alter table public.web_mention_runs  enable row level security;
+alter table public.web_mentions      enable row level security;
+alter table public.search_keys       enable row level security;
+
+-- Project children: access allowed when the parent project belongs to the
+-- user, same shape as topics/runs/mentions above. The weekly cron uses the
+-- service-role client and bypasses these, exactly like /api/cron/run.
+drop policy if exists "web_mention_watch_owner" on public.web_mention_watch;
+create policy "web_mention_watch_owner" on public.web_mention_watch
+  for all using (project_id in (select id from public.projects where user_id = auth.uid()))
+  with check (project_id in (select id from public.projects where user_id = auth.uid()));
+
+drop policy if exists "web_mention_runs_owner" on public.web_mention_runs;
+create policy "web_mention_runs_owner" on public.web_mention_runs
+  for all using (project_id in (select id from public.projects where user_id = auth.uid()))
+  with check (project_id in (select id from public.projects where user_id = auth.uid()));
+
+drop policy if exists "web_mentions_owner" on public.web_mentions;
+create policy "web_mentions_owner" on public.web_mentions
+  for all using (project_id in (select id from public.projects where user_id = auth.uid()))
+  with check (project_id in (select id from public.projects where user_id = auth.uid()));
+
+-- search_keys: owned by user, same shape as provider_keys.
+drop policy if exists "search_keys_owner" on public.search_keys;
+create policy "search_keys_owner" on public.search_keys
+  for all using (user_id = auth.uid()) with check (user_id = auth.uid());


### PR DESCRIPTION
## What this is

Foundation PR for the **web-mentions signal** (fourth signal: brand + topic chatter on Reddit and other third-party sites), per the design doc as revised by Mahir's review:

- **Brand-mention tracking is the core** (greenlit)
- **Weekly collection**, not daily — the past-week freshness window means a weekly tick loses nothing, and cost drops to ~$0.50/client/month
- Topic queries are *prioritization for known topics*; discovery of unknown topics comes later via extraction from collected threads, not speculative polling

## Contents

- **Schema** (`supabase/schema.sql`, additive + idempotent): `web_mention_watch` (opt-in per project, per-tick query budget, `last_collected_at` drives the weekly due-check like `projects.last_run_at`), `web_mention_runs` (`query_count` = billing ledger), `web_mentions` (one row per project x page, re-sightings upsert), `search_keys` (BYOK, encrypted, `brave` allow-list). Owner RLS matching the existing policies.
- **`lib/search/`**: `SearchProvider` interface + Brave adapter — normalized results with ranks, `week`/`year` freshness windows, page-size clamp, distinct `SearchRateLimitError` (collector treats 429 as back-off-and-stop; weekly window makes a lost tick free). Pure query builders (`brandQueries` 3-terms-per-OR-chunk, `topicQuery`, `sitesForTick` primary + rotating-secondary) — these encode the cost model, so they're the most-tested part.
- **`lib/search-keys.ts`**: clone of the `provider_keys` contract — verify against the API first, encrypt second, persist ciphertext + non-reversible hint only. Separate table/module so the search allow-list can never widen the LLM provider allow-list (same reasoning as `router_keys`).

No collector, cron, routes, or UI yet — those are the next two PRs, so this stays reviewable.

## Verification

- `tsc --noEmit` clean; `vitest run` 651/651 (20 new tests); lint has only pre-existing warnings.
- Schema block is additive and safe to re-run; it has **not** been applied to the shared database yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
