### PR TITLE
feat(analytics): PostHog product analytics, inert without a key

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { DM_Sans, DM_Mono, Ibarra_Real_Nova } from "next/font/google";
 import "./globals.css";
 import { ThemeProvider, themeInitScript } from "@/components/theme";
 import { RB2BPixel } from "@/components/rb2b-pixel";
+import { PostHogAnalytics } from "@/components/posthog";
 import { publicEnvScript } from "@/lib/public-env";
 
 const dmSans = DM_Sans({
@@ -80,6 +81,7 @@ export default function RootLayout({
       <body>
         <ThemeProvider>{children}</ThemeProvider>
         <RB2BPixel />
+        <PostHogAnalytics />
       </body>
     </html>
   );

--- a/components/posthog.tsx
+++ b/components/posthog.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect } from "react";
+import posthog from "posthog-js";
+
+/**
+ * PostHog product analytics.
+ *
+ * Renders nothing and does nothing unless NEXT_PUBLIC_POSTHOG_KEY is set, so it
+ * is inert in local dev and in self-hosted container images (which are built
+ * without the key — operators' deployments are never tracked). The key is the
+ * project API key (phc_...), which is public by design, NOT a secret.
+ *
+ * Unlike the RB2B pixel this runs on every route, authenticated product
+ * included — product analytics is the point. The `defaults` date opts into
+ * PostHog's current recommended behavior, which includes automatic pageview
+ * capture across client-side navigations.
+ */
+export function PostHogAnalytics() {
+  const key = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+  const host = process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://us.i.posthog.com";
+
+  useEffect(() => {
+    if (!key || posthog.__loaded) return;
+    posthog.init(key, {
+      api_host: host,
+      defaults: "2025-05-24",
+    });
+  }, [key, host]);
+
+  return null;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "mcp-handler": "^1.1.0",
         "next": "14.2.15",
         "openai": "^4.67.3",
+        "posthog-js": "^1.417.1",
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "recharts": "^2.12.7",
@@ -1018,6 +1019,31 @@
         "node": ">=14"
       }
     },
+    "node_modules/@posthog/browser-common": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@posthog/browser-common/-/browser-common-0.5.0.tgz",
+      "integrity": "sha512-8DaxVZS1bQPbA514RePurLNbYjei3P4jhnC206DwVv5XThmZM3QdlsXenI2ujE3pLbgQ79hYn9o1Kda8I3WK/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "^1.47.0",
+        "@posthog/types": "^1.402.2"
+      }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.48.1",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.48.1.tgz",
+      "integrity": "sha512-mxw31XdYgt/SnlwqLPAcltK67q+QmsiYjVLGQ4GbBc8OJ7O4yRFSDwAXt8QsokHokeyEZtTRWM6jDHL7LYMx1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "^1.404.1"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.404.1",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.404.1.tgz",
+      "integrity": "sha512-i2Gei6ARfOSBeTN4s2yUP1p97s2UNI+1NWmtLjhnR/V6t3RFOfI1sBWKcJNWHjtoOCCWoAFU+PNPY6SgT2VtEQ==",
+      "license": "MIT"
+    },
     "node_modules/@redis/bloom": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
@@ -1694,6 +1720,13 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.65.0",
@@ -3407,6 +3440,20 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.50.0.tgz",
+      "integrity": "sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -3768,6 +3815,15 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {
@@ -4785,6 +4841,12 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.9.tgz",
+      "integrity": "sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -7336,6 +7398,42 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/posthog-js": {
+      "version": "1.417.1",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.417.1.tgz",
+      "integrity": "sha512-QpZnHA2PieGq9+W03LBw23DnN9CD1zM37DcXnpZkg+C5iAwYXLiZs8qof0Yi/BhY35PYuhVmv93nhztyHjVaJw==",
+      "license": "(Apache-2.0 AND MIT)",
+      "dependencies": {
+        "@posthog/browser-common": "^0.5.0",
+        "@posthog/core": "^1.48.1",
+        "@posthog/types": "^1.404.1",
+        "core-js": "^3.49.0",
+        "dompurify": "^3.4.13",
+        "fflate": "^0.4.8",
+        "preact": "^10.29.3",
+        "query-selector-shadow-dom": "^1.0.1",
+        "web-vitals": "^5.3.0",
+        "web-vitals-soft-navs": "npm:web-vitals@6.0.0"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.8",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.8.tgz",
+      "integrity": "sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -7395,6 +7493,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -9252,6 +9356,19 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+      "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/web-vitals-soft-navs": {
+      "name": "web-vitals",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-6.0.0.tgz",
+      "integrity": "sha512-Guaibvy/+uNtL6Bsu4jmMJGzuSl91oeRH5iO9pPRbYftnFUr3yqT1TUNX/OE4o9HexuEMU3Kb/Wg7iKhlffZUA==",
+      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "mcp-handler": "^1.1.0",
     "next": "14.2.15",
     "openai": "^4.67.3",
+    "posthog-js": "^1.417.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "recharts": "^2.12.7",


### PR DESCRIPTION
Adds PostHog to the Lettertrace app via a small client component (`components/posthog.tsx`) wired into the root layout.

**Design — follows the RB2B pixel precedent:**
- Completely inert unless `NEXT_PUBLIC_POSTHOG_KEY` is set, so local dev, preview deploys, and self-hosted container images (built without the key) never send events. Only the Vercel production build activates it.
- Unlike the marketing-only RB2B pixel, this runs on every route including the authenticated product — product analytics is the point.
- `defaults: "2025-05-24"` opts into PostHog's current recommended config, which auto-captures pageviews across client-side navigations.

**Provisioning (already done, no action needed):**
- New "Lettertrace" project created in the existing PostHog org (US cloud), so the default `us.i.posthog.com` host applies.
- `NEXT_PUBLIC_POSTHOG_KEY` is set on the Vercel project for Production only.

Typecheck and a full `next build` pass. Events should appear in PostHog within minutes of the first production visit after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/117"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789315721&installation_model_id=431526&pr_number=117&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F117&signature=269e61c21fd5d1f1e69512d6a3e90aa2da1b89a31d0a06f0a923b3d31c83e650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->