### PR TITLE
feat(web-mentions): collector + weekly cron

### DIFF
--- a/app/api/cron/web-mentions/route.ts
+++ b/app/api/cron/web-mentions/route.ts
@@ -1,0 +1,149 @@
+import crypto from "node:crypto";
+import { NextResponse } from "next/server";
+import { createServiceClient } from "@/lib/supabase/server";
+import { ConfigurationError } from "@/lib/crypto";
+import { decryptedSearchKey } from "@/lib/search-keys";
+import { collectWebMentions } from "@/lib/web-mentions";
+import { recordOpsError } from "@/lib/ops";
+import type { Project, Topic, WebMentionWatch } from "@/lib/types";
+
+export const maxDuration = 300;
+export const dynamic = "force-dynamic";
+
+// The web-mentions scheduler. A separate cron from /api/cron/run on purpose:
+// the two signals must not share a failure domain or a function clock — a
+// slow LLM portfolio should never cost a search tick, or vice versa.
+//
+// The cron FIRES daily but each project COLLECTS weekly: a project is due
+// when it has never collected or last collected >= 7 days ago. Daily firing
+// self-heals drift (a missed tick delays a project one day, not one week)
+// and spreads projects enabled on different days across the week naturally.
+
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** Cross-project ceiling per tick. A brake against many runaway configs at
+ *  once, not a budget: at Brave's pricing this caps a tick at ~$2. Projects
+ *  left over stay due and collect on the next daily firing. */
+const GLOBAL_QUERY_CEILING = 400;
+
+function isDue(watch: WebMentionWatch, now: number): boolean {
+  if (!watch.last_collected_at) return true;
+  return now - new Date(watch.last_collected_at).getTime() >= WEEK_MS;
+}
+
+interface WatchResult {
+  projectId: string;
+  status: "completed" | "failed" | "skipped";
+  reason?: string;
+  runId?: string;
+  queryCount?: number;
+  newCount?: number;
+  seenCount?: number;
+}
+
+// Same constant-time auth as /api/cron/run, same CRON_SECRET.
+function authorized(header: string | null, secret: string | undefined): boolean {
+  if (!header || !secret) return false;
+  const a = Buffer.from(header);
+  const b = Buffer.from(`Bearer ${secret}`);
+  return a.length === b.length && crypto.timingSafeEqual(a, b);
+}
+
+async function handle(request: Request) {
+  if (!authorized(request.headers.get("authorization"), process.env.CRON_SECRET)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const supabase = createServiceClient();
+  const now = Date.now();
+
+  // Oldest collection first, never-collected before that: the projects that
+  // have waited longest get the global ceiling's headroom first.
+  const { data: watchRows, error: watchErr } = await supabase
+    .from("web_mention_watch")
+    .select("*")
+    .eq("enabled", true)
+    .order("last_collected_at", { ascending: true, nullsFirst: true });
+  if (watchErr) {
+    return NextResponse.json({ error: watchErr.message }, { status: 500 });
+  }
+
+  const watches = ((watchRows ?? []) as WebMentionWatch[]).filter((w) => isDue(w, now));
+  const results: WatchResult[] = [];
+  let remaining = GLOBAL_QUERY_CEILING;
+
+  for (const watch of watches) {
+    if (remaining <= 0) {
+      results.push({ projectId: watch.project_id, status: "skipped", reason: "tick ceiling" });
+      continue;
+    }
+
+    try {
+      const { data: projectRow } = await supabase
+        .from("projects")
+        .select("*")
+        .eq("id", watch.project_id)
+        .maybeSingle();
+      const project = projectRow as Project | null;
+      if (!project) {
+        results.push({ projectId: watch.project_id, status: "skipped", reason: "project gone" });
+        continue;
+      }
+
+      // Strictly self-funded, like scheduled LLM runs: no stored key, no
+      // collection — an unattended schedule can never spend operator money.
+      const apiKey = await decryptedSearchKey(supabase, project.user_id, "brave");
+      if (!apiKey) {
+        results.push({ projectId: watch.project_id, status: "skipped", reason: "no key" });
+        continue;
+      }
+
+      const { data: topicRows } = await supabase
+        .from("topics")
+        .select("*")
+        .eq("project_id", project.id)
+        .order("created_at");
+
+      const result = await collectWebMentions({
+        supabase,
+        project,
+        watch,
+        topics: (topicRows ?? []) as Topic[],
+        apiKey,
+        maxQueries: remaining,
+      });
+      remaining -= result.queryCount;
+      results.push({
+        projectId: watch.project_id,
+        status: result.status,
+        runId: result.runId,
+        queryCount: result.queryCount,
+        newCount: result.newCount,
+        seenCount: result.seenCount,
+        reason: result.error,
+      });
+    } catch (e) {
+      // A stored key this deployment can't decrypt is the operator's problem
+      // (rotated ENCRYPTION_KEY), and must read differently from "no key",
+      // which tells the user to add one they already added.
+      const reason =
+        e instanceof ConfigurationError
+          ? `decryption unavailable: ${e.message}`
+          : e instanceof Error
+            ? e.message
+            : "unknown error";
+      recordOpsError("cron.web-mentions", e, { project_id: watch.project_id });
+      results.push({ projectId: watch.project_id, status: "failed", reason });
+    }
+  }
+
+  return NextResponse.json({ processed: results, dueCount: watches.length });
+}
+
+export async function POST(request: Request) {
+  return handle(request);
+}
+
+export async function GET(request: Request) {
+  return handle(request);
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -262,3 +262,58 @@ export interface ActivityLog {
   metadata: Record<string, unknown>;
   created_at: string;
 }
+
+// ---------- web mentions (fourth signal) ----------
+
+/** Per-project watch config for the web-mentions signal. Off by default:
+ *  collection spends real search-API money. */
+export interface WebMentionWatch {
+  id: string;
+  project_id: string;
+  enabled: boolean;
+  /** Watched hosts; index 0 is the primary (queried every tick), the rest
+   *  rotate one per tick. */
+  sites: string[];
+  extra_keywords: string[];
+  /** Name-collision guard: results matching any of these are dropped. */
+  exclude_terms: string[];
+  /** Max search queries per collection tick — a runaway-config brake. */
+  query_budget: number;
+  last_collected_at: string | null;
+  created_at: string;
+}
+
+/** One collection event. query_count is the billing truth. */
+export interface WebMentionRun {
+  id: string;
+  project_id: string;
+  status: "running" | "completed" | "failed";
+  query_count: number;
+  new_count: number;
+  seen_count: number;
+  error: string | null;
+  started_at: string;
+  finished_at: string | null;
+  created_at: string;
+}
+
+/** One third-party page where the brand or a topic came up. One row per
+ *  (project, page); re-sightings update the row rather than duplicate it. */
+export interface WebMention {
+  id: string;
+  project_id: string;
+  page_key: string;
+  url: string;
+  domain: string;
+  title: string | null;
+  snippet: string | null;
+  kind: "brand" | "topic";
+  topic_id: string | null;
+  matched_terms: string[];
+  search_rank: number | null;
+  seen_count: number;
+  first_seen_at: string;
+  last_seen_at: string;
+  discovered_via: "search" | "llm_citation";
+  metadata: Record<string, unknown>;
+}

--- a/lib/web-mentions.test.ts
+++ b/lib/web-mentions.test.ts
@@ -1,0 +1,343 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  buildQueryPlan,
+  classifyResults,
+  cleanSnippet,
+  collectWebMentions,
+  matchedTerms,
+  mergeSighting,
+} from "@/lib/web-mentions";
+import { SearchRateLimitError } from "@/lib/search/types";
+import type { SearchProvider, SearchResult } from "@/lib/search";
+import type { Project, Topic, WebMentionWatch } from "@/lib/types";
+
+const project = {
+  id: "p1",
+  user_id: "u1",
+  brand_name: "Acme",
+  brand_aliases: ["AcmeHQ"],
+  brand_domains: ["acme.com", "acme-phantom.com"],
+} as Project;
+
+const watch: WebMentionWatch = {
+  id: "w1",
+  project_id: "p1",
+  enabled: true,
+  sites: ["reddit.com"],
+  extra_keywords: [],
+  exclude_terms: ["Acme Insurance"],
+  query_budget: 60,
+  last_collected_at: "2026-07-30T00:00:00Z",
+  created_at: "2026-07-01T00:00:00Z",
+};
+
+const topics: Topic[] = [
+  { id: "t1", project_id: "p1", name: "best crm", description: null, created_at: "" },
+];
+
+function result(url: string, title: string, snippet = "", rank = 1): SearchResult {
+  return { url, title, snippet, rank };
+}
+
+describe("cleanSnippet", () => {
+  it("strips markup, decodes entities, collapses whitespace", () => {
+    expect(cleanSnippet("Try <strong>Acme</strong> &amp; friends  &#39;today&#39;")).toBe(
+      "Try Acme & friends 'today'",
+    );
+  });
+  it("returns null for empty or markup-only input", () => {
+    expect(cleanSnippet(null)).toBeNull();
+    expect(cleanSnippet("<b></b>")).toBeNull();
+  });
+});
+
+describe("classifyResults", () => {
+  it("drops results on the client's own domains, phantoms included", () => {
+    const out = classifyResults(
+      [
+        result("https://acme.com/blog/post", "Acme post"),
+        result("https://www.acme-phantom.com/x", "Acme phantom"),
+        result("https://reddit.com/r/crm/1", "Acme thread"),
+      ],
+      project,
+      watch,
+      topics,
+      null,
+    );
+    expect(out.map((c) => c.domain)).toEqual(["reddit.com"]);
+  });
+
+  it("drops results hitting an exclude term — the name-collision guard", () => {
+    const out = classifyResults(
+      [result("https://reddit.com/r/x/1", "Acme Insurance rates thread")],
+      project,
+      watch,
+      topics,
+      null,
+    );
+    expect(out).toEqual([]);
+  });
+
+  it("never trusts the engine: brand-query results without a verified term are dropped", () => {
+    const out = classifyResults(
+      [result("https://reddit.com/r/x/1", "A thread about acmeish things")],
+      project,
+      watch,
+      topics,
+      null,
+    );
+    expect(out).toEqual([]);
+  });
+
+  it("verifies brand terms word-boundary and records which matched", () => {
+    const out = classifyResults(
+      [result("https://reddit.com/r/x/1", "Comparing AcmeHQ to others", "Acme wins")],
+      project,
+      watch,
+      topics,
+      null,
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].kind).toBe("brand");
+    expect(out[0].matched_terms).toEqual(["Acme", "AcmeHQ"]);
+  });
+
+  it("keeps topic-query results without a brand term as kind=topic with the query's topic", () => {
+    const out = classifyResults(
+      [result("https://reddit.com/r/crm/2", "What is the best crm for freelancers?")],
+      project,
+      watch,
+      topics,
+      "t1",
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ kind: "topic", topic_id: "t1", matched_terms: [] });
+  });
+
+  it("upgrades a topic-query result to brand when the brand appears", () => {
+    const out = classifyResults(
+      [result("https://reddit.com/r/crm/3", "best crm?", "I use Acme")],
+      project,
+      watch,
+      topics,
+      "t1",
+    );
+    expect(out[0]).toMatchObject({ kind: "brand", topic_id: "t1" });
+  });
+
+  it("assigns brand-query results a topic by name pass, else leaves unassigned", () => {
+    const out = classifyResults(
+      [
+        result("https://reddit.com/r/a/1", "Acme is the best crm around"),
+        result("https://reddit.com/r/a/2", "Acme raised a round"),
+      ],
+      project,
+      watch,
+      topics,
+      null,
+    );
+    expect(out[0].topic_id).toBe("t1");
+    expect(out[1].topic_id).toBeNull();
+  });
+
+  it("drops unparseable URLs", () => {
+    expect(classifyResults([result("::::", "Acme")], project, watch, topics, null)).toEqual([]);
+  });
+});
+
+describe("mergeSighting", () => {
+  const existing = {
+    kind: "topic" as const,
+    topic_id: null,
+    matched_terms: [],
+    search_rank: 9,
+    seen_count: 2,
+  };
+  const fresh = {
+    page_key: "reddit.com/r/x/1",
+    url: "https://reddit.com/r/x/1",
+    domain: "reddit.com",
+    title: "t",
+    snippet: "s",
+    kind: "brand" as const,
+    topic_id: "t1",
+    matched_terms: ["Acme"],
+    search_rank: 3,
+  };
+
+  it("upgrades kind, fills topic, unions terms, keeps best rank, bumps seen_count", () => {
+    expect(mergeSighting(existing, fresh, "2026-08-06T00:00:00Z")).toMatchObject({
+      kind: "brand",
+      topic_id: "t1",
+      matched_terms: ["Acme"],
+      search_rank: 3,
+      seen_count: 3,
+      last_seen_at: "2026-08-06T00:00:00Z",
+    });
+  });
+
+  it("never downgrades brand to topic and never replaces an assigned topic", () => {
+    const merged = mergeSighting(
+      { ...existing, kind: "brand", topic_id: "t-old", search_rank: 2 },
+      { ...fresh, kind: "topic", topic_id: "t-new", search_rank: 5 },
+      "now",
+    );
+    expect(merged).toMatchObject({ kind: "brand", topic_id: "t-old", search_rank: 2 });
+  });
+
+  it("treats a null rank as worse than any real rank", () => {
+    expect(mergeSighting({ ...existing, search_rank: null }, fresh, "now").search_rank).toBe(3);
+    expect(
+      mergeSighting(existing, { ...fresh, search_rank: null }, "now").search_rank,
+    ).toBe(9);
+  });
+});
+
+describe("buildQueryPlan", () => {
+  it("brand queries first, then one topic query per site", () => {
+    const plan = buildQueryPlan(project, watch, topics, 0);
+    expect(plan).toEqual([
+      { query: 'site:reddit.com ("Acme" OR "AcmeHQ")', topicId: null },
+      { query: "site:reddit.com best crm", topicId: "t1" },
+    ]);
+  });
+
+  it("applies the primary + rotating-secondary site rule", () => {
+    const multi = { ...watch, sites: ["reddit.com", "news.ycombinator.com", "x.com"] };
+    const plan = buildQueryPlan(project, multi, topics, 0);
+    const sitesUsed = new Set(plan.map((p) => p.query.split(" ")[0]));
+    expect(sitesUsed).toEqual(new Set(["site:reddit.com", "site:news.ycombinator.com"]));
+  });
+});
+
+// ---- collectWebMentions against a fake db + provider ----
+
+function fakeDb(existing: { page_key: string }[] = []) {
+  const calls: Record<string, unknown[]> = { runUpdates: [], mentionUpdates: [], upserts: [], watchUpdates: [] };
+  const db = {
+    from(table: string) {
+      return {
+        insert: () => ({
+          select: () => ({ single: async () => ({ data: { id: "run-1" }, error: null }) }),
+        }),
+        select: () => ({
+          eq: () => ({ in: async () => ({ data: existing, error: null }) }),
+        }),
+        update: (values: unknown) => ({
+          eq: async () => {
+            if (table === "web_mention_runs") calls.runUpdates.push(values);
+            if (table === "web_mentions") calls.mentionUpdates.push(values);
+            if (table === "web_mention_watch") calls.watchUpdates.push(values);
+            return { error: null };
+          },
+        }),
+        upsert: async (rows: unknown) => {
+          calls.upserts.push(rows);
+          return { error: null };
+        },
+      };
+    },
+  };
+  return { db: db as never, calls };
+}
+
+function fakeProvider(fn: (query: string) => SearchResult[]): SearchProvider {
+  return {
+    id: "brave",
+    label: "Fake",
+    keyUrl: "",
+    keyPrefix: "",
+    search: vi.fn(async (_key: string, query: string) => fn(query)),
+    verifyKey: async () => ({ ok: true }),
+  };
+}
+
+const base = { apiKey: "k", pauseMs: 0, backoffMs: 0, now: () => Date.parse("2026-08-06T12:00:00Z") };
+
+describe("collectWebMentions", () => {
+  it("stores new mentions, settles the run, stamps the watch", async () => {
+    const { db, calls } = fakeDb();
+    const provider = fakeProvider((q) =>
+      q.includes('"Acme"') ? [result("https://reddit.com/r/x/1", "Acme thread")] : [],
+    );
+    const out = await collectWebMentions({
+      supabase: db, project, watch, topics, provider, ...base,
+    });
+    expect(out).toMatchObject({ status: "completed", queryCount: 2, newCount: 1, seenCount: 0 });
+    expect(calls.upserts).toHaveLength(1);
+    expect((calls.upserts[0] as unknown[])[0]).toMatchObject({ project_id: "p1", kind: "brand" });
+    expect(calls.runUpdates[0]).toMatchObject({ status: "completed", query_count: 2, new_count: 1 });
+    expect(calls.watchUpdates).toHaveLength(1);
+  });
+
+  it("merges re-sightings instead of inserting duplicates", async () => {
+    const { db, calls } = fakeDb([
+      { page_key: "reddit.com/r/x/1", kind: "topic", topic_id: null, matched_terms: [], search_rank: 9, seen_count: 1, id: "m1" } as never,
+    ]);
+    const provider = fakeProvider((q) =>
+      q.includes('"Acme"') ? [result("https://reddit.com/r/x/1", "Acme thread", "", 2)] : [],
+    );
+    const out = await collectWebMentions({
+      supabase: db, project, watch, topics, provider, ...base,
+    });
+    expect(out).toMatchObject({ newCount: 0, seenCount: 1 });
+    expect(calls.upserts).toHaveLength(0);
+    expect(calls.mentionUpdates[0]).toMatchObject({ kind: "brand", seen_count: 2, search_rank: 2 });
+  });
+
+  it("uses the year window on the seed run and the week window after", async () => {
+    const { db } = fakeDb();
+    const provider = fakeProvider(() => []);
+    await collectWebMentions({
+      supabase: db, project, watch: { ...watch, last_collected_at: null }, topics, provider, ...base,
+    });
+    expect((provider.search as ReturnType<typeof vi.fn>).mock.calls[0][2]).toEqual({ freshness: "year" });
+    await collectWebMentions({ supabase: db, project, watch, topics, provider, ...base });
+    expect((provider.search as ReturnType<typeof vi.fn>).mock.calls.at(-1)![2]).toEqual({ freshness: "week" });
+  });
+
+  it("stops the tick after a backed-off retry is still rate-limited", async () => {
+    const { db, calls } = fakeDb();
+    const provider: SearchProvider = {
+      ...fakeProvider(() => []),
+      search: vi.fn(async () => {
+        throw new SearchRateLimitError("Fake");
+      }),
+    };
+    const out = await collectWebMentions({
+      supabase: db, project, watch, topics, provider, ...base,
+    });
+    // First plan step: attempt + one retry, then stop — the second step never runs.
+    expect(provider.search).toHaveBeenCalledTimes(2);
+    expect(out.error).toMatch(/rate-limited/);
+    expect(calls.runUpdates[0]).toMatchObject({ status: "completed" });
+  });
+
+  it("respects the per-tick allowance and says what it dropped", async () => {
+    const { db } = fakeDb();
+    const provider = fakeProvider(() => []);
+    const out = await collectWebMentions({
+      supabase: db, project, watch, topics, provider, ...base, maxQueries: 1,
+    });
+    expect(out.queryCount).toBe(1);
+    expect(out.error).toMatch(/query budget \(1 of 2 planned\)/);
+  });
+
+  it("skips a failing query but lets the first failure narrate the run", async () => {
+    const { db } = fakeDb();
+    let n = 0;
+    const provider: SearchProvider = {
+      ...fakeProvider(() => []),
+      search: vi.fn(async () => {
+        n++;
+        if (n === 1) throw new Error("HTTP 500 from provider");
+        return [result("https://reddit.com/r/crm/9", "best crm talk")];
+      }),
+    };
+    const out = await collectWebMentions({
+      supabase: db, project, watch, topics, provider, ...base,
+    });
+    expect(out).toMatchObject({ status: "completed", queryCount: 2, newCount: 1 });
+    expect(out.error).toMatch(/HTTP 500/);
+  });
+});

--- a/lib/web-mentions.ts
+++ b/lib/web-mentions.ts
@@ -1,0 +1,365 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { hostOf, isOwnedDomain } from "@/lib/engine";
+import { brandTerms, detectMention } from "@/lib/mentions";
+import { pageKey } from "@/lib/metrics";
+import { recordOps, recordOpsError } from "@/lib/ops";
+import { SEARCH_PROVIDERS, SearchRateLimitError } from "@/lib/search";
+import type { SearchProvider, SearchResult } from "@/lib/search";
+import { brandQueries, sitesForTick, topicQuery } from "@/lib/search/query";
+import type { Project, Topic, WebMention, WebMentionWatch } from "@/lib/types";
+
+// ==================================================================
+// The web-mentions collector: one project, one tick.
+//
+// Runs the site-scoped brand and topic queries through a search provider,
+// filters what comes back (owned domains out, exclude-terms out), re-verifies
+// every result with the same word-boundary matcher the AI Answers signal
+// uses — never the search engine's own matching — and upserts one row per
+// (project, page). Re-sightings update the row; the topic trend derives from
+// first_seen_at, which an update never touches.
+//
+// Collection is WEEKLY: each steady-state tick queries a past-week window,
+// so a lost tick costs nothing but latency. The first tick after enabling
+// (last_collected_at null) is the seed run — a past-year window, so the feed
+// isn't empty for its first week.
+// ==================================================================
+
+/** Between queries, to stay under provider per-second limits (Brave's free
+ *  tier allows 1/s). The budget caps a tick at ~a minute of spacing, well
+ *  inside the route ceiling. */
+const QUERY_SPACING_MS = 1100;
+
+/** One retry after one backoff on a 429; a second 429 ends the tick early.
+ *  The weekly window guarantees the next tick recovers anything missed. */
+const RATE_LIMIT_BACKOFF_MS = 2500;
+
+export interface CollectParams {
+  supabase: SupabaseClient;
+  project: Project;
+  watch: WebMentionWatch;
+  topics: Topic[];
+  apiKey: string;
+  /** Cross-project ceiling for this cron tick; the collector never exceeds
+   *  min(watch.query_budget, maxQueries). Defaults to the watch budget. */
+  maxQueries?: number;
+  /** Test seams. Callers outside tests leave these unset. */
+  provider?: SearchProvider;
+  pauseMs?: number;
+  backoffMs?: number;
+  now?: () => number;
+}
+
+export interface CollectResult {
+  runId: string;
+  status: "completed" | "failed";
+  queryCount: number;
+  newCount: number;
+  seenCount: number;
+  /** Set when the tick ended early or failed; stored on the run row. */
+  error?: string;
+}
+
+const sleep = (ms: number) => (ms > 0 ? new Promise((r) => setTimeout(r, ms)) : Promise.resolve());
+
+/** Brave descriptions carry markup (<strong>…) and entities; the matcher
+ *  needs prose. Tags out, the few common entities decoded, whitespace
+ *  collapsed. */
+export function cleanSnippet(raw: string | null): string | null {
+  if (!raw) return null;
+  const text = raw
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&#0?39;|&apos;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/\s+/g, " ")
+    .trim();
+  return text || null;
+}
+
+/** Which of `terms` actually appear in the text, word-boundary matched.
+ *  Recorded on the row so a human can catch a bad alias at a glance. */
+export function matchedTerms(text: string, terms: string[]): string[] {
+  return terms.filter((t) => detectMention(text, [t]).mentioned);
+}
+
+/** The planned queries for one tick, in execution order: brand queries first
+ *  (they can upgrade rows the topic queries created, never the reverse), then
+ *  one query per topic. Each entry carries the topic it inherits. */
+export function buildQueryPlan(
+  project: Project,
+  watch: WebMentionWatch,
+  topics: Topic[],
+  tick: number,
+): { query: string; topicId: string | null }[] {
+  const sites = sitesForTick(watch.sites, tick);
+  const plan: { query: string; topicId: string | null }[] = [];
+  for (const site of sites) {
+    for (const q of brandQueries(site, project.brand_name, project.brand_aliases)) {
+      plan.push({ query: q, topicId: null });
+    }
+  }
+  for (const site of sites) {
+    for (const topic of topics) {
+      plan.push({ query: topicQuery(site, topic.name, watch.extra_keywords), topicId: topic.id });
+    }
+  }
+  return plan;
+}
+
+interface Candidate {
+  page_key: string;
+  url: string;
+  domain: string;
+  title: string | null;
+  snippet: string | null;
+  kind: "brand" | "topic";
+  topic_id: string | null;
+  matched_terms: string[];
+  search_rank: number | null;
+}
+
+/**
+ * Turn one query's results into storable candidates. Exported for tests:
+ * this is where every filtering decision lives.
+ */
+export function classifyResults(
+  results: SearchResult[],
+  project: Project,
+  watch: WebMentionWatch,
+  topics: Topic[],
+  queryTopicId: string | null,
+): Candidate[] {
+  const terms = brandTerms(project.brand_name, project.brand_aliases);
+  const out: Candidate[] = [];
+  for (const r of results) {
+    const key = pageKey(r.url);
+    if (!key) continue;
+
+    // Chatter on the client's own sites (main domain AND phantoms) is not
+    // third-party chatter.
+    const domain = hostOf(r.url);
+    if (project.brand_domains.some((d) => isOwnedDomain(domain, hostOf(d)))) continue;
+
+    const title = cleanSnippet(r.title);
+    const snippet = cleanSnippet(r.snippet);
+    const text = [title, snippet].filter(Boolean).join(" ");
+
+    // The name-collision guard: one hit on an exclude term drops the page.
+    if (watch.exclude_terms.length > 0 && detectMention(text, watch.exclude_terms).mentioned) {
+      continue;
+    }
+
+    // Never trust the search engine's matching: a result only counts as a
+    // brand mention if OUR matcher sees a brand term in the text. Topic-query
+    // results without one still count — as topic chatter, which is what the
+    // query asked about.
+    const matched = matchedTerms(text, terms);
+    const isBrand = matched.length > 0;
+    if (!isBrand && queryTopicId === null) continue; // brand query, no verified brand term
+
+    // Query inheritance first (deterministic, free); brand-query results get
+    // a keyword pass against topic names so obvious ones don't land in the
+    // unassigned bucket.
+    let topicId = queryTopicId;
+    if (topicId === null) {
+      topicId = topics.find((t) => detectMention(text, [t.name]).mentioned)?.id ?? null;
+    }
+
+    out.push({
+      page_key: key,
+      url: r.url,
+      domain,
+      title,
+      snippet,
+      kind: isBrand ? "brand" : "topic",
+      topic_id: topicId,
+      matched_terms: matched,
+      search_rank: r.rank,
+    });
+  }
+  return out;
+}
+
+/** Merge a fresh sighting onto what is already stored. Kind only ever
+ *  upgrades to brand; rank keeps the best (lowest); the crawl-time capture
+ *  (title/snippet) refreshes to the newest; first_seen_at is never touched. */
+export function mergeSighting(
+  existing: Pick<WebMention, "kind" | "topic_id" | "matched_terms" | "search_rank" | "seen_count">,
+  fresh: Candidate,
+  nowIso: string,
+): Partial<WebMention> {
+  return {
+    url: fresh.url,
+    title: fresh.title,
+    snippet: fresh.snippet,
+    kind: existing.kind === "brand" || fresh.kind === "brand" ? "brand" : "topic",
+    topic_id: existing.topic_id ?? fresh.topic_id,
+    matched_terms: [...new Set([...existing.matched_terms, ...fresh.matched_terms])],
+    search_rank:
+      existing.search_rank === null || fresh.search_rank === null
+        ? (existing.search_rank ?? fresh.search_rank)
+        : Math.min(existing.search_rank, fresh.search_rank),
+    seen_count: existing.seen_count + 1,
+    last_seen_at: nowIso,
+  };
+}
+
+/**
+ * Collect web mentions for one project. Settles its own run row on every
+ * path and stamps watch.last_collected_at on every attempt — a failing
+ * config must wait for the next weekly tick like everyone else, not hot-loop.
+ */
+export async function collectWebMentions(params: CollectParams): Promise<CollectResult> {
+  const { supabase, project, watch, topics, apiKey } = params;
+  const provider = params.provider ?? SEARCH_PROVIDERS.brave;
+  const pauseMs = params.pauseMs ?? QUERY_SPACING_MS;
+  const backoffMs = params.backoffMs ?? RATE_LIMIT_BACKOFF_MS;
+  const now = params.now ?? Date.now;
+
+  const { data: runRow, error: runErr } = await supabase
+    .from("web_mention_runs")
+    .insert({ project_id: project.id })
+    .select("id")
+    .single();
+  if (runErr || !runRow) {
+    return {
+      runId: "",
+      status: "failed",
+      queryCount: 0,
+      newCount: 0,
+      seenCount: 0,
+      error: runErr?.message || "Could not create the collection run.",
+    };
+  }
+  const runId = (runRow as { id: string }).id;
+
+  const seed = watch.last_collected_at === null;
+  const freshness = seed ? ("year" as const) : ("week" as const);
+  const tick = Math.floor(now() / (7 * 24 * 60 * 60 * 1000));
+  const budget = Math.max(0, Math.min(watch.query_budget, params.maxQueries ?? Infinity));
+
+  const plan = buildQueryPlan(project, watch, topics, tick);
+  const truncated = plan.length > budget;
+  const toRun = plan.slice(0, budget);
+
+  let queryCount = 0;
+  let newCount = 0;
+  let seenCount = 0;
+  let stoppedEarly: string | null = null;
+  let hardError: string | null = null;
+
+  for (const step of toRun) {
+    if (queryCount > 0) await sleep(pauseMs);
+    let results: SearchResult[];
+    try {
+      try {
+        queryCount++;
+        results = await provider.search(apiKey, step.query, { freshness });
+      } catch (err) {
+        if (!(err instanceof SearchRateLimitError)) throw err;
+        await sleep(backoffMs);
+        queryCount++;
+        results = await provider.search(apiKey, step.query, { freshness });
+      }
+    } catch (err) {
+      if (err instanceof SearchRateLimitError) {
+        // Still limited after one backoff: end the tick. What was stored is
+        // real; the weekly window recovers the rest next tick.
+        stoppedEarly = "Stopped early: the search provider rate-limited the collection.";
+        recordOps("web_mentions.rate_limited", {
+          level: "warn",
+          signature: "web_mentions.rate_limited",
+        });
+        break;
+      }
+      // Any other failure: skip this query, keep the tick alive, and let the
+      // FIRST failure narrate the run — mirroring how LLM runs report.
+      if (!hardError) hardError = err instanceof Error ? err.message : "Search query failed.";
+      recordOpsError("web-mentions.query", err, { project_id: project.id });
+      continue;
+    }
+
+    const candidates = classifyResults(results, project, watch, topics, step.topicId);
+    if (candidates.length === 0) continue;
+
+    // Read what we already have for these pages, then split into inserts and
+    // per-row merges. Not a blind upsert: seen_count increments, kind only
+    // upgrades, and rank keeps the best — none of which a set-style upsert
+    // can express.
+    const keys = candidates.map((c) => c.page_key);
+    const { data: existingRows } = await supabase
+      .from("web_mentions")
+      .select("id, page_key, kind, topic_id, matched_terms, search_rank, seen_count")
+      .eq("project_id", project.id)
+      .in("page_key", keys);
+    const byKey = new Map(
+      ((existingRows ?? []) as (Pick<
+        WebMention,
+        "id" | "page_key" | "kind" | "topic_id" | "matched_terms" | "search_rank" | "seen_count"
+      >)[]).map((r) => [r.page_key, r]),
+    );
+
+    const nowIso = new Date(now()).toISOString();
+    const inserts: (Candidate & { project_id: string })[] = [];
+    for (const c of candidates) {
+      const existing = byKey.get(c.page_key);
+      if (!existing) {
+        inserts.push({ ...c, project_id: project.id });
+        continue;
+      }
+      const { error } = await supabase
+        .from("web_mentions")
+        .update(mergeSighting(existing, c, nowIso))
+        .eq("id", existing.id);
+      if (!error) seenCount++;
+    }
+    if (inserts.length > 0) {
+      // Two queries in one tick can both surface a page the table has never
+      // seen; the second insert must merge, not die on the unique constraint.
+      const { error } = await supabase
+        .from("web_mentions")
+        .upsert(inserts, { onConflict: "project_id,page_key", ignoreDuplicates: false });
+      if (error) {
+        if (!hardError) hardError = error.message;
+        recordOpsError("web-mentions.store", error, { project_id: project.id });
+      } else {
+        newCount += inserts.length;
+      }
+    }
+  }
+
+  const notes = [
+    stoppedEarly,
+    truncated ? `Stopped at the query budget (${toRun.length} of ${plan.length} planned).` : null,
+    hardError,
+  ].filter(Boolean);
+  const status: CollectResult["status"] =
+    queryCount > 0 && (newCount > 0 || seenCount > 0 || !hardError) ? "completed" : "failed";
+
+  await supabase
+    .from("web_mention_runs")
+    .update({
+      status,
+      query_count: queryCount,
+      new_count: newCount,
+      seen_count: seenCount,
+      error: notes.length > 0 ? notes.join(" ") : null,
+      finished_at: new Date(now()).toISOString(),
+    })
+    .eq("id", runId);
+  await supabase
+    .from("web_mention_watch")
+    .update({ last_collected_at: new Date(now()).toISOString() })
+    .eq("id", watch.id);
+
+  return {
+    runId,
+    status,
+    queryCount,
+    newCount,
+    seenCount,
+    error: notes.length > 0 ? notes.join(" ") : undefined,
+  };
+}

--- a/vercel.json
+++ b/vercel.json
@@ -4,6 +4,10 @@
     {
       "path": "/api/cron/run",
       "schedule": "0 8 * * *"
+    },
+    {
+      "path": "/api/cron/web-mentions",
+      "schedule": "0 9 * * *"
     }
   ]
 }


### PR DESCRIPTION
## What this is

PR 2 of the web-mentions signal — the working half. Replaces #103, which GitHub auto-closed when its stacked base branch was deleted after #102 merged; this is the same commit rebased onto master.

## Contents

- **`lib/web-mentions.ts` — the collector.** Builds the tick's query plan (brand queries first so they can upgrade rows topic queries created; primary site every tick, secondaries rotate one per tick), runs it with 1.1s spacing, and per result: `pageKey` normalize -> drop owned domains (phantoms included) -> drop exclude-term hits -> **re-verify with `detectMention`/`brandTerms`** — a result counts as a brand mention only if our word-boundary matcher sees a brand term, never because the search engine matched it. Re-sightings merge instead of duplicate: `seen_count`++, `kind` only upgrades topic->brand, best rank wins, `first_seen_at` never touched (the topic trend derives from it). Seed run on first collection uses a past-year window; steady state past-week. A 429 backs off once, retries, and if still limited ends the tick — the weekly window recovers everything next tick. Any other query failure skips that query and narrates the run via its first error, mirroring LLM runs. Budget truncation is named on the run row — no silent caps.
- **`app/api/cron/web-mentions/route.ts`** — fires daily, collects weekly per project (`last_collected_at` >= 7 days, never-collected first). Oldest-first under a 400-query global per-tick ceiling; leftover projects stay due and collect the next day. Strictly self-funded like scheduled LLM runs: no stored Brave key, no collection. `ConfigurationError` (key stored but not decryptable — operator problem) reads differently from "no key" (user problem). Same constant-time `CRON_SECRET` auth as `/api/cron/run`, separate cron entry at 09:00 UTC so the two signals never share a failure domain or a function clock.
- Row types (`WebMentionWatch`, `WebMentionRun`, `WebMention`) in `lib/types.ts`; `vercel.json` cron entry.

## Verification

- `tsc --noEmit` clean; `vitest run` **672/672** on the rebased branch (21 new tests: classification matrix, merge semantics, plan shape, collector loop against a fake db + provider — budget stop, rate-limit stop, seed-vs-weekly freshness, failure narration).
- The schema this rides on is applied to the shared DB and was live-tested after #102 (constraints, upsert merge, RLS, cascade).

Remaining for PR 3: the five `/api/v1` routes + settings/feed UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
