### PR TITLE
Admin Growth tab: runs-based actives, top accounts, run log, and the outbound lead list

### DIFF
--- a/app/admin/growth/page.tsx
+++ b/app/admin/growth/page.tsx
@@ -1,0 +1,359 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { ArrowUpRight, Flame } from "lucide-react";
+import { requireAdmin } from "@/lib/admin";
+import { growthReport, type EmailClass, type Lead } from "@/lib/growth";
+import { Badge, Card, SectionHeading, StatCard } from "@/components/ui";
+import { timeAgo } from "@/lib/utils";
+
+export const dynamic = "force-dynamic";
+export const metadata = { robots: { index: false, follow: false } };
+
+/**
+ * The outbound side of /admin.
+ *
+ * Unlike the operations page, this one shows emails in the clear and links
+ * into customer run content — that is its job: it exists so the operator can
+ * decide who to email next and know what they saw when they last used the
+ * product. Same requireAdmin gate, different purpose.
+ *
+ * Layout: one row of numbers, one row pairing the shape (sparkline) with the
+ * names behind it (top accounts), then the two working lists full-width with
+ * real column headers — they are tables the operator reads line by line, not
+ * cards to glance at.
+ */
+
+type SP = Record<string, string | string[] | undefined>;
+
+const CLASS_TONE: Record<EmailClass, "teal" | "sand" | "terracotta"> = {
+  work: "teal",
+  personal: "sand",
+  burner: "terracotta",
+};
+
+const LEAD_FILTERS: { key: string; label: string; pick: (l: Lead) => boolean }[] = [
+  { key: "work", label: "Work", pick: (l) => l.emailClass === "work" },
+  { key: "personal", label: "Personal", pick: (l) => l.emailClass === "personal" },
+  { key: "burner", label: "Burner", pick: (l) => l.emailClass === "burner" },
+  { key: "all", label: "All", pick: () => true },
+];
+
+function leadFilterFrom(searchParams: SP) {
+  const raw = Array.isArray(searchParams.f) ? searchParams.f[0] : searchParams.f;
+  return LEAD_FILTERS.find((f) => f.key === raw) ?? LEAD_FILTERS[0];
+}
+
+/** 30 days of runs as bars. Inline SVG on purpose: no chart dependency, and
+ *  the numbers live in <title> tooltips rather than labels — this is a shape,
+ *  not a report. Colors go through style, not SVG attributes, because CSS
+ *  var() only resolves in styles. */
+function RunSparkline({ series }: { series: { day: string; users: number; runs: number }[] }) {
+  const max = Math.max(1, ...series.map((d) => d.runs));
+  const barW = 600 / series.length;
+  return (
+    <svg
+      viewBox="0 0 600 110"
+      preserveAspectRatio="none"
+      className="h-32 w-full"
+      role="img"
+      aria-label="Runs per day, last 30 days"
+    >
+      {series.map((d, i) => {
+        const h = d.runs === 0 ? 2 : Math.max(4, (d.runs / max) * 100);
+        return (
+          <rect
+            key={d.day}
+            x={i * barW + 1.5}
+            y={106 - h}
+            width={barW - 3}
+            height={h}
+            rx={1.5}
+            style={{
+              fill: d.runs === 0 ? "rgb(var(--c-ink) / 0.12)" : "rgb(var(--c-mint-bright))",
+            }}
+          >
+            <title>{`${d.day} — ${d.runs} run${d.runs === 1 ? "" : "s"}, ${d.users} user${d.users === 1 ? "" : "s"}`}</title>
+          </rect>
+        );
+      })}
+    </svg>
+  );
+}
+
+/** Uppercase micro-headers that make a flex list read as a table. */
+function ColumnHeader({ children, className }: { children: React.ReactNode; className?: string }) {
+  return (
+    <span
+      className={`text-[10px] font-medium uppercase tracking-wider text-ink-faint ${className ?? ""}`}
+    >
+      {children}
+    </span>
+  );
+}
+
+export default async function GrowthPage({ searchParams }: { searchParams: SP }) {
+  const admin = await requireAdmin();
+  if (!admin) notFound();
+
+  const report = await growthReport();
+  const { activity } = report;
+  const filter = leadFilterFrom(searchParams);
+  const leads = report.leads.filter(filter.pick);
+  const leadCounts = new Map(LEAD_FILTERS.map((f) => [f.key, report.leads.filter(f.pick).length]));
+  const bestDay = activity.series.reduce((a, b) => (b.runs > a.runs ? b : a), activity.series[0]);
+
+  return (
+    <div className="space-y-10">
+      <SectionHeading
+        title="Growth"
+        description="Activity measured in runs, and the lead list it produces. Emails are shown in the clear here — this page exists for outbound."
+      />
+
+      {report.degraded && (
+        <Card className="border-terracotta/40 bg-terracotta/[0.04]">
+          <p className="px-6 py-4 text-sm text-terracotta-dark">
+            Some figures could not be loaded ({report.degraded}) — treat the numbers below as
+            incomplete rather than as zero.
+          </p>
+        </Card>
+      )}
+
+      {/* ---- Row 1: the numbers --------------------------------------------- */}
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        <StatCard
+          label="Daily active"
+          value={activity.daily.users.toLocaleString()}
+          hint={`${activity.daily.runs.toLocaleString()} runs · rolling 24h`}
+          accent="mint"
+        />
+        <StatCard
+          label="Weekly active"
+          value={activity.weekly.users.toLocaleString()}
+          hint={`${activity.weekly.runs.toLocaleString()} runs · rolling 7d`}
+          accent="teal"
+        />
+        <StatCard
+          label="Monthly active"
+          value={activity.monthly.users.toLocaleString()}
+          hint={`${activity.monthly.runs.toLocaleString()} runs · rolling 30d`}
+          accent="butter"
+        />
+        <StatCard
+          label="Stickiness"
+          value={activity.stickiness === null ? "—" : `${activity.stickiness}%`}
+          hint={`DAU / MAU · ${report.totalUsers.toLocaleString()} signups total`}
+          accent="sand"
+        />
+      </div>
+
+      {/* ---- Row 2: the shape next to the names ------------------------------ */}
+      <div className="grid gap-4 lg:grid-cols-5">
+        <Card className="flex flex-col lg:col-span-2">
+          <div className="flex flex-1 flex-col px-5 pb-4 pt-5">
+            <div className="flex items-baseline justify-between gap-3">
+              <h3 className="text-sm font-semibold text-ink">Runs per day</h3>
+              <span className="text-xs text-ink-faint">30d</span>
+            </div>
+            <div className="mt-3 flex flex-1 items-end">
+              <RunSparkline series={activity.series} />
+            </div>
+            <p className="mt-3 text-xs tabular-nums text-ink-faint">
+              {activity.monthly.runs.toLocaleString()} runs total · best day {bestDay.runs} ·
+              hover bars for counts
+            </p>
+          </div>
+        </Card>
+
+        <Card className="lg:col-span-3">
+          <div className="flex items-baseline justify-between gap-3 px-5 pb-2 pt-5">
+            <h3 className="text-sm font-semibold text-ink">Most active accounts</h3>
+            <span className="text-xs text-ink-faint">by runs, 30d</span>
+          </div>
+          {report.topAccounts.length === 0 ? (
+            <p className="px-5 py-8 text-sm text-ink-faint">No runs in the last 30 days.</p>
+          ) : (
+            <div className="max-h-72 divide-y divide-ink/5 overflow-y-auto">
+              {report.topAccounts.map((account, i) => (
+                <div
+                  key={account.userId}
+                  className="flex items-center gap-3 px-5 py-2.5 transition hover:bg-ink/[0.02]"
+                >
+                  <span className="w-5 shrink-0 text-right font-mono text-xs tabular-nums text-ink-faint">
+                    {i + 1}
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate font-mono text-[13px] text-ink">
+                      {account.email ?? account.userId}
+                      {i === 0 && account.runs30d > 0 && (
+                        <Flame
+                          className="ml-1 inline h-3.5 w-3.5 align-[-2px] text-terracotta"
+                          aria-hidden
+                        />
+                      )}
+                    </p>
+                    <p className="truncate text-xs text-ink-faint">
+                      {account.brands.length > 0 ? account.brands.join(" · ") : "no brands"} · last
+                      run {timeAgo(account.lastRunAt)}
+                    </p>
+                  </div>
+                  <Badge tone={CLASS_TONE[account.emailClass]}>{account.emailClass}</Badge>
+                  <span className="w-14 shrink-0 text-right font-mono text-sm tabular-nums text-ink">
+                    {account.runs30d.toLocaleString()}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </Card>
+      </div>
+
+      {/* ---- Row 3: the outbound log ----------------------------------------- */}
+      <section className="space-y-3">
+        <div>
+          <h3 className="text-lg font-semibold text-ink">Latest runs</h3>
+          <p className="mt-1 max-w-3xl text-sm text-ink-faint">
+            Who just used the product and what they ran. Open a run to see the prompts, the
+            answers, and what the engines said about their brand.
+          </p>
+        </div>
+        <Card>
+          {report.recentRuns.length === 0 ? (
+            <p className="px-5 py-8 text-sm text-ink-faint">No runs in the last 30 days.</p>
+          ) : (
+            <>
+              <div className="flex items-center gap-4 border-b border-ink/10 px-5 py-2">
+                <ColumnHeader className="flex-1">Account · brand</ColumnHeader>
+                <ColumnHeader className="w-20 text-right">Status</ColumnHeader>
+                <ColumnHeader className="w-16 text-right">Answers</ColumnHeader>
+                <ColumnHeader className="w-20 text-right">When</ColumnHeader>
+                <span className="w-4" />
+              </div>
+              <div className="max-h-96 divide-y divide-ink/5 overflow-y-auto">
+                {report.recentRuns.map((run) => (
+                  <Link
+                    key={run.id}
+                    href={`/admin/runs/${run.id}`}
+                    className="flex items-center gap-4 px-5 py-2.5 transition hover:bg-ink/[0.03]"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate font-mono text-[13px] text-ink">
+                        {run.email ?? "(no email)"}
+                      </p>
+                      <p className="truncate text-xs text-ink-faint">
+                        {run.brandName || run.projectName} · {run.provider}/{run.model}
+                      </p>
+                    </div>
+                    <span className="w-20 shrink-0 text-right">
+                      <Badge
+                        tone={
+                          run.status === "completed"
+                            ? "mint"
+                            : run.status === "failed"
+                              ? "terracotta"
+                              : "butter"
+                        }
+                      >
+                        {run.status}
+                      </Badge>
+                    </span>
+                    <span className="w-16 shrink-0 text-right font-mono text-xs tabular-nums text-ink-faint">
+                      {run.done}/{run.planned}
+                    </span>
+                    <span className="w-20 shrink-0 text-right text-xs tabular-nums text-ink-faint">
+                      {timeAgo(run.createdAt)}
+                    </span>
+                    <ArrowUpRight className="h-4 w-4 shrink-0 text-ink-faint" aria-hidden />
+                  </Link>
+                ))}
+              </div>
+            </>
+          )}
+        </Card>
+      </section>
+
+      {/* ---- Row 4: the lead list --------------------------------------------- */}
+      <section className="space-y-3">
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <h3 className="text-lg font-semibold text-ink">Lapsed leads</h3>
+            <p className="mt-1 max-w-2xl text-sm text-ink-faint">
+              No run in 7 days. Work addresses are the outbound list — and “never ran” is the
+              warmest lead: they wanted this enough to sign up, then bounced off something.
+            </p>
+          </div>
+          <div className="flex items-center gap-1 rounded border border-ink/10 bg-surface p-1">
+            {LEAD_FILTERS.map((f) => (
+              <Link
+                key={f.key}
+                href={`/admin/growth?f=${f.key}`}
+                scroll={false}
+                aria-current={f.key === filter.key ? "page" : undefined}
+                className={`rounded-sm px-2.5 py-1 text-xs transition ${
+                  f.key === filter.key
+                    ? "bg-ink/[0.08] font-medium text-ink"
+                    : "text-ink-faint hover:text-ink-soft"
+                }`}
+              >
+                {f.label}
+                <span className="ml-1 tabular-nums opacity-60">{leadCounts.get(f.key)}</span>
+              </Link>
+            ))}
+          </div>
+        </div>
+        <Card>
+          {leads.length === 0 ? (
+            <p className="px-5 py-8 text-sm text-ink-faint">
+              Nobody in this segment has lapsed. Either everyone is active, or nobody in it exists.
+            </p>
+          ) : (
+            <>
+              <div className="flex items-center gap-4 border-b border-ink/10 px-5 py-2">
+                <ColumnHeader className="flex-1">Email · signup</ColumnHeader>
+                <ColumnHeader className="w-16 text-right">Class</ColumnHeader>
+                <ColumnHeader className="w-28 text-right">Last run</ColumnHeader>
+                <ColumnHeader className="w-14 text-right">R/30d</ColumnHeader>
+              </div>
+              <div className="max-h-96 divide-y divide-ink/5 overflow-y-auto">
+                {leads.map((lead) => (
+                  <div
+                    key={lead.userId}
+                    className="flex items-center gap-4 px-5 py-2.5 transition hover:bg-ink/[0.02]"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate font-mono text-[13px] text-ink">{lead.email}</p>
+                      <p className="text-xs text-ink-faint">
+                        signed up {timeAgo(lead.signedUpAt)} · {lead.projects} project
+                        {lead.projects === 1 ? "" : "s"}
+                      </p>
+                    </div>
+                    <span className="w-16 shrink-0 text-right">
+                      <Badge tone={CLASS_TONE[lead.emailClass]}>{lead.emailClass}</Badge>
+                    </span>
+                    <span className="w-28 shrink-0 text-right text-xs tabular-nums">
+                      {lead.lastRunAt === null ? (
+                        <span className="font-medium text-terracotta-dark">never ran</span>
+                      ) : (
+                        <span className="text-ink-faint">{timeAgo(lead.lastRunAt)}</span>
+                      )}
+                    </span>
+                    <span className="w-14 shrink-0 text-right font-mono text-xs tabular-nums text-ink-faint">
+                      {lead.runs30d}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
+        </Card>
+      </section>
+
+      <p className="text-xs text-ink-faint">
+        Active means “fired a run”, not “signed in”. Email classes: work = company domain,
+        personal = consumer providers, burner = disposable inboxes.{" "}
+        <Link href="/admin" className="underline">
+          Back to operations
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import Link from "next/link";
 import { Logo } from "@/components/logo";
 import { ThemeToggle } from "@/components/theme";
+import { AdminNav } from "./nav";
 
 /**
  * A deliberately plain shell, separate from the dashboard's.
@@ -20,12 +21,10 @@ export default function AdminLayout({ children }: { children: ReactNode }) {
   return (
     <div className="min-h-screen bg-paper">
       <header className="border-b border-ink/10">
-        <div className="mx-auto flex max-w-5xl items-center justify-between gap-4 px-6 py-4">
+        <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-6 py-4">
           <div className="flex items-center gap-3">
             <Logo />
-            <span className="rounded-sm bg-ink/[0.06] px-2 py-0.5 text-xs font-medium text-ink-soft">
-              operations
-            </span>
+            <AdminNav />
           </div>
           <div className="flex items-center gap-3">
             <Link href="/dashboard" className="text-sm text-ink-faint hover:text-ink">
@@ -35,7 +34,7 @@ export default function AdminLayout({ children }: { children: ReactNode }) {
           </div>
         </div>
       </header>
-      <main className="mx-auto max-w-5xl px-6 py-10">{children}</main>
+      <main className="mx-auto max-w-6xl px-6 py-10">{children}</main>
     </div>
   );
 }

--- a/app/admin/nav.tsx
+++ b/app/admin/nav.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils";
+
+/**
+ * The admin surface grew a second page, so the static "operations" chip in the
+ * layout became these tabs. Client-side only for usePathname — there is no
+ * state here.
+ *
+ * A run detail page is reached from Growth, so it highlights Growth: the tab
+ * answers "which section am I in", not "which URL is this".
+ */
+const TABS = [
+  { href: "/admin", label: "Operations", match: (p: string) => p === "/admin" },
+  {
+    href: "/admin/growth",
+    label: "Growth",
+    match: (p: string) => p.startsWith("/admin/growth") || p.startsWith("/admin/runs"),
+  },
+];
+
+export function AdminNav() {
+  const pathname = usePathname() ?? "";
+  return (
+    <nav className="flex items-center gap-1 rounded border border-ink/10 bg-surface p-1">
+      {TABS.map((tab) => {
+        const active = tab.match(pathname);
+        return (
+          <Link
+            key={tab.href}
+            href={tab.href}
+            aria-current={active ? "page" : undefined}
+            className={cn(
+              "rounded-sm px-2.5 py-1 text-xs transition",
+              active ? "bg-ink/[0.08] font-medium text-ink" : "text-ink-faint hover:text-ink-soft",
+            )}
+          >
+            {tab.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/app/admin/runs/[id]/page.tsx
+++ b/app/admin/runs/[id]/page.tsx
@@ -1,0 +1,257 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { requireAdmin } from "@/lib/admin";
+import { classifyEmail } from "@/lib/growth";
+import { createServiceClient } from "@/lib/supabase/service";
+import { Badge, Card, SectionHeading, StatCard } from "@/components/ui";
+import { timeAgo } from "@/lib/utils";
+
+export const dynamic = "force-dynamic";
+export const metadata = { robots: { index: false, follow: false } };
+
+/**
+ * One run, opened up: the prompts that were asked, the answers that came
+ * back, and what the engines said about the account's brand. Reached from
+ * the Growth page's run log.
+ *
+ * This crosses the user boundary on purpose (service role): the operator is
+ * reading their own product's data to write a better outbound email —
+ * "ChatGPT recommended your competitor in 4 of your 12 prompts" beats
+ * "just checking in". The admin gate is the whole access control, so it 404s
+ * exactly like the rest of /admin for anyone else.
+ */
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+interface MentionRow {
+  response_id: string;
+  entity_type: string;
+  entity_name: string;
+  mentioned: boolean;
+  sentiment: string | null;
+  recommended: boolean;
+}
+
+interface SourceRow {
+  response_id: string;
+  domain: string;
+  is_owned: boolean;
+}
+
+export default async function AdminRunPage({ params }: { params: { id: string } }) {
+  const admin = await requireAdmin();
+  if (!admin) notFound();
+  if (!UUID_RE.test(params.id)) notFound();
+
+  const svc = createServiceClient();
+  const { data: run } = await svc
+    .from("runs")
+    .select(
+      "id, project_id, status, provider, model, prompt_count, completed_count, replicates, route, error, created_at, finished_at",
+    )
+    .eq("id", params.id)
+    .maybeSingle();
+  if (!run) notFound();
+
+  const [{ data: project }, { data: responses }] = await Promise.all([
+    svc
+      .from("projects")
+      .select("id, user_id, name, brand_name")
+      .eq("id", run.project_id)
+      .maybeSingle(),
+    svc
+      .from("responses")
+      .select("id, prompt_id, provider, model, response_text, created_at")
+      .eq("run_id", run.id)
+      .order("created_at", { ascending: true })
+      .limit(500),
+  ]);
+
+  const promptIds = [...new Set((responses ?? []).map((r) => r.prompt_id).filter(Boolean))];
+  const [{ data: profile }, { data: prompts }, { data: mentions }, { data: sources }] =
+    await Promise.all([
+      project
+        ? svc.from("profiles").select("email").eq("id", project.user_id).maybeSingle()
+        : Promise.resolve({ data: null }),
+      promptIds.length > 0
+        ? svc.from("prompts").select("id, text").in("id", promptIds as string[])
+        : Promise.resolve({ data: [] }),
+      svc
+        .from("mentions")
+        .select("response_id, entity_type, entity_name, mentioned, sentiment, recommended")
+        .eq("run_id", run.id)
+        .limit(2_000),
+      svc
+        .from("sources")
+        .select("response_id, domain, is_owned")
+        .eq("run_id", run.id)
+        .limit(2_000),
+    ]);
+
+  const promptText = new Map((prompts ?? []).map((p) => [p.id, p.text]));
+  const mentionsByResponse = new Map<string, MentionRow[]>();
+  for (const m of (mentions ?? []) as MentionRow[]) {
+    const list = mentionsByResponse.get(m.response_id) ?? [];
+    list.push(m);
+    mentionsByResponse.set(m.response_id, list);
+  }
+  const sourcesByResponse = new Map<string, SourceRow[]>();
+  for (const s of (sources ?? []) as SourceRow[]) {
+    const list = sourcesByResponse.get(s.response_id) ?? [];
+    list.push(s);
+    sourcesByResponse.set(s.response_id, list);
+  }
+
+  const email = profile?.email ?? null;
+  const brandMentioned = (responses ?? []).filter((r) =>
+    (mentionsByResponse.get(r.id) ?? []).some((m) => m.entity_type === "brand" && m.mentioned),
+  ).length;
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <Link
+          href="/admin/growth"
+          className="mb-3 inline-flex items-center gap-1.5 text-sm text-ink-faint hover:text-ink"
+        >
+          <ArrowLeft className="h-4 w-4" aria-hidden /> Growth
+        </Link>
+        <SectionHeading
+          title={project?.brand_name || project?.name || "Run"}
+          description={
+            email
+              ? `Run by ${email} (${classifyEmail(email)} address) · project “${project?.name}”`
+              : "The owning project has been deleted; the answers below survive it."
+          }
+          action={
+            <Badge
+              tone={
+                run.status === "completed"
+                  ? "mint"
+                  : run.status === "failed"
+                    ? "terracotta"
+                    : "butter"
+              }
+            >
+              {run.status}
+            </Badge>
+          }
+        />
+      </div>
+
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        <StatCard
+          label="Engine"
+          value={<span className="font-mono text-xl">{run.provider}</span>}
+          hint={`${run.model}${run.route ? ` · via ${run.route}` : ""}`}
+          accent="teal"
+        />
+        <StatCard
+          label="Answers"
+          value={`${run.completed_count}/${run.prompt_count}`}
+          hint={`${run.replicates ?? 1} replicate${(run.replicates ?? 1) === 1 ? "" : "s"} per prompt`}
+          accent="mint"
+        />
+        <StatCard
+          label="Brand mentioned"
+          value={`${brandMentioned}/${(responses ?? []).length}`}
+          hint="answers naming the brand"
+          accent={brandMentioned > 0 ? "mint" : "terracotta"}
+        />
+        <StatCard
+          label="When"
+          value={timeAgo(run.created_at)}
+          hint={run.finished_at ? `finished ${timeAgo(run.finished_at)}` : "not finished"}
+          accent="sand"
+        />
+      </div>
+
+      {run.error && (
+        <Card className="border-terracotta/40 bg-terracotta/[0.04]">
+          <p className="break-words px-6 py-4 font-mono text-xs text-terracotta-dark">
+            {run.error}
+          </p>
+        </Card>
+      )}
+
+      <section className="space-y-2">
+        <div className="flex flex-wrap items-baseline gap-x-3">
+          <h3 className="text-lg font-semibold text-ink">Answers</h3>
+          <span className="text-sm tabular-nums text-ink-faint">{(responses ?? []).length}</span>
+        </div>
+        {(responses ?? []).length === 0 ? (
+          <Card>
+            <p className="px-6 py-8 text-sm text-ink-faint">
+              No answers recorded — the run {run.status === "failed" ? "failed" : "has not produced any yet"}.
+            </p>
+          </Card>
+        ) : (
+          <div className="space-y-3">
+            {(responses ?? []).map((response) => {
+              const responseMentions = mentionsByResponse.get(response.id) ?? [];
+              const responseSources = sourcesByResponse.get(response.id) ?? [];
+              const brand = responseMentions.find((m) => m.entity_type === "brand");
+              const competitors = responseMentions.filter(
+                (m) => m.entity_type === "competitor" && m.mentioned,
+              );
+              return (
+                <Card key={response.id}>
+                  <details className="group">
+                    <summary className="flex cursor-pointer list-none items-center gap-3 px-6 py-3.5 [&::-webkit-details-marker]:hidden">
+                      <span className="min-w-0 flex-1 truncate text-sm text-ink">
+                        {promptText.get(response.prompt_id ?? "") ?? "(prompt deleted)"}
+                      </span>
+                      {brand?.mentioned ? (
+                        <Badge tone={brand.recommended ? "mint" : "teal"}>
+                          {brand.recommended ? "recommended" : "mentioned"}
+                          {brand.sentiment ? ` · ${brand.sentiment}` : ""}
+                        </Badge>
+                      ) : (
+                        <Badge tone="sand">absent</Badge>
+                      )}
+                      {competitors.length > 0 && (
+                        <Badge tone="butter">
+                          {competitors.length} competitor{competitors.length === 1 ? "" : "s"}
+                        </Badge>
+                      )}
+                      <span className="shrink-0 text-xs text-ink-faint transition group-open:rotate-90">
+                        ›
+                      </span>
+                    </summary>
+                    <div className="space-y-4 border-t border-ink/5 px-6 py-4">
+                      <p className="whitespace-pre-wrap text-sm leading-relaxed text-ink-soft">
+                        {response.response_text}
+                      </p>
+                      {competitors.length > 0 && (
+                        <p className="text-xs text-ink-faint">
+                          Competitors named:{" "}
+                          {competitors
+                            .map((c) => `${c.entity_name}${c.recommended ? " (recommended)" : ""}`)
+                            .join(", ")}
+                        </p>
+                      )}
+                      {responseSources.length > 0 && (
+                        <p className="break-words text-xs text-ink-faint">
+                          Cited:{" "}
+                          {[...new Set(responseSources.map((s) => `${s.domain}${s.is_owned ? " ✓owned" : ""}`))].join(
+                            " · ",
+                          )}
+                        </p>
+                      )}
+                    </div>
+                  </details>
+                </Card>
+              );
+            })}
+          </div>
+        )}
+      </section>
+
+      <p className="text-xs text-ink-faint">
+        Operator view — this page shows customer run content so outbound can reference what the
+        account actually saw.
+      </p>
+    </div>
+  );
+}

--- a/lib/growth.test.ts
+++ b/lib/growth.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyEmail,
+  emailDomain,
+  shapeActivity,
+  shapeLeads,
+  shapeRecentRuns,
+  shapeTopAccounts,
+  type GrowthProfileRow,
+  type GrowthProjectRow,
+  type GrowthRunRow,
+} from "./growth";
+
+const DAY_MS = 86_400_000;
+const NOW = Date.parse("2026-08-15T12:00:00.000Z");
+
+function iso(daysAgo: number, hoursAgo = 0): string {
+  return new Date(NOW - daysAgo * DAY_MS - hoursAgo * 3_600_000).toISOString();
+}
+
+function run(overrides: Partial<GrowthRunRow>): GrowthRunRow {
+  return {
+    id: "r-" + Math.abs(JSON.stringify(overrides).length + (overrides.created_at?.length ?? 0)),
+    project_id: "proj-a",
+    status: "completed",
+    provider: "anthropic",
+    model: "claude-sonnet-4-6",
+    prompt_count: 10,
+    completed_count: 10,
+    created_at: iso(0, 1),
+    ...overrides,
+  };
+}
+
+const PROJECTS: GrowthProjectRow[] = [
+  { id: "proj-a", user_id: "u1", name: "Acme", brand_name: "Acme", last_run_at: iso(0, 1) },
+  { id: "proj-b", user_id: "u2", name: "Beta", brand_name: "BetaCo", last_run_at: iso(2) },
+  { id: "proj-c", user_id: "u2", name: "Beta EU", brand_name: "BetaCo", last_run_at: iso(40) },
+];
+
+const PROFILES: GrowthProfileRow[] = [
+  { id: "u1", email: "jo@acme.io", created_at: iso(60) },
+  { id: "u2", email: "sam@gmail.com", created_at: iso(20) },
+  { id: "u3", email: "eval@mailinator.com", created_at: iso(3) },
+];
+
+describe("emailDomain", () => {
+  it("lowercases and takes the part after the last @", () => {
+    expect(emailDomain("Jo@Acme.IO")).toBe("acme.io");
+    expect(emailDomain('"odd@local"@corp.com')).toBe("corp.com");
+  });
+
+  it("returns null for things that are not addresses", () => {
+    expect(emailDomain(null)).toBeNull();
+    expect(emailDomain("")).toBeNull();
+    expect(emailDomain("@nolocal.com")).toBeNull();
+    expect(emailDomain("no-at-sign")).toBeNull();
+    expect(emailDomain("user@nodot")).toBeNull();
+  });
+});
+
+describe("classifyEmail", () => {
+  it("classes company domains as work", () => {
+    expect(classifyEmail("jo@acme.io")).toBe("work");
+    expect(classifyEmail("a@sub.corp.co.uk")).toBe("work");
+  });
+
+  it("classes free providers as personal, including country variants", () => {
+    expect(classifyEmail("a@gmail.com")).toBe("personal");
+    expect(classifyEmail("a@GMAIL.com")).toBe("personal");
+    expect(classifyEmail("a@yahoo.co.uk")).toBe("personal");
+    expect(classifyEmail("a@outlook.com.br")).toBe("personal");
+    expect(classifyEmail("a@proton.me")).toBe("personal");
+  });
+
+  it("classes disposable inboxes as burner, including subdomains", () => {
+    expect(classifyEmail("x@mailinator.com")).toBe("burner");
+    expect(classifyEmail("x@abc.mailinator.com")).toBe("burner");
+    expect(classifyEmail("x@yopmail.com")).toBe("burner");
+  });
+
+  it("does not suffix-match personal providers into work domains", () => {
+    // notgmail.com is somebody's company, not Google.
+    expect(classifyEmail("a@notgmail.com")).toBe("work");
+  });
+
+  it("falls back to personal when unparseable", () => {
+    expect(classifyEmail(null)).toBe("personal");
+    expect(classifyEmail("nonsense")).toBe("personal");
+  });
+});
+
+describe("shapeActivity", () => {
+  const owners = new Map([
+    ["proj-a", "u1"],
+    ["proj-b", "u2"],
+    ["proj-c", "u2"],
+  ]);
+
+  it("counts rolling windows in both users and runs", () => {
+    const runs = [
+      run({ project_id: "proj-a", created_at: iso(0, 2) }), // today, u1
+      run({ project_id: "proj-a", created_at: iso(0, 3) }), // today again, u1
+      run({ project_id: "proj-b", created_at: iso(3) }), // this week, u2
+      run({ project_id: "proj-b", created_at: iso(20) }), // this month, u2
+    ];
+    const a = shapeActivity(runs, owners, NOW);
+    expect(a.daily).toEqual({ users: 1, runs: 2 });
+    expect(a.weekly).toEqual({ users: 2, runs: 3 });
+    expect(a.monthly).toEqual({ users: 2, runs: 4 });
+    expect(a.stickiness).toBe(50);
+  });
+
+  it("ignores runs outside 30 days and runs from the future", () => {
+    const runs = [
+      run({ created_at: iso(31) }),
+      run({ created_at: new Date(NOW + DAY_MS).toISOString() }),
+    ];
+    const a = shapeActivity(runs, owners, NOW);
+    expect(a.monthly).toEqual({ users: 0, runs: 0 });
+    expect(a.stickiness).toBeNull();
+  });
+
+  it("zero-fills a 30-day series, oldest first", () => {
+    const runs = [run({ created_at: iso(1, 1) })];
+    const a = shapeActivity(runs, owners, NOW);
+    expect(a.series).toHaveLength(30);
+    expect(a.series[29].day).toBe("2026-08-15");
+    expect(a.series.reduce((sum, d) => sum + d.runs, 0)).toBe(1);
+    expect(a.series.filter((d) => d.runs === 0)).toHaveLength(29);
+  });
+
+  it("counts a run whose project is gone in runs but not users", () => {
+    const runs = [run({ project_id: "proj-deleted", created_at: iso(0, 1) })];
+    const a = shapeActivity(runs, owners, NOW);
+    expect(a.daily).toEqual({ users: 0, runs: 1 });
+  });
+});
+
+describe("shapeTopAccounts", () => {
+  it("ranks by run count and aggregates brands across projects", () => {
+    const runs = [
+      run({ project_id: "proj-b", created_at: iso(1) }),
+      run({ project_id: "proj-c", created_at: iso(2) }),
+      run({ project_id: "proj-a", created_at: iso(3) }),
+    ];
+    const top = shapeTopAccounts(runs, PROJECTS, PROFILES);
+    expect(top.map((t) => t.userId)).toEqual(["u2", "u1"]);
+    expect(top[0]).toMatchObject({
+      email: "sam@gmail.com",
+      emailClass: "personal",
+      runs30d: 2,
+      projects: 2,
+      brands: ["BetaCo"],
+    });
+  });
+
+  it("honors the limit", () => {
+    const runs = [
+      run({ project_id: "proj-a", created_at: iso(1) }),
+      run({ project_id: "proj-b", created_at: iso(1, 1) }),
+    ];
+    expect(shapeTopAccounts(runs, PROJECTS, PROFILES, 1)).toHaveLength(1);
+  });
+});
+
+describe("shapeRecentRuns", () => {
+  it("returns newest first with the owner's email attached", () => {
+    const runs = [
+      run({ id: "old", project_id: "proj-a", created_at: iso(5) }),
+      run({ id: "new", project_id: "proj-b", created_at: iso(0, 1) }),
+    ];
+    const feed = shapeRecentRuns(runs, PROJECTS, PROFILES);
+    expect(feed.map((r) => r.id)).toEqual(["new", "old"]);
+    expect(feed[0]).toMatchObject({
+      email: "sam@gmail.com",
+      projectName: "Beta",
+      brandName: "BetaCo",
+    });
+  });
+
+  it("survives a run whose project was deleted", () => {
+    const feed = shapeRecentRuns([run({ project_id: "gone" })], PROJECTS, PROFILES);
+    expect(feed[0].projectName).toBe("(deleted project)");
+    expect(feed[0].email).toBeNull();
+  });
+});
+
+describe("shapeLeads", () => {
+  it("lists users with no run in 7 days, including never-ran signups", () => {
+    const runs = [run({ project_id: "proj-b", created_at: iso(10) })];
+    const projects: GrowthProjectRow[] = [
+      { ...PROJECTS[0], last_run_at: iso(10) }, // u1 lapsed
+      { ...PROJECTS[1], last_run_at: iso(10) }, // u2 lapsed
+    ];
+    const leads = shapeLeads(runs, projects, PROFILES, NOW);
+    // Newest signup first: u3 (never ran) → u2 → u1.
+    expect(leads.map((l) => l.userId)).toEqual(["u3", "u2", "u1"]);
+    expect(leads[0]).toMatchObject({ emailClass: "burner", lastRunAt: null, projects: 0 });
+    expect(leads[1].runs30d).toBe(1);
+  });
+
+  it("excludes anyone active within 7 days", () => {
+    const runs = [run({ project_id: "proj-a", created_at: iso(2) })];
+    const leads = shapeLeads(runs, PROJECTS, PROFILES, NOW);
+    expect(leads.some((l) => l.userId === "u1")).toBe(false);
+  });
+
+  it("uses projects.last_run_at when the run predates the fetched window", () => {
+    // No runs fetched at all, but the project remembers a run 3 days ago.
+    const projects: GrowthProjectRow[] = [{ ...PROJECTS[0], last_run_at: iso(3) }];
+    const leads = shapeLeads([], projects, PROFILES, NOW);
+    expect(leads.some((l) => l.userId === "u1")).toBe(false);
+  });
+
+  it("drops accounts without an email — they cannot be contacted", () => {
+    const profiles: GrowthProfileRow[] = [{ id: "u9", email: null, created_at: iso(1) }];
+    expect(shapeLeads([], [], profiles, NOW)).toHaveLength(0);
+  });
+});

--- a/lib/growth.ts
+++ b/lib/growth.ts
@@ -1,0 +1,491 @@
+import { createServiceClient } from "@/lib/supabase/service";
+
+/**
+ * The growth half of the operations picture: who is actually using the
+ * product, measured in RUNS rather than sessions.
+ *
+ * A visibility tracker's unit of value is the run — a user who signs in daily
+ * but never fires one is a spectator, and a user who runs weekly on a schedule
+ * is retained even if they never open the app. So "active" here always means
+ * "had a run", and every count comes in pairs: distinct users AND run volume,
+ * because ten users running once and one user running ten times are different
+ * businesses.
+ *
+ * This module also exists for outbound. The ops page deliberately masks
+ * emails and never touches customer content; this one deliberately does the
+ * opposite, because its consumer is the operator deciding who to email next.
+ * Both pages sit behind the same requireAdmin gate — the difference is
+ * purpose, not privilege.
+ *
+ * Everything below the loader is pure and unit-tested; the loader only
+ * fetches rows and hands them over.
+ */
+
+// ---------------------------------------------------------------------------
+// Email classification
+// ---------------------------------------------------------------------------
+
+export type EmailClass = "work" | "personal" | "burner";
+
+/** Free consumer mail providers — real people, weak outbound targets. */
+const PERSONAL_DOMAINS = new Set([
+  "gmail.com",
+  "googlemail.com",
+  "icloud.com",
+  "me.com",
+  "mac.com",
+  "aol.com",
+  "msn.com",
+  "mail.com",
+  "email.com",
+  "proton.me",
+  "protonmail.com",
+  "pm.me",
+  "zoho.com",
+  "qq.com",
+  "163.com",
+  "126.com",
+  "naver.com",
+  "daum.net",
+  "web.de",
+  "t-online.de",
+  "comcast.net",
+  "verizon.net",
+  "att.net",
+  "sbcglobal.net",
+  "hey.com",
+  "fastmail.com",
+  "duck.com",
+  "duckduckgo.com",
+]);
+
+/** Providers with many country TLDs — match on the first label instead of
+ *  enumerating yahoo.co.uk, yahoo.fr, outlook.com.br, … */
+const PERSONAL_FIRST_LABELS = new Set([
+  "yahoo",
+  "ymail",
+  "hotmail",
+  "outlook",
+  "live",
+  "gmx",
+  "yandex",
+]);
+
+/** Disposable-inbox services. A signup from one is almost never a lead — but
+ *  it IS a signal (someone evaluating anonymously, or abuse), so they are
+ *  labeled rather than dropped. Suffix-matched: mailinator.com covers
+ *  anything.mailinator.com. */
+const BURNER_DOMAINS = [
+  "mailinator.com",
+  "guerrillamail.com",
+  "guerrillamailblock.com",
+  "sharklasers.com",
+  "yopmail.com",
+  "temp-mail.org",
+  "tempmail.dev",
+  "tempmail.com",
+  "temp-mail.io",
+  "10minutemail.com",
+  "10minemail.com",
+  "trashmail.com",
+  "trash-mail.com",
+  "getnada.com",
+  "nada.email",
+  "dropmail.me",
+  "maildrop.cc",
+  "mohmal.com",
+  "fakeinbox.com",
+  "mintemail.com",
+  "dispostable.com",
+  "mailnesia.com",
+  "tempr.email",
+  "discard.email",
+  "spamgourmet.com",
+  "mytemp.email",
+  "throwawaymail.com",
+  "emailondeck.com",
+  "burnermail.io",
+  "33mail.com",
+  "tmpmail.net",
+  "mail.tm",
+  "inboxkitten.com",
+];
+
+/** The domain part, lowercased, or null when the string isn't shaped like an
+ *  address. Plus-addressing and case live in the local part and don't matter
+ *  here. */
+export function emailDomain(email: string | null | undefined): string | null {
+  const at = (email ?? "").lastIndexOf("@");
+  if (at <= 0) return null;
+  const domain = (email ?? "")
+    .slice(at + 1)
+    .trim()
+    .toLowerCase();
+  return domain.includes(".") ? domain : null;
+}
+
+/** work / personal / burner. Unparseable addresses class as personal — the
+ *  conservative bucket, since both other classes trigger operator action
+ *  (outbound and suspicion respectively). */
+export function classifyEmail(email: string | null | undefined): EmailClass {
+  const domain = emailDomain(email);
+  if (!domain) return "personal";
+  if (BURNER_DOMAINS.some((b) => domain === b || domain.endsWith(`.${b}`))) return "burner";
+  if (PERSONAL_DOMAINS.has(domain)) return "personal";
+  const firstLabel = domain.split(".")[0];
+  if (PERSONAL_FIRST_LABELS.has(firstLabel)) return "personal";
+  return "work";
+}
+
+// ---------------------------------------------------------------------------
+// Row shapes (what the loader fetches — kept minimal on purpose)
+// ---------------------------------------------------------------------------
+
+export interface GrowthRunRow {
+  id: string;
+  project_id: string;
+  status: string;
+  provider: string;
+  model: string;
+  prompt_count: number;
+  completed_count: number;
+  created_at: string;
+}
+
+export interface GrowthProjectRow {
+  id: string;
+  user_id: string;
+  name: string;
+  brand_name: string;
+  last_run_at: string | null;
+}
+
+export interface GrowthProfileRow {
+  id: string;
+  email: string | null;
+  created_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Activity: DAU / WAU / MAU in runs terms
+// ---------------------------------------------------------------------------
+
+export interface ActivityWindow {
+  /** Distinct users who fired at least one run in the window. */
+  users: number;
+  /** Runs created in the window, any status — intent counts even when the
+   *  provider fails the run. */
+  runs: number;
+}
+
+export interface ActivityDay {
+  /** UTC date, YYYY-MM-DD. */
+  day: string;
+  users: number;
+  runs: number;
+}
+
+export interface Activity {
+  daily: ActivityWindow;
+  weekly: ActivityWindow;
+  monthly: ActivityWindow;
+  /** daily.users / monthly.users — the classic stickiness ratio, null until
+   *  there is a month of anyone to divide by. */
+  stickiness: number | null;
+  /** Last 30 UTC days, oldest first, zero-filled — a gap is a real zero. */
+  series: ActivityDay[];
+}
+
+const DAY_MS = 86_400_000;
+
+function utcDay(iso: string): string {
+  return iso.slice(0, 10);
+}
+
+/** Rolling windows (24h / 7d / 30d back from `now`), not calendar buckets —
+ *  an admin checking at 9am should not see a DAU that reset at midnight. */
+export function shapeActivity(
+  runs: GrowthRunRow[],
+  projectOwner: Map<string, string>,
+  now: number,
+): Activity {
+  const cutoffs = { daily: now - DAY_MS, weekly: now - 7 * DAY_MS, monthly: now - 30 * DAY_MS };
+  const win = {
+    daily: { users: new Set<string>(), runs: 0 },
+    weekly: { users: new Set<string>(), runs: 0 },
+    monthly: { users: new Set<string>(), runs: 0 },
+  };
+  const byDay = new Map<string, { users: Set<string>; runs: number }>();
+
+  for (const run of runs) {
+    const t = Date.parse(run.created_at);
+    const owner = projectOwner.get(run.project_id);
+    if (!Number.isFinite(t) || t < cutoffs.monthly || t > now) continue;
+    for (const key of ["daily", "weekly", "monthly"] as const) {
+      if (t >= cutoffs[key]) {
+        win[key].runs += 1;
+        if (owner) win[key].users.add(owner);
+      }
+    }
+    const day = utcDay(run.created_at);
+    const bucket = byDay.get(day) ?? { users: new Set<string>(), runs: 0 };
+    bucket.runs += 1;
+    if (owner) bucket.users.add(owner);
+    byDay.set(day, bucket);
+  }
+
+  const series: ActivityDay[] = [];
+  for (let i = 29; i >= 0; i--) {
+    const day = new Date(now - i * DAY_MS).toISOString().slice(0, 10);
+    const bucket = byDay.get(day);
+    series.push({ day, users: bucket?.users.size ?? 0, runs: bucket?.runs ?? 0 });
+  }
+
+  const monthlyUsers = win.monthly.users.size;
+  return {
+    daily: { users: win.daily.users.size, runs: win.daily.runs },
+    weekly: { users: win.weekly.users.size, runs: win.weekly.runs },
+    monthly: { users: monthlyUsers, runs: win.monthly.runs },
+    stickiness: monthlyUsers > 0 ? Math.round((win.daily.users.size / monthlyUsers) * 100) : null,
+    series,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Most active accounts
+// ---------------------------------------------------------------------------
+
+export interface TopAccount {
+  userId: string;
+  email: string | null;
+  emailClass: EmailClass;
+  runs30d: number;
+  projects: number;
+  /** The account's brands, for "who is this" at a glance. */
+  brands: string[];
+  lastRunAt: string | null;
+}
+
+export function shapeTopAccounts(
+  runs: GrowthRunRow[],
+  projects: GrowthProjectRow[],
+  profiles: GrowthProfileRow[],
+  limit = 15,
+): TopAccount[] {
+  const projectOwner = new Map(projects.map((p) => [p.id, p.user_id]));
+  const emailByUser = new Map(profiles.map((p) => [p.id, p.email]));
+
+  const acc = new Map<string, { runs: number; lastRunAt: string | null }>();
+  for (const run of runs) {
+    const owner = projectOwner.get(run.project_id);
+    if (!owner) continue;
+    const entry = acc.get(owner) ?? { runs: 0, lastRunAt: null };
+    entry.runs += 1;
+    if (!entry.lastRunAt || run.created_at > entry.lastRunAt) entry.lastRunAt = run.created_at;
+    acc.set(owner, entry);
+  }
+  // projects.last_run_at reaches further back than the fetched run window, so
+  // an account whose last run predates the window still shows WHEN, even
+  // though its 30d count is zero.
+  const byUser = new Map<string, { projects: number; brands: string[]; lastRunAt: string | null }>();
+  for (const p of projects) {
+    const entry = byUser.get(p.user_id) ?? { projects: 0, brands: [], lastRunAt: null };
+    entry.projects += 1;
+    if (p.brand_name && !entry.brands.includes(p.brand_name)) entry.brands.push(p.brand_name);
+    if (p.last_run_at && (!entry.lastRunAt || p.last_run_at > entry.lastRunAt)) {
+      entry.lastRunAt = p.last_run_at;
+    }
+    byUser.set(p.user_id, entry);
+  }
+
+  return [...acc.entries()]
+    .map(([userId, a]) => {
+      const email = emailByUser.get(userId) ?? null;
+      const meta = byUser.get(userId);
+      return {
+        userId,
+        email,
+        emailClass: classifyEmail(email),
+        runs30d: a.runs,
+        projects: meta?.projects ?? 0,
+        brands: (meta?.brands ?? []).slice(0, 3),
+        lastRunAt: a.lastRunAt ?? meta?.lastRunAt ?? null,
+      };
+    })
+    .sort((a, b) => b.runs30d - a.runs30d || (b.lastRunAt ?? "").localeCompare(a.lastRunAt ?? ""))
+    .slice(0, limit);
+}
+
+// ---------------------------------------------------------------------------
+// Recent runs feed (the outbound log)
+// ---------------------------------------------------------------------------
+
+export interface RecentRun {
+  id: string;
+  email: string | null;
+  emailClass: EmailClass;
+  projectName: string;
+  brandName: string;
+  provider: string;
+  model: string;
+  status: string;
+  done: number;
+  planned: number;
+  createdAt: string;
+}
+
+export function shapeRecentRuns(
+  runs: GrowthRunRow[],
+  projects: GrowthProjectRow[],
+  profiles: GrowthProfileRow[],
+  limit = 30,
+): RecentRun[] {
+  const projectById = new Map(projects.map((p) => [p.id, p]));
+  const emailByUser = new Map(profiles.map((p) => [p.id, p.email]));
+  return [...runs]
+    .sort((a, b) => b.created_at.localeCompare(a.created_at))
+    .slice(0, limit)
+    .map((run) => {
+      const project = projectById.get(run.project_id);
+      const email = project ? (emailByUser.get(project.user_id) ?? null) : null;
+      return {
+        id: run.id,
+        email,
+        emailClass: classifyEmail(email),
+        projectName: project?.name ?? "(deleted project)",
+        brandName: project?.brand_name ?? "",
+        provider: run.provider,
+        model: run.model,
+        status: run.status,
+        done: run.completed_count,
+        planned: run.prompt_count,
+        createdAt: run.created_at,
+      };
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Lapsed leads (the outbound list)
+// ---------------------------------------------------------------------------
+
+export interface Lead {
+  userId: string;
+  email: string;
+  emailClass: EmailClass;
+  signedUpAt: string;
+  /** Null = never fired a run at all (often the best outbound target: they
+   *  wanted this enough to sign up, then bounced off something). */
+  lastRunAt: string | null;
+  runs30d: number;
+  projects: number;
+}
+
+/** Users with no run in the last 7 days, most recent signup first. The page
+ *  filters by class; this returns all three so the counts per class come for
+ *  free. Accounts without an email can't be contacted and are dropped. */
+export function shapeLeads(
+  runs: GrowthRunRow[],
+  projects: GrowthProjectRow[],
+  profiles: GrowthProfileRow[],
+  now: number,
+): Lead[] {
+  const cutoff = now - 7 * DAY_MS;
+  const projectOwner = new Map(projects.map((p) => [p.id, p.user_id]));
+
+  const lastRunByUser = new Map<string, string>();
+  const runs30dByUser = new Map<string, number>();
+  for (const p of projects) {
+    if (!p.last_run_at) continue;
+    const prev = lastRunByUser.get(p.user_id);
+    if (!prev || p.last_run_at > prev) lastRunByUser.set(p.user_id, p.last_run_at);
+  }
+  for (const run of runs) {
+    const owner = projectOwner.get(run.project_id);
+    if (!owner) continue;
+    runs30dByUser.set(owner, (runs30dByUser.get(owner) ?? 0) + 1);
+    const prev = lastRunByUser.get(owner);
+    if (!prev || run.created_at > prev) lastRunByUser.set(owner, run.created_at);
+  }
+
+  const projectsByUser = new Map<string, number>();
+  for (const p of projects) {
+    projectsByUser.set(p.user_id, (projectsByUser.get(p.user_id) ?? 0) + 1);
+  }
+
+  return profiles
+    .filter((p) => p.email)
+    .map((p) => {
+      const lastRunAt = lastRunByUser.get(p.id) ?? null;
+      return {
+        userId: p.id,
+        email: p.email as string,
+        emailClass: classifyEmail(p.email),
+        signedUpAt: p.created_at,
+        lastRunAt,
+        runs30d: runs30dByUser.get(p.id) ?? 0,
+        projects: projectsByUser.get(p.id) ?? 0,
+      };
+    })
+    .filter((lead) => !lead.lastRunAt || Date.parse(lead.lastRunAt) < cutoff)
+    .sort((a, b) => b.signedUpAt.localeCompare(a.signedUpAt));
+}
+
+// ---------------------------------------------------------------------------
+// Loader
+// ---------------------------------------------------------------------------
+
+export interface GrowthReport {
+  activity: Activity;
+  topAccounts: TopAccount[];
+  recentRuns: RecentRun[];
+  leads: Lead[];
+  totalUsers: number;
+  /** Set when a query failed — the page says "incomplete", never fake zero. */
+  degraded: string | null;
+}
+
+/** Row caps, not pagination: at 10× today's volume these still fit in one
+ *  server render, and the day they don't is the day this page earns real
+ *  aggregation SQL. */
+const RUNS_CAP = 20_000;
+const ROWS_CAP = 10_000;
+
+export async function growthReport(now = Date.now()): Promise<GrowthReport> {
+  const svc = createServiceClient();
+  const since = new Date(now - 30 * DAY_MS).toISOString();
+
+  const [runsQ, projectsQ, profilesQ] = await Promise.all([
+    svc
+      .from("runs")
+      .select("id, project_id, status, provider, model, prompt_count, completed_count, created_at")
+      .gte("created_at", since)
+      .order("created_at", { ascending: false })
+      .limit(RUNS_CAP),
+    svc.from("projects").select("id, user_id, name, brand_name, last_run_at").limit(ROWS_CAP),
+    svc
+      .from("profiles")
+      .select("id, email, created_at")
+      .order("created_at", { ascending: false })
+      .limit(ROWS_CAP),
+  ]);
+
+  const failed = [
+    runsQ.error && "runs",
+    projectsQ.error && "projects",
+    profilesQ.error && "profiles",
+  ].filter(Boolean);
+
+  const runs = (runsQ.data ?? []) as GrowthRunRow[];
+  const projects = (projectsQ.data ?? []) as GrowthProjectRow[];
+  const profiles = (profilesQ.data ?? []) as GrowthProfileRow[];
+  const projectOwner = new Map(projects.map((p) => [p.id, p.user_id]));
+
+  return {
+    activity: shapeActivity(runs, projectOwner, now),
+    topAccounts: shapeTopAccounts(runs, projects, profiles),
+    recentRuns: shapeRecentRuns(runs, projects, profiles),
+    leads: shapeLeads(runs, projects, profiles, now),
+    totalUsers: profiles.length,
+    degraded: failed.length > 0 ? failed.join(", ") : null,
+  };
+}


### PR DESCRIPTION
## What

`/admin` grows a second tab. **Operations** (unchanged) answers *"is the deployment healthy"*; the new **Growth** tab answers *"who is using it, and who should we email next"*.

### Growth page (`/admin/growth`)
- **DAU / WAU / MAU in runs terms** — rolling 24h/7d/30d windows (not calendar buckets), each shown as *distinct users who fired a run* **and** *run volume*, because ten users running once and one user running ten times are different businesses. Plus DAU/MAU stickiness and a 30-day runs-per-day sparkline.
- **Most active accounts** — ranked by 30d runs, with email, brands, project count, last-run recency.
- **Latest runs log** — who just ran what, engine/model, completion; each row opens the run.
- **Lapsed leads** — everyone with no run in 7 days, newest signup first, classified by email domain: `work` (company domain), `personal` (consumer providers incl. country variants), `burner` (~30 disposable-inbox domains, subdomain-matched). Filter chips default to **Work** — that's the outbound list. Never-ran signups get their own flag: warmest leads of all.

### Run detail (`/admin/runs/[id]`)
The run opened up for outbound context: every prompt, the full answer text, whether the brand was mentioned/recommended (with sentiment), competitors named, and cited domains (owned ones flagged). *"ChatGPT recommended your competitor in 4 of your 12 prompts"* beats *"just checking in"*.

## Design notes

- **Privacy stance is deliberate and stated on-page.** The ops page keeps its "no customer content" promise untouched. Growth does the opposite — emails in the clear, run content one click away — and says so in its own copy. Same `requireAdmin` gate (404 to outsiders), different purpose.
- **Public repo hygiene:** the email-provider lists are generic; nothing org-specific ships in source.
- **All shaping logic is pure** (`lib/growth.ts`) and unit-tested; the loader fetches rows and hands them over. Row caps instead of pagination — the day the caps bind is the day this page earns real aggregation SQL.
- `projects.last_run_at` backstops the 30-day run window, so an account whose last run predates the window still shows *when* rather than pretending "never".
- Admin container widened 5xl → 6xl; the static "operations" chip in the layout became the tab nav.

## Testing

- 19 new unit tests for classification (incl. the `notgmail.com` trap, subdomain burners, country-TLD providers), rolling windows, zero-filled series, deleted-project runs, and lead edge cases (never-ran, no-email, out-of-window last runs).
- Full suite: **671 passing**. `tsc --noEmit` and eslint clean.
- Exercised locally against the live DB with real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789429077&installation_model_id=431526&pr_number=119&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F119&signature=499118ee148e4fbfe2206f720edfe85fe1cdea5a85f4e904a81581ba4fbe05b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->