### PR TITLE
Catalog: current consumer models (GPT-5.6 Sol/Luna, Claude Sonnet 5)

### DIFF
--- a/lib/models.test.ts
+++ b/lib/models.test.ts
@@ -35,6 +35,20 @@ describe("provider catalog", () => {
     expect(defaultModelFor("google")).toBe("gemini-pro-latest");
   });
 
+  // The consumer-surface refresh (2026-08): these are what ChatGPT and
+  // claude.ai actually serve, offered WITHOUT touching the defaults — a
+  // default swap changes the measured surface under every project that never
+  // picked a model, and rates are only comparable run-over-run on one surface.
+  it("offers the current consumer models without moving the defaults", () => {
+    const openaiIds = PROVIDERS.openai.models.map((m) => m.id);
+    expect(openaiIds).toContain("gpt-5.6-sol");
+    expect(openaiIds).toContain("gpt-5.6-luna");
+    expect(defaultModelFor("openai")).toBe("gpt-4o");
+    const anthropicIds = PROVIDERS.anthropic.models.map((m) => m.id);
+    expect(anthropicIds).toContain("claude-sonnet-5");
+    expect(defaultModelFor("anthropic")).toBe("claude-opus-4-8");
+  });
+
   it("offers Google AI Overviews as a distinct engine under google", () => {
     const ids = PROVIDERS.google.models.map((m) => m.id);
     expect(ids).toContain(GOOGLE_AI_OVERVIEWS_MODEL);

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -31,8 +31,12 @@ export const PROVIDERS: Record<Provider, ProviderInfo> = {
     label: "Anthropic (Claude)",
     keyUrl: "https://console.anthropic.com/settings/keys",
     keyPrefix: "sk-ant-",
+    // Ordered by capability; the FIRST entry is the provider default
+    // (defaultModelFor), so reordering is a behavior change for every project
+    // that never picked a model — don't reorder to freshen the picker.
     models: [
       { id: "claude-opus-4-8", label: "Claude Opus 4.8", note: "Most capable" },
+      { id: "claude-sonnet-5", label: "Claude Sonnet 5", note: "claude.ai's default" },
       { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6", note: "Balanced" },
       { id: "claude-haiku-4-5", label: "Claude Haiku 4.5", note: "Fast & cheap" },
     ],
@@ -42,8 +46,16 @@ export const PROVIDERS: Record<Provider, ProviderInfo> = {
     label: "OpenAI (ChatGPT)",
     keyUrl: "https://platform.openai.com/api-keys",
     keyPrefix: "sk-",
+    // gpt-4o stays first (the default) for measurement continuity — a run's
+    // rates are only comparable to the runs before it on the same surface, so
+    // moving the default is a deliberate cut-over, not a freshen. The 5.6
+    // entries are what ChatGPT actually serves consumers today; nothing is
+    // removed because a project pinned to a dropped id would fail its next
+    // run at resolveEngine.
     models: [
-      { id: "gpt-4o", label: "GPT-4o", note: "Flagship" },
+      { id: "gpt-4o", label: "GPT-4o", note: "Legacy flagship" },
+      { id: "gpt-5.6-sol", label: "GPT-5.6 Sol", note: "ChatGPT's paid default" },
+      { id: "gpt-5.6-luna", label: "GPT-5.6 Luna", note: "ChatGPT's free default" },
       { id: "gpt-4o-mini", label: "GPT-4o mini", note: "Fast & cheap" },
       { id: "gpt-4-turbo", label: "GPT-4 Turbo" },
     ],

--- a/lib/pricing.ts
+++ b/lib/pricing.ts
@@ -43,13 +43,22 @@ const RATES: Record<Provider, { models: Record<string, number>; fallback: number
   anthropic: {
     models: {
       "claude-opus-4-8": 25,
+      "claude-sonnet-5": 10,
       "claude-sonnet-4-6": 15,
       "claude-haiku-4-5": 5,
     },
     fallback: 25,
   },
-  // Placeholders that err high — see PROVENANCE above.
-  openai: { models: {}, fallback: 30 },
+  // The 5.6 rows are published output rates (Sol $30/Mtok; Luna quoted $1.20–6,
+  // charged at the higher figure per the err-high rule). Anything else falls
+  // back to the deliberately-high placeholder — see PROVENANCE above.
+  openai: {
+    models: {
+      "gpt-5.6-sol": 30,
+      "gpt-5.6-luna": 6,
+    },
+    fallback: 30,
+  },
   google: { models: {}, fallback: 30 },
   perplexity: { models: {}, fallback: 30 },
 };


### PR DESCRIPTION
## Why

A prod audit of the Letterbrace GEO pipeline (delphi PR letterstory/Letterbrace#819 has the data) flagged the catalog as stale: the newest OpenAI entry is `gpt-4o`, but ChatGPT today serves **GPT-5.6 Sol** to paid users and **GPT-5.6 Luna** to free users, and claude.ai defaults to **Claude Sonnet 5**. For a product measuring what AI engines say about a brand, not offering the surfaces real users see undercounts visibility by construction.

## What

- `openai`: add `gpt-5.6-sol` ("ChatGPT's paid default") and `gpt-5.6-luna` ("ChatGPT's free default"); `gpt-4o` relabeled "Legacy flagship".
- `anthropic`: add `claude-sonnet-5` ("claude.ai's default").
- `pricing.ts`: published output rates — Sol $30/Mtok, Sonnet 5 $10/Mtok; Luna quoted $1.20–6 across sources, charged at $6 per the err-high rule.
- Tests pin the new entries AND that the defaults did not move.

## Deliberately NOT in this PR

- **No default changes.** `defaultModelFor` = first entry, and every project that never picked a model runs the default — swapping it changes the measured surface mid-trend-line. If we want new projects on 5.6, that's a deliberate cut-over (and Letterbrace pins its models explicitly as of letterstory/Letterbrace#819, so it's unaffected either way).
- **No removals.** A project pinned to a dropped id would fail its next run at `resolveEngine`.
- **google default left as `gemini-pro-latest`** despite the 2026-07 undersampling incident: that predates the 800s invocation ceiling (#98), so the completion premise is stale, and the existing test pins the flagship-default choice deliberately.

## Verification

Model ids and pricing verified against current sources ([GPT-5.6 announcement](https://openai.com/index/gpt-5-6/), [OpenRouter gpt-5.6-sol](https://openrouter.ai/openai/gpt-5.6-sol), [OpenRouter gpt-5.6-luna](https://openrouter.ai/openai/gpt-5.6-luna), [Claude Sonnet 5 announcement](https://www.anthropic.com/news/claude-sonnet-5), [Claude platform pricing](https://platform.claude.com/docs/en/about-claude/pricing)). Full vitest suite: 652 passed. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/114"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789165815&installation_model_id=431526&pr_number=114&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F114&signature=9f46df373984e9d62cb0ffd7a99a624eb705d38247e829ae585989749ffcff64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->