### PR TITLE
ci: publish amd64 only — the multi-arch build never shipped

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,10 +37,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # arm64 as well as amd64: most people evaluating this locally are on an
-      # Apple Silicon laptop, and an amd64-only image makes their first
-      # experience a QEMU emulation warning.
-      - uses: docker/setup-qemu-action@v3
+      # amd64 only, deliberately. The first multi-arch run on master ran 83
+      # minutes and never published: arm64 has to be emulated under QEMU, and
+      # caches written on a PR branch aren't readable from the base branch, so
+      # every merge paid for a cold emulated build.
+      #
+      # Apple Silicon runs an amd64 image under Rosetta. It starts a little
+      # slower; nobody trying a container for ten minutes will notice. That is
+      # a far better trade than an image that takes over an hour to ship.
       - uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
@@ -64,7 +68,7 @@ jobs:
       - uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -205,9 +205,10 @@ between the internet and your provider spend.
 
 ### Building it yourself
 
-The published image is multi-arch (amd64 + arm64) and built from this
-repository by [`.github/workflows/docker.yml`](./.github/workflows/docker.yml).
-To build locally instead:
+The published image is **amd64**, built from this repository by
+[`.github/workflows/docker.yml`](./.github/workflows/docker.yml). On Apple
+Silicon it runs under Rosetta — a little slower to start, otherwise unremarkable.
+Build locally if you want a native arm64 image, or just prefer to build your own:
 
 ```bash
 docker build -t lettertrace .


### PR DESCRIPTION
The first publish run on `master` ran **83 minutes** and was cancelled without producing an image.

Two things compounded: arm64 is emulated under QEMU, and GitHub Actions caches written on a PR branch are not readable from the base branch — so every merge paid for a cold *emulated* build. The identical build on the PR, which does not push, took 17–19 minutes.

**amd64 only.** Apple Silicon runs it under Rosetta: slower to start, otherwise unremarkable. An image that exists beats a native one that takes an hour and a half to publish.

Building arm64 at all was over-delivery on my part, for a cosmetic concern, and it cost the thing it was meant to improve.

Also corrects the README, which claimed the published image was multi-arch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789148118&installation_model_id=431526&pr_number=111&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F111&signature=8ae0a600be729006dc21cbb6102f1d07ec4624065b1f565609119cdb14b5aff7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->