### PR TITLE
fix(dashboard): default captions off in Why-free video popup

### DIFF
--- a/components/dashboard/why-free.tsx
+++ b/components/dashboard/why-free.tsx
@@ -9,9 +9,10 @@ import { cn } from "@/lib/utils";
 // video answering "Why is this free?". Its own "use client" island so the
 // server-rendered dashboard layout stays a server component.
 
-// youtu.be/pQNaLHnxY8c -> privacy-friendly embed, autoplay on open.
+// youtu.be/pQNaLHnxY8c -> privacy-friendly embed, autoplay on open,
+// captions off by default (cc_load_policy=0).
 const VIDEO_EMBED_URL =
-  "https://www.youtube-nocookie.com/embed/pQNaLHnxY8c?autoplay=1&rel=0";
+  "https://www.youtube-nocookie.com/embed/pQNaLHnxY8c?autoplay=1&rel=0&cc_load_policy=0";
 
 export function WhyFree({ className }: { className?: string }) {
   const [open, setOpen] = useState(false);


### PR DESCRIPTION
Adds `cc_load_policy=0` to the "Why is this free?" YouTube embed so the popup opens with captions off by default. This edit was lost when PR #107 was merged, so this re-applies it on top of master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789102013&installation_model_id=431526&pr_number=108&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F108&signature=7c19c991a87f7867ea61d33306d9a8810dbcc5ba6e59ccb76ac064bd7faaaee4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->