### PR TITLE
Self-hostable container image — one docker run, any Supabase

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,24 @@
+# Keep the build context small and, more importantly, keep secrets out of it.
+# Anything listed here cannot end up in an image layer by accident.
+.env
+.env.local
+.env*.local
+*.pem
+
+node_modules
+.next
+out
+coverage
+
+.git
+.github
+.vercel
+.claude
+
+**/*.test.ts
+**/*.test.tsx
+
+.DS_Store
+npm-debug.log*
+README.md
+docs

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,72 @@
+name: Publish container image
+
+# Builds and pushes ghcr.io/letterstory/lettertrace.
+#
+# Publishing the image is the whole point of the exercise: a Dockerfile alone
+# still asks someone to clone the repo and build it. An image means one
+# `docker run` and no toolchain.
+#
+# Pull requests build but do not push — so a broken Dockerfile is caught in
+# review without publishing anything.
+
+on:
+  push:
+    branches: [master]
+    tags: ["v*"]
+  pull_request:
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - package.json
+      - package-lock.json
+      - next.config.mjs
+      - .github/workflows/docker.yml
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # arm64 as well as amd64: most people evaluating this locally are on an
+      # Apple Silicon laptop, and an amd64-only image makes their first
+      # experience a QEMU emulation warning.
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,format=short
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,62 @@
+# Lettertrace — self-hostable image.
+#
+# The point of this file is that the resulting image is NOT tied to the Supabase
+# project it was built against. Everything an operator needs to configure is read
+# at runtime, including the values the browser needs (see lib/public-env.ts), so
+# one published image works for everybody:
+#
+#   docker run -p 3000:3000 --env-file .env ghcr.io/letterstory/lettertrace
+#
+# Node 22 to match package.json engines (>=20 <23). Node 24 is deliberately
+# avoided: an undici regression there intermittently drops LLM connections
+# mid-response, which is most of what this app does.
+
+# ---------------------------------------------------------------- dependencies
+FROM node:22-alpine AS deps
+WORKDIR /app
+
+# Copied on their own so this layer is only rebuilt when the lockfile moves,
+# not on every source edit.
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# ---------------------------------------------------------------------- builder
+FROM node:22-alpine AS builder
+WORKDIR /app
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+# No NEXT_PUBLIC_* build args on purpose. Supplying them here would bake one
+# Supabase project into the bundle and silently override whatever the operator
+# passes to `docker run` — the exact failure this image exists to avoid.
+ENV NEXT_TELEMETRY_DISABLED=1
+RUN npm run build
+
+# ---------------------------------------------------------------------- runtime
+FROM node:22-alpine AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+
+# Runs unprivileged. The image needs no write access to its own filesystem.
+RUN addgroup -g 1001 -S nodejs && adduser -S -u 1001 -G nodejs nextjs
+
+# `standalone` carries its own minimal node_modules; static/ and public/ are not
+# included in it and have to come across separately.
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
+
+USER nextjs
+EXPOSE 3000
+
+# Fails the healthcheck on anything but a real HTTP response, so an orchestrator
+# restarts a wedged container rather than leaving it in the load balancer.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD node -e "require('http').get({host:'127.0.0.1',port:process.env.PORT||3000,path:'/login'},r=>process.exit(r.statusCode<500?0:1)).on('error',()=>process.exit(1))"
+
+CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -136,6 +136,88 @@ Open [http://localhost:3000](http://localhost:3000), create an account, and you'
 3. **Topics** → add a topic and click **Generate variations** to auto-create prompts (or add your own).
 4. **Runs** → **Run monitor now**. When it finishes, the **Overview** fills in with visibility, share of voice, sentiment, and per-topic breakdowns.
 
+## Run it with Docker
+
+Steps 1–2 above still apply — Lettertrace needs a Supabase project and its
+schema, and there is no way around that. Everything after them is one command:
+
+```bash
+docker run -p 3000:3000 \
+  -e NEXT_PUBLIC_SUPABASE_URL="https://xxxx.supabase.co" \
+  -e NEXT_PUBLIC_SUPABASE_ANON_KEY="eyJ..." \
+  -e SUPABASE_SERVICE_ROLE_KEY="eyJ..." \
+  -e ENCRYPTION_KEY="$(openssl rand -base64 32)" \
+  -e NEXT_PUBLIC_SITE_URL="http://localhost:3000" \
+  ghcr.io/letterstory/lettertrace
+```
+
+Then open [http://localhost:3000](http://localhost:3000) and create an account.
+Add your provider key in **Settings** as usual — it is BYOK either way, so the
+image ships with no model credentials in it.
+
+Already have a `.env`? `--env-file` is less to type and keeps keys out of your
+shell history:
+
+```bash
+docker run -p 3000:3000 --env-file .env ghcr.io/letterstory/lettertrace
+```
+
+> [!IMPORTANT]
+> `ENCRYPTION_KEY` decrypts the provider keys stored in your database. Generate
+> it once and keep it. If you lose it, every stored BYOK key becomes
+> unreadable and has to be re-entered; if you change it, the same.
+
+### What's required and what isn't
+
+| Variable | Needed for |
+|---|---|
+| `NEXT_PUBLIC_SUPABASE_URL` | Everything |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Everything |
+| `SUPABASE_SERVICE_ROLE_KEY` | Scheduled runs, admin surfaces |
+| `ENCRYPTION_KEY` | Storing BYOK provider keys (32 bytes, base64) |
+| `NEXT_PUBLIC_SITE_URL` | Correct auth redirects and OG metadata — set it to the URL users actually visit |
+| `CRON_SECRET` | Only if you wire up scheduled runs (below) |
+
+Everything else in [`.env.example`](./.env.example) is optional: the `TRIAL_*`
+keys exist to hand out free runs on your own provider account, and the
+`ADMIN_*` / `RESEND_API_KEY` values only enable operator alerts.
+
+Unlike a typical Next.js image, the `NEXT_PUBLIC_*` values here are read **at
+runtime**, not baked in at build time — so the published image works against any
+Supabase project without rebuilding. See [`lib/public-env.ts`](./lib/public-env.ts)
+if you want to know how, and note the one invariant it documents before adding a
+statically-rendered page that talks to Supabase from the browser.
+
+### Scheduled runs off Vercel
+
+[`vercel.json`](./vercel.json) schedules `/api/cron/run` daily, and that
+scheduler does not exist outside Vercel. Point your own cron at the endpoint
+instead:
+
+```bash
+0 8 * * * curl -fsS -X POST http://localhost:3000/api/cron/run \
+  -H "Authorization: Bearer $CRON_SECRET"
+```
+
+Set the same `CRON_SECRET` on the container. Without it the endpoint refuses
+the request, which is the intended behaviour — it is the only thing standing
+between the internet and your provider spend.
+
+### Building it yourself
+
+The published image is multi-arch (amd64 + arm64) and built from this
+repository by [`.github/workflows/docker.yml`](./.github/workflows/docker.yml).
+To build locally instead:
+
+```bash
+docker build -t lettertrace .
+docker run -p 3000:3000 --env-file .env lettertrace
+```
+
+No build arguments are needed, deliberately — passing `NEXT_PUBLIC_*` at build
+time would bake one Supabase project into the bundle and silently override
+whatever you pass at run time.
+
 ## LLM routers (one key, several assistants)
 
 Instead of a key per provider, you can connect a single **LLM router** (gateway) credential and reach several assistants through it. The bar for adding one is a live probe, not a docs page — both entries below were corrected by probing:

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { DM_Sans, DM_Mono, Ibarra_Real_Nova } from "next/font/google";
 import "./globals.css";
 import { ThemeProvider, themeInitScript } from "@/components/theme";
 import { RB2BPixel } from "@/components/rb2b-pixel";
+import { publicEnvScript } from "@/lib/public-env";
 
 const dmSans = DM_Sans({
   subsets: ["latin"],
@@ -69,6 +70,10 @@ export default function RootLayout({
       suppressHydrationWarning
     >
       <head>
+        {/* Supabase browser config, read from the server environment at request
+            time so a prebuilt container image can be pointed at any project.
+            Public values only — see lib/public-env.ts. */}
+        <script dangerouslySetInnerHTML={{ __html: publicEnvScript() }} />
         {/* Applies the saved theme before first paint to avoid a flash. */}
         <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
       </head>

--- a/lib/api-service.ts
+++ b/lib/api-service.ts
@@ -31,7 +31,7 @@ import {
   type RunSummary,
   type TopicStat,
 } from "@/lib/metrics";
-import { waitUntil } from "@vercel/functions";
+import { fireAndForget } from "@/lib/notify";
 import { normalizeCompetitorList } from "@/lib/competitors";
 import { selectAll } from "@/lib/paging";
 import { discoverCompanies, type DiscoveredCompany } from "@/lib/discover";
@@ -1227,9 +1227,13 @@ export async function triggerRunForProject(
 
   if (options?.background) {
     const prepared = await prepareRun(runParams);
-    // waitUntil keeps the serverless invocation alive past the response; the
-    // run settles its own row (completed/failed) exactly as in the sync path.
-    waitUntil(
+    // Keeps the serverless invocation alive past the response; the run settles
+    // its own row (completed/failed) exactly as in the sync path. Routed
+    // through fireAndForget rather than calling Vercel's waitUntil directly:
+    // off-Vercel — a container, a plain Node host — the import itself is what
+    // fails, and this was the one call site that would have taken background
+    // runs down with it.
+    fireAndForget(
       resumeRun(prepared, runParams).catch(async (err) => {
         // resumeRun never rejects for per-prompt failures, so reaching here
         // means the settle itself failed — and swallowing that left the row

--- a/lib/public-env.ts
+++ b/lib/public-env.ts
@@ -1,0 +1,53 @@
+/**
+ * Public browser configuration, delivered at request time rather than baked
+ * into the bundle at build time.
+ *
+ * WHY THIS EXISTS. Next inlines `NEXT_PUBLIC_*` into the client bundle when the
+ * app is built. That is fine on Vercel, where we build with the right values —
+ * but it makes a prebuilt container image unusable by anyone else: the browser
+ * would carry whatever Supabase project WE built against and silently ignore
+ * the `-e NEXT_PUBLIC_SUPABASE_URL=...` the operator passed to `docker run`.
+ * Silently is the problem. Everything would look configured and nothing would
+ * work.
+ *
+ * So the server reads these at runtime and hands them to the browser in a small
+ * inline script, the same way the theme flash-guard already does.
+ *
+ * NOTHING SECRET GOES THROUGH HERE. The anon key is designed to sit in a
+ * browser — it is the key RLS policies are written against. The service-role
+ * key is server-only and must never appear in this object.
+ *
+ * ONE INVARIANT: any page whose client components call `createClient()` must be
+ * dynamically rendered, or the script is baked at build time and we are back
+ * where we started. Every such page reads cookies for auth today, which makes
+ * it dynamic automatically — but if you add a static page with a Supabase
+ * browser client on it, that page needs to opt into dynamic rendering.
+ */
+
+export interface PublicEnv {
+	supabaseUrl: string;
+	supabaseAnonKey: string;
+}
+
+/** The window property the script writes and the browser client reads. */
+export const PUBLIC_ENV_GLOBAL = "__LETTERTRACE_PUBLIC_ENV__";
+
+/** Read at request time on the server, where `process.env` is still live. */
+export function serverPublicEnv(): PublicEnv {
+	return {
+		supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL ?? "",
+		supabaseAnonKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "",
+	};
+}
+
+/**
+ * The inline script, as source.
+ *
+ * `<` is escaped because a JSON string containing `</script>` would end the
+ * element early — the standard defence, and the only escaping this needs given
+ * every value is a URL or a key.
+ */
+export function publicEnvScript(env: PublicEnv = serverPublicEnv()): string {
+	const json = JSON.stringify(env).replace(/</g, "\\u003c");
+	return `window.${PUBLIC_ENV_GLOBAL}=${json};`;
+}

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,11 +1,43 @@
 "use client";
 
 import { createBrowserClient } from "@supabase/ssr";
+import { PUBLIC_ENV_GLOBAL, type PublicEnv } from "@/lib/public-env";
+
+/**
+ * Runtime config first, build-time inlining second.
+ *
+ * The injected object is what makes a prebuilt image work for someone else's
+ * Supabase project (see lib/public-env.ts). The `process.env` fallback is what
+ * keeps a Vercel build working unchanged if the script is ever missing — on
+ * Vercel both paths hold the same values, so the order only matters for
+ * self-hosted containers.
+ */
+function browserEnv(): PublicEnv {
+  const injected = (globalThis as unknown as Record<string, PublicEnv | undefined>)[
+    PUBLIC_ENV_GLOBAL
+  ];
+
+  return {
+    supabaseUrl: injected?.supabaseUrl || process.env.NEXT_PUBLIC_SUPABASE_URL || "",
+    supabaseAnonKey:
+      injected?.supabaseAnonKey || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || "",
+  };
+}
 
 // Browser Supabase client (uses the public anon key + RLS).
 export function createClient() {
-  return createBrowserClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-  );
+  const { supabaseUrl, supabaseAnonKey } = browserEnv();
+
+  // Failing loudly here beats createBrowserClient throwing something opaque
+  // about an invalid URL. Self-hosting is the case that hits this, so the
+  // message names the fix rather than the symptom.
+  if (!supabaseUrl || !supabaseAnonKey) {
+    throw new Error(
+      "Supabase browser config is missing. Set NEXT_PUBLIC_SUPABASE_URL and " +
+        "NEXT_PUBLIC_SUPABASE_ANON_KEY in the server environment — see the " +
+        "self-hosting section of the README.",
+    );
+  }
+
+  return createBrowserClient(supabaseUrl, supabaseAnonKey);
 }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  // Emits .next/standalone — a self-contained server with only the node_modules
+  // it actually needs. This is what keeps the container image small enough to
+  // be worth publishing. Vercel ignores it, so the hosted deploy is unaffected.
+  output: "standalone",
   eslint: {
     // Lint is run separately in CI; don't fail production builds on lint.
     ignoreDuringBuilds: true,


### PR DESCRIPTION
Someone asked for a single `docker run` so they can try Lettertrace on their own infra. The repo describes itself as *"open-source, BYOK monitoring"* under MIT and shipped no Dockerfile and no image, so this closes that gap.

```bash
docker run -p 3000:3000 \
  -e NEXT_PUBLIC_SUPABASE_URL="https://xxxx.supabase.co" \
  -e NEXT_PUBLIC_SUPABASE_ANON_KEY="eyJ..." \
  -e SUPABASE_SERVICE_ROLE_KEY="eyJ..." \
  -e ENCRYPTION_KEY="$(openssl rand -base64 32)" \
  ghcr.io/letterstory/lettertrace
```

## The problem that made this more than packaging

Next inlines `NEXT_PUBLIC_*` into the client bundle **at build time**. A prebuilt image would therefore have carried whatever Supabase project *we* built against and **silently ignored** the `-e NEXT_PUBLIC_SUPABASE_URL` an operator passed to `docker run`. Silently is the issue — everything would look configured and nothing would work.

Only one file actually had this problem: **`lib/supabase/client.ts`**, the browser client. `NEXT_PUBLIC_SITE_URL` and the server-side Supabase clients (`server.ts`, `service.ts`, `middleware.ts`) already read `process.env` at request time and needed no change.

So the server now hands the browser its two public values in a small inline script — the same pattern the theme flash-guard already uses — and the browser client prefers that over the inlined constants:

- `lib/public-env.ts` — reads the values server-side at request time, escapes `<` so a value can't close the `<script>`, and documents the one invariant: **a page whose client components call `createClient()` must be dynamically rendered.** Every such page reads cookies for auth today, so that holds automatically; it's written down for whoever adds a static one.
- The `process.env` fallback stays, so **a Vercel build behaves exactly as it does today.** On Vercel both paths hold the same values; the order only matters for containers.

Only the anon key crosses — it's the key RLS is written against and is designed to sit in a browser. The service-role key never enters that object.

## Verified, not assumed

| Check | Result |
|---|---|
| One image, two different `NEXT_PUBLIC_SUPABASE_URL` values | Each request serves its own project ✓ |
| Tenant values baked into `.next/static`? | None — only the Supabase SDK's own `*.supabase.co` wildcard list ✓ |
| `/login` in the container | HTTP 200 ✓ |
| Container healthcheck | `healthy` ✓ |
| Typecheck / 651 tests / lint | Pass (two pre-existing `<img>` warnings in `nav.tsx`, untouched) ✓ |
| Image size | 266 MB |

## A portability bug this surfaced

`lib/api-service.ts` imported Vercel's `waitUntil` at module top level and called it on the **background-run path** — the main feature. Off-Vercel that breaks.

The repo already solved this: `lib/notify.ts` exports `fireAndForget`, which lazily requires `waitUntil` and falls back cleanly when it isn't there. This was the one call site not using it. Worth fixing whether or not the Docker work lands, and it changes a real code path, which is the main reason this is a PR rather than a push.

## Not solved — documented

- **Supabase is still required.** Steps 1–2 of Getting Started still apply: a project, and `supabase/schema.sql` applied. Bundling self-hosted Supabase would be ~8 containers and a standing maintenance burden; judged not worth it. So the honest pitch is *"one `docker run`, bring your own Supabase"*, not *"one click, nothing else."*
- **Cron doesn't exist off Vercel.** `vercel.json` schedules `/api/cron/run` daily. The README now gives the crontab line and explains that `CRON_SECRET` is the only thing between the internet and your provider spend.
- **`ENCRYPTION_KEY` is load-bearing.** Called out in a warning callout: lose it and every stored BYOK key becomes unreadable. The generation command matches what `lib/crypto.ts` already recommends in its own error message.

## Files

| | |
|---|---|
| `Dockerfile` | Multi-stage, `node:22-alpine`, non-root, healthcheck. No `NEXT_PUBLIC_*` build args, deliberately |
| `.dockerignore` | Keeps `.env*` and `*.pem` out of the build context entirely |
| `.github/workflows/docker.yml` | Publishes multi-arch (amd64 + arm64) to GHCR; PRs build without pushing |
| `lib/public-env.ts` | New — runtime public config |
| `next.config.mjs` | `output: "standalone"` (Vercel ignores it) |
| `README.md` | New "Run it with Docker" section |

Node 22 in the image to match `engines` — Node 24's undici regression drops LLM connections mid-response, which is most of what this app does.

**One thing to confirm before merge:** GHCR publishing needs package write permission for the repo. The workflow requests `packages: write` and uses `GITHUB_TOKEN`, which is usually enough, but the first run on `master` is worth watching. Until it succeeds, the `docker build` path in the README works today.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789141283&installation_model_id=431526&pr_number=110&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F110&signature=e82e75ddadd7cb14e97ecd865bde7d0abb1208636e7155ac035f7c00227f6d3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->