### PR TITLE
docs: frame Supabase as a prerequisite, link Docker from step 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ openssl rand -hex 32      # -> CRON_SECRET
 
 ### 4. Install & run
 
+> Running it as a container instead? Skip to [Run it with Docker](#run-it-with-docker)
+> — steps 1–3 still apply, step 4 becomes a single `docker run`.
+
 Use **Node 22 LTS** (see [`.nvmrc`](./.nvmrc)). Node 23+ has an `undici`
 regression that intermittently drops provider connections mid-response
 ("Premature close"). With [nvm](https://github.com/nvm-sh/nvm):
@@ -138,8 +141,12 @@ Open [http://localhost:3000](http://localhost:3000), create an account, and you'
 
 ## Run it with Docker
 
-Steps 1–2 above still apply — Lettertrace needs a Supabase project and its
-schema, and there is no way around that. Everything after them is one command:
+**Prerequisites:** a Supabase project with [`supabase/schema.sql`](./supabase/schema.sql)
+applied — [steps 1](#1-create-a-supabase-project) and [2](#2-apply-the-database-schema)
+above, about two minutes on the free tier. Supabase provides auth and the
+database, so it lives outside the container.
+
+Then:
 
 ```bash
 docker run -p 3000:3000 \
@@ -151,9 +158,9 @@ docker run -p 3000:3000 \
   ghcr.io/letterstory/lettertrace
 ```
 
-Then open [http://localhost:3000](http://localhost:3000) and create an account.
-Add your provider key in **Settings** as usual — it is BYOK either way, so the
-image ships with no model credentials in it.
+Open [http://localhost:3000](http://localhost:3000), create an account, and add
+your provider key in **Settings** as usual — it is BYOK either way, so the image
+ships with no model credentials in it.
 
 Already have a `.env`? `--env-file` is less to type and keeps keys out of your
 shell history:


### PR DESCRIPTION
Docs only.

The Docker section opened by explaining that Supabase was unavoidable, which read as an apology. It now reads as a prerequisite — the way any self-hosted app states its database requirement — with links to the two steps that set it up and a note that it takes about two minutes on the free tier.

Also adds a pointer from **Install & run** to the Docker section so someone landing on the README finds the container path without scrolling to the bottom.

Purpose: the README can now be linked directly in response to the Product Hunt request for a single `docker run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789149054&installation_model_id=431526&pr_number=112&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F112&signature=1aaf35992125c12051566a9e9fc1ff7c6bf1b289d1785815703db7314db77cd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->