### PR TITLE
feat(landing): add floating Product Hunt badge in bottom-right corner

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -399,6 +399,24 @@ export default function LandingPage() {
           </div>
         </div>
       </footer>
+
+      {/* Product Hunt badge */}
+      <a
+        href="https://www.producthunt.com/products/lettertrace?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-lettertrace-2"
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Lettertrace on Product Hunt"
+        className="fixed bottom-5 right-5 z-50 transition hover:opacity-90"
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          alt="Lettertrace - Track your AI visibility for free (using your own API keys!) | Product Hunt"
+          width={210}
+          height={45}
+          src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1218357&theme=light&t=1786538146874"
+          className="rounded shadow-lift"
+        />
+      </a>
     </div>
   );
 }


### PR DESCRIPTION
Adds the Product Hunt launch badge as a fixed, padded floating element in the bottom-right corner of the landing page. It's scaled down to 210×45 (from the embed's 250×54) so it stays subtle, with rounded corners, a `shadow-lift`, and a light hover fade to match the site styling. Uses a plain `<img>` since the badge is served from `api.producthunt.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789130253&installation_model_id=431526&pr_number=109&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F109&signature=0eb29401c2a6ef94d5914bf598f59879f5c0363f91c65fb8162e9a7f027afefc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->