### PR TITLE
feat(letterprove): attest real product usage, inert unless a key is set

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,32 @@ NEXT_PUBLIC_SITE_URL=http://localhost:3000
 # only set it in the deployment that actually serves lettertrace.com.
 NEXT_PUBLIC_RB2B_KEY=
 
+# --- Letterprove usage attestation (optional) ---
+# Letterprove (letterprove.com) publishes signed, machine-readable attestations
+# that a vendor's named customers really use the product, for AI agents to fetch
+# and verify. Lettertrace is its first real vendor, so this is us dogfooding.
+#
+# Loaded by components/letterprove-attest.tsx ONLY on the authenticated product
+# (/dashboard) — the inverse of the RB2B pixel above, and for the same reason
+# read the other way: attestation is about real usage by real accounts, which
+# only exists behind the login, and there is nothing to observe on a marketing
+# page.
+#
+# What leaves the browser is the DOMAIN of the signed-in email and nothing else
+# — attest.js splits the local part off and discards it before building any
+# request. No address, no user id, no name.
+#
+# Not a secret. It ships in the HTML of every authenticated page (hence
+# NEXT_PUBLIC) and only identifies the vendor; Letterprove pins it to our origin
+# and rejects it from anywhere else. It is still deployment-specific: only set it
+# on the deployment serving lettertrace.com. Self-hosters leave it blank and are
+# never reported on. Note the origin pin means this is inert on localhost even
+# when set.
+NEXT_PUBLIC_LETTERPROVE_KEY=
+# Override only if pointing at a non-production Letterprove.
+# Defaults to https://letterprove.vercel.app
+NEXT_PUBLIC_LETTERPROVE_ORIGIN=
+
 # --- OAuth (optional) ---
 # Lettertrace is its own OAuth 2.1 Authorization Server, so a CLI or external
 # system can obtain scoped, expiring, revocable access WITHOUT you hand-minting

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -5,6 +5,7 @@ import { OrgSwitcher } from "@/components/dashboard/org-switcher";
 import { SignOutButton } from "@/components/dashboard/signout";
 import { WhyFree } from "@/components/dashboard/why-free";
 import { TrialBanner } from "@/components/dashboard/trial-banner";
+import { LetterproveAttest } from "@/components/letterprove-attest";
 import { RunReadyBanner } from "@/components/dashboard/run-ready-banner";
 import { ThemeToggle } from "@/components/theme";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
@@ -73,6 +74,12 @@ export default async function DashboardLayout({
 
   return (
     <div className="min-h-screen bg-paper md:flex">
+      {/* Usage attestation. Mounted here rather than in the root layout because
+          it reports on authenticated product usage, which only exists behind
+          this boundary — and because `user` is already resolved above, so it
+          costs no extra query. Only the domain of the address is ever sent. */}
+      <LetterproveAttest email={user.email} />
+
       <aside className="flex flex-col border-b border-ink/10 bg-paper md:h-screen md:w-[260px] md:shrink-0 md:border-b-0 md:border-r">
         <div className="flex flex-col gap-6 px-5 py-6 md:h-full">
           <div className="flex items-center justify-between gap-2">

--- a/components/letterprove-attest.tsx
+++ b/components/letterprove-attest.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Letterprove usage attestation.
+ *
+ * Renders nothing and does nothing unless NEXT_PUBLIC_LETTERPROVE_KEY is set,
+ * so it is inert in local dev and in self-hosted container images (operators'
+ * own deployments are never reported on). The key is a publishable, origin-
+ * pinned vendor key — it ships in the HTML of every authenticated page and is
+ * NOT a secret; Letterprove rejects it from any origin but ours.
+ *
+ * This is the inverse of the RB2B pixel's scope, deliberately. RB2B
+ * de-anonymizes strangers on marketing pages and has no business on the
+ * product. Letterprove measures *real product usage by real accounts*, which
+ * only exists behind the login, so it is mounted in the dashboard layout and
+ * nowhere else. There is nothing for it to observe on a public page.
+ *
+ * What actually leaves the browser is the DOMAIN of the signed-in email and
+ * nothing else — `attest.js` splits the local part off and discards it before
+ * building any request. We never send the address, a user id, or a name. See
+ * Letterprove's README § "The one hard rule: domain only".
+ *
+ * Why the script is injected by hand rather than via next/script: `attest.js`
+ * reads its configuration off its own <script> element (`data-key`, and the
+ * origin of `src`), and it exposes `window.Letterprove` only once it has run.
+ * Creating the element explicitly keeps both of those guarantees visible here
+ * instead of resting on how a wrapper forwards unknown props.
+ */
+
+const SCRIPT_ID = "letterprove-attest";
+const DEFAULT_ORIGIN = "https://letterprove.vercel.app";
+
+declare global {
+  interface Window {
+    Letterprove?: {
+      identify: (email: string) => void;
+      signup: (email: string) => void;
+      login: (email: string) => void;
+    };
+  }
+}
+
+export function LetterproveAttest({ email }: { email?: string | null }) {
+  const key = process.env.NEXT_PUBLIC_LETTERPROVE_KEY;
+  const origin = process.env.NEXT_PUBLIC_LETTERPROVE_ORIGIN ?? DEFAULT_ORIGIN;
+
+  useEffect(() => {
+    if (!key || !email) return;
+
+    // Already injected by an earlier mount this page load. `identify` is
+    // idempotent per page load on Letterprove's side — it fires at most one
+    // session event — so calling it again on a client-side navigation is safe
+    // and keeps the domain established if this remounts.
+    const existing = document.getElementById(SCRIPT_ID);
+    if (existing) {
+      window.Letterprove?.identify(email);
+      return;
+    }
+
+    const script = document.createElement("script");
+    script.id = SCRIPT_ID;
+    script.src = `${origin}/attest.js`;
+    script.async = true;
+    script.setAttribute("data-key", key);
+    // Telemetry must never break the product. attest.js wraps its own public
+    // methods, but the load itself can still fail — a blocked request, an
+    // offline client — and that has to be a no-op, not an error boundary.
+    script.onload = () => {
+      try {
+        window.Letterprove?.identify(email);
+      } catch {
+        /* ignore */
+      }
+    };
+    script.onerror = () => {
+      /* ignore — no attestation this page load */
+    };
+    document.head.appendChild(script);
+  }, [key, email, origin]);
+
+  return null;
+}


### PR DESCRIPTION
Lettertrace is Letterprove's first real vendor — everything it had published until now was a fictional fixture. This is the client half. The Letterprove side is [letterstory/Letterprove#22](https://github.com/letterstory/Letterprove/pull/22); **that has to merge and deploy first**, or the key here isn't recognised.

## What it does

When someone signs into the dashboard, `attest.js` reports **the domain of their email address and nothing else** — `acme.com`, never `jane@acme.com`. The script splits the local part off and discards it before building any request. No address, no user id, no name. That domain is how Letterprove attributes usage to a company.

## Scope: the inverse of the RB2B pixel, on purpose

RB2B de-anonymizes strangers on marketing pages and is explicitly kept off the product. This is the mirror image: attestation is about *real usage by real accounts*, which only exists behind the login. So it mounts in the dashboard layout and nowhere else — there is nothing for it to observe on a public page. It reuses the `user` that layout has already resolved, so it costs no extra query.

## Safety

**Inert unless `NEXT_PUBLIC_LETTERPROVE_KEY` is set**, matching the RB2B and PostHog components — local dev and self-hosted container images report nothing.

**The key is publishable, not secret.** It ships in the HTML of every authenticated page and only identifies the vendor. Letterprove pins it to our origin, which is what makes that safe. Verified against a local Letterprove build:

| Origin | Result |
|---|---|
| `https://lettertrace.com` | `204` · `x-letterprove: on` |
| `https://evil.example` | `204` · `x-letterprove: off` |
| `https://www.lettertrace.com` | `204` · `x-letterprove: off` |

**Cannot break the product.** `attest.js` wraps its own methods, and the injection here handles a failed load as a no-op.

## Two footguns worth knowing

**This is inert on localhost even with a key set** — the origin pin rejects `localhost`. Expect no local events; that's correct behaviour, not a bug to chase.

**`www` is rejected**, and today that doesn't matter because `www.lettertrace.com` 307s to the apex, so page origin is always `lettertrace.com`. If we ever serve `www` directly, collection stops silently — `204` either way, with only the `x-letterprove` header saying `off`.

## One implementation note

The `<script>` element is created by hand rather than through `next/script`. `attest.js` reads its configuration off its own element (`data-key`, and the origin of `src`) and only defines `window.Letterprove` once it has run — creating it explicitly keeps both of those guarantees visible in this file instead of resting on how a wrapper forwards unknown props.

## Verification

`tsc --noEmit` clean, `next build` succeeds, `next lint` shows only pre-existing `<img>` warnings in untouched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789321676&installation_model_id=431526&pr_number=118&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F118&signature=dddf3da64e15621d329b12f785b450e8eacab2009cc2d944f480015ee573477d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->