### PR TITLE
feat(landing): auto-scrolling reviews carousel above the final CTA

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,6 +16,7 @@ import { Badge, Button, Card } from "@/components/ui";
 import { Logo } from "@/components/logo";
 import { ThemeToggle } from "@/components/theme";
 import { InstallCli } from "@/components/install-cli";
+import { Reviews } from "@/components/reviews";
 
 const GITHUB_URL = "https://github.com/letterstory/lettertrace";
 
@@ -160,6 +161,7 @@ export default function LandingPage() {
             <a href="#how" className="transition hover:text-ink">How it works</a>
             <a href="#features" className="transition hover:text-ink">Features</a>
             <a href="#open-source" className="transition hover:text-ink">Open source</a>
+            <a href="#reviews" className="transition hover:text-ink">Reviews</a>
           </nav>
           <div className="flex items-center gap-2">
             <a
@@ -339,6 +341,9 @@ export default function LandingPage() {
         </div>
       </section>
 
+      {/* Reviews */}
+      <Reviews />
+
       {/* Final CTA */}
       <section className="relative overflow-hidden">
         <div className="pointer-events-none absolute left-1/2 top-0 h-64 w-[36rem] -translate-x-1/2 rounded bg-terracotta/50 glow-blob" />
@@ -373,6 +378,7 @@ export default function LandingPage() {
               { label: "How it works", href: "#how" },
               { label: "Features", href: "#features" },
               { label: "Open source", href: "#open-source" },
+              { label: "Reviews", href: "#reviews" },
             ]}
           />
           <FooterCol

--- a/components/reviews.tsx
+++ b/components/reviews.tsx
@@ -1,0 +1,237 @@
+import { Star } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+// ------------------------------------------------------------------
+// Landing-page social proof: a single marquee row of review cards.
+//
+// ⚠️ MOCK COPY — the reviews below are written placeholders standing in for
+// the real Product Hunt / customer quotes. Swap `REVIEWS` wholesale (names,
+// roles, and bodies) once the real ones land; nothing else needs to change.
+//
+// Layout follows what actually converts for a launch-stage page: a small
+// aggregate line, then individually readable reviews a visitor can stop and
+// read — hover or keyboard focus pauses the drift — rather than a slideshow
+// nobody clicks through. Sits directly above the final CTA, where social
+// proof does the most work.
+// ------------------------------------------------------------------
+
+type Review = {
+  name: string;
+  /** Avatar-tile glyph, normally the reviewer's initials. */
+  initials: string;
+  role: string;
+  stars: 4 | 5;
+  body: string;
+  tone: keyof typeof toneTile;
+};
+
+const toneTile = {
+  terracotta: "bg-terracotta/12 text-terracotta-dark",
+  teal: "bg-teal/15 text-teal-dark",
+  mint: "bg-mint-tint text-mint-ink",
+  butter: "bg-butter-tint text-butter-ink",
+  sand: "bg-sand-tint text-ink-soft",
+} as const;
+
+const REVIEWS: Review[] = [
+  {
+    name: "Dana R.",
+    initials: "DR",
+    role: "Head of growth · B2B SaaS",
+    stars: 5,
+    tone: "terracotta",
+    body:
+      "Went in assuming I'd hit a “talk to sales” wall inside five minutes, because that's exactly what happened with the last two AEO tools I tried. It never came. Pointed it at my own Anthropic key, added six topics, had a first run back in under ten minutes. Three weeks in and the only thing I've changed is adding a competitor. The bring-your-own-key part is why I'm still here — I moved one project from Claude to Gemini just to see whether the answers diverged, and it cost nothing extra on Lettertrace's end, because they aren't in the billing path at all.",
+  },
+  {
+    name: "Priya N.",
+    initials: "PN",
+    role: "Content lead · Series A fintech",
+    stars: 4,
+    tone: "teal",
+    body:
+      "Someone dropped this in our growth channel. I track four topics and get a weekly run telling me whether we're in the answer or not. That's the whole use case. Took about two minutes. I'd like Perplexity in the mix eventually, but it already replaced a spreadsheet I hated maintaining.",
+  },
+  {
+    name: "Tom W.",
+    initials: "TW",
+    role: "Founder · dev tools",
+    stars: 5,
+    tone: "mint",
+    body:
+      "Share of voice against our three named competitors was the one number I couldn't get anywhere else without signing a $2k/mo contract. Ran it, got it, screenshotted it into the board deck the same afternoon.",
+  },
+  {
+    name: "Alex K.",
+    initials: "AK",
+    role: "Staff engineer · marketplace",
+    stars: 4,
+    tone: "butter",
+    body:
+      "Almost skipped it. I already script my own eval runs against the raw APIs and figured a wrapper wouldn't add much. What got me was the variation generation — one topic becomes twenty questions that actually sound like what a person types, and I was never going to hand-write those every week. Reading the source before signing up didn't hurt either. Only real gripe: CSV export doesn't break out per-model columns yet.",
+  },
+  {
+    name: "Sofia M.",
+    initials: "SM",
+    role: "Platform engineer · healthtech",
+    stars: 5,
+    tone: "sand",
+    body:
+      "Self-hosted onto our own Supabase in an afternoon. Clone, env vars, deploy. Our data never leaves our infrastructure, which is the only reason legal signed off on any of this.",
+  },
+  {
+    name: "Ben A.",
+    initials: "BA",
+    role: "VP marketing · B2B SaaS",
+    stars: 5,
+    tone: "terracotta",
+    body:
+      "Being mentioned and being recommended are not the same thing, and this is the first tool I've used that tells them apart. Turned out we showed up in about 60% of answers and got hedged in most of them. That one distinction changed everything we published last quarter.",
+  },
+  {
+    name: "Marcus O.",
+    initials: "MO",
+    role: "SEO lead · agency",
+    stars: 4,
+    tone: "teal",
+    body:
+      "The trend line is the actual product. One run is a curiosity; eight weekly runs is a chart I can walk into a planning meeting with. Setup took longer than the 60 seconds I'd assumed — closer to ten minutes once you count keys and topics — but it has run itself ever since.",
+  },
+  {
+    name: "Elena V.",
+    initials: "EV",
+    role: "Solo founder",
+    stars: 5,
+    tone: "mint",
+    body:
+      "Total spend so far is whatever the model calls cost me, which is somewhere around $3. I kept waiting for the free tier to reveal itself as a trial. It hasn't.",
+  },
+];
+
+const AVERAGE = REVIEWS.reduce((sum, r) => sum + r.stars, 0) / REVIEWS.length;
+
+function Stars({ n }: { n: number }) {
+  return (
+    <span className="flex items-center gap-0.5" aria-label={`${n} out of 5 stars`}>
+      {Array.from({ length: 5 }, (_, i) => (
+        <Star
+          key={i}
+          aria-hidden
+          className={cn(
+            "h-3.5 w-3.5",
+            i < n ? "fill-terracotta text-terracotta" : "fill-ink/10 text-ink/10",
+          )}
+        />
+      ))}
+    </span>
+  );
+}
+
+function ReviewCard({ review }: { review: Review }) {
+  return (
+    <figure className="flex w-[19rem] shrink-0 flex-col rounded border border-ink/10 bg-surface p-5 shadow-card transition hover:border-ink/25 hover:shadow-lift sm:w-[22rem]">
+      <Stars n={review.stars} />
+      <blockquote className="mt-3 flex-1 text-sm leading-relaxed text-ink-soft">
+        {review.body}
+      </blockquote>
+      <figcaption className="mt-5 flex items-center gap-3 border-t border-ink/[0.07] pt-4">
+        <span
+          className={cn(
+            "flex h-9 w-9 shrink-0 items-center justify-center rounded font-mono text-[11px] font-medium",
+            toneTile[review.tone],
+          )}
+          aria-hidden
+        >
+          {review.initials}
+        </span>
+        <span className="min-w-0">
+          <span className="block truncate text-sm font-medium text-ink">{review.name}</span>
+          <span className="block truncate text-xs text-ink-faint">{review.role}</span>
+        </span>
+      </figcaption>
+    </figure>
+  );
+}
+
+/**
+ * The drifting row.
+ *
+ * The cards are rendered twice: the first copy is the real content, the second
+ * is `aria-hidden` scenery whose only job is to be under the viewport edge at
+ * the moment the track snaps back, so a screen reader hears eight reviews
+ * rather than sixteen.
+ *
+ * Motion stops on hover *and* on focus-within — a keyboard user tabbing into a
+ * card must not have it slide out from under them — and stops entirely under
+ * `prefers-reduced-motion`, where the row degrades to an ordinary horizontally
+ * scrollable strip.
+ */
+function MarqueeRow({ items, duration }: { items: Review[]; duration: string }) {
+  return (
+    <div className="group flex overflow-x-auto pb-2 [-ms-overflow-style:none] [scrollbar-width:none] motion-safe:overflow-hidden [&::-webkit-scrollbar]:hidden">
+      {/* No gap on the track itself, and a trailing `pr-5` on each half. That
+          makes one half exactly (n cards + n gaps) wide, so -50% lands the
+          duplicate precisely where the original began. Putting the gap on the
+          track instead leaves the seam half a gap short, and the row visibly
+          hitches once per loop. */}
+      <div
+        className={cn(
+          "flex w-max motion-safe:animate-marquee",
+          "motion-safe:group-hover:[animation-play-state:paused]",
+          "motion-safe:group-focus-within:[animation-play-state:paused]",
+        )}
+        style={{ animationDuration: duration }}
+      >
+        <div className="flex gap-5 pr-5">
+          {items.map((r) => (
+            <ReviewCard key={r.name} review={r} />
+          ))}
+        </div>
+        <div className="flex gap-5 pr-5" aria-hidden>
+          {items.map((r) => (
+            <ReviewCard key={`${r.name}-dup`} review={r} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function Reviews() {
+  return (
+    // Plain paper, not the `paper-shade` band used above it — the open-source
+    // section is already shaded, and two shaded bands in a row read as one.
+    <section id="reviews" className="border-t border-ink/10 bg-paper py-20">
+      <div className="mx-auto max-w-6xl px-5">
+        <div className="max-w-2xl">
+          <p className="mono-eyebrow">reviews</p>
+          <h2 className="mt-3 text-3xl font-semibold text-ink sm:text-4xl">
+            Teams who stopped guessing.
+          </h2>
+          <p className="mt-4 text-ink-soft">
+            Marketers, founders, and engineers using Lettertrace to see how AI assistants
+            answer questions about them.
+          </p>
+        </div>
+
+        <div className="mt-7 flex flex-wrap items-center gap-x-4 gap-y-2">
+          <Stars n={Math.round(AVERAGE)} />
+          <p className="text-sm text-ink-soft">
+            <span className="font-serif text-lg font-semibold text-ink">
+              {AVERAGE.toFixed(1)}
+            </span>{" "}
+            average across {REVIEWS.length} reviews
+          </p>
+        </div>
+      </div>
+
+      {/* Full-bleed and edge-masked, so cards dissolve at the viewport rather
+          than being guillotined by a container edge. The mask lives on this
+          wrapper, not the row: a mask on the animated element travels with the
+          transform, and the fade would drift off-screen along with it. */}
+      <div className="mt-10 [mask-image:linear-gradient(to_right,transparent,black_6%,black_94%,transparent)]">
+        <MarqueeRow items={REVIEWS} duration="100s" />
+      </div>
+    </section>
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -84,10 +84,21 @@ const config: Config = {
           "0%,100%": { opacity: "1" },
           "50%": { opacity: "0" },
         },
+        // The track holds the review list twice over, so travelling exactly
+        // -50% lands the duplicate where the original started and the loop is
+        // seamless. Percentages here are of the track's own width, which is why
+        // the halves must be identical.
+        marquee: {
+          from: { transform: "translateX(0)" },
+          to: { transform: "translateX(-50%)" },
+        },
       },
       animation: {
         "fade-up": "fade-up 0.6s cubic-bezier(0.22,1,0.36,1) both",
         blink: "blink 1.1s step-end infinite",
+        // Duration is set per-row at the call site; linear so the drift never
+        // eases and re-reads as a stutter at the loop seam.
+        marquee: "marquee 60s linear infinite",
       },
     },
   },


### PR DESCRIPTION
Adds a reviews section to the bottom of lettertrace.com — a single auto-scrolling marquee row of review cards, sitting between the open-source band and the closing CTA.

## ⚠️ Before merging: the review copy is mock

Every review in `REVIEWS` is written placeholder copy, flagged as such in a header comment on the file. It stands in until the real Product Hunt / customer quotes land — at which point swapping the array (names, roles, bodies) is the entire change. **This should not go live in front of real users as-is.**

The aggregate line computes from the array (`4.6 average across 8 reviews`) rather than asserting a review count we don't have.

## Why a marquee and not a click-through carousel

Standard CRO advice is that carousels lose to static grids, because slides behind a next arrow are slides nobody clicks. The exception is exactly our situation: a low review count (5–15), where a sparse grid signals scarcity, and social proof supporting a homepage rather than being the main content. A continuous marquee keeps every card in the rotation without hiding any behind an interaction, and placing it adjacent to the final CTA is where testimonials measurably do the most work.

## Accessibility / motion

- Drift **pauses on hover and on `focus-within`** — a card can't slide out from under someone mid-read or mid-tab.
- Stops outright under `prefers-reduced-motion`, where the row degrades to an ordinary horizontally scrollable strip.
- The duplicated half of the track is `aria-hidden`, so screen readers hear eight reviews rather than sixteen.
- Stars carry an `aria-label`; the decorative initials tile is hidden.

## Implementation notes

- `components/reviews.tsx` — server component, no client JS. Pure CSS animation.
- `marquee` keyframe added to `tailwind.config.ts`; duration is set per-row at the call site.
- The track carries no gap and each half a trailing `pr-5`, so one half is exactly *(n cards + n gaps)* wide and `-50%` lands the duplicate where the original began. Gap on the track instead leaves the seam half a gap short and the row hitches once per loop.
- The edge mask lives on a static wrapper, not the animated element — a mask on the animated element travels with the transform and the fade drifts off-screen with it.
- Sits on plain `bg-paper`, not `paper-shade`, because the open-source section above it is already shaded and two shaded bands in a row read as one.
- Nav and footer both gain a `#reviews` link.

## Verification

`npm run build`, `npm run typecheck`, and `npm test` (651 tests) all green. Rendering confirmed on a local dev server. Colours are all existing theme tokens, but a dedicated dark/light visual pass hasn't been done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/106"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789060800&installation_model_id=431526&pr_number=106&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F106&signature=b85d4cce0cb541bf687d7024f271417ce2067921b052e2f2781a9fed2b09f5fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
