### PR TITLE
feat(admin): People directory modal and per-account telemetry

### DIFF
--- a/app/admin/accounts/[id]/page.tsx
+++ b/app/admin/accounts/[id]/page.tsx
@@ -1,0 +1,566 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { ArrowLeft, ArrowUpRight, Flame } from "lucide-react";
+import { requireAdmin } from "@/lib/admin";
+import { classifyEmail } from "@/lib/growth";
+import { deriveCompany } from "@/lib/accounts";
+import { createServiceClient } from "@/lib/supabase/service";
+import { Badge, Card, SectionHeading, StatCard } from "@/components/ui";
+import { formatDate, timeAgo } from "@/lib/utils";
+
+export const dynamic = "force-dynamic";
+export const metadata = { robots: { index: false, follow: false } };
+
+/**
+ * One account, opened up: how often they run, what they monitor, and what
+ * they've done. Reached from the People directory on the Growth page.
+ *
+ * Like the run page, this crosses the user boundary on purpose (service role):
+ * the operator is reading their own product's data to understand who is using
+ * it and decide who to reach. The admin gate is the whole access control, so it
+ * 404s exactly like the rest of /admin for anyone else.
+ */
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const DAY_MS = 86_400_000;
+
+const SCHEDULE_TONE = { off: "sand", daily: "mint", weekly: "teal" } as const;
+
+interface ProjectRow {
+  id: string;
+  name: string;
+  brand_name: string;
+  brand_domains: string[];
+  description: string | null;
+  schedule: "off" | "daily" | "weekly";
+  default_provider: string;
+  default_model: string;
+  replicates: number;
+  use_web_search: boolean;
+  last_run_at: string | null;
+  created_at: string;
+}
+interface RunRow {
+  id: string;
+  project_id: string;
+  status: string;
+  provider: string;
+  model: string;
+  prompt_count: number;
+  completed_count: number;
+  created_at: string;
+}
+interface TopicRow {
+  id: string;
+  project_id: string;
+  name: string;
+}
+interface PromptRow {
+  id: string;
+  project_id: string;
+  topic_id: string | null;
+  text: string;
+  target_url: string | null;
+}
+interface CompetitorRow {
+  id: string;
+  project_id: string;
+  name: string;
+  domain: string | null;
+}
+interface WatchRow {
+  project_id: string;
+  enabled: boolean;
+  sites: string[];
+}
+interface ActivityRow {
+  id: string;
+  category: string;
+  action: string;
+  status: string;
+  summary: string;
+  channel: string;
+  created_at: string;
+}
+
+function statusTone(status: string): "mint" | "terracotta" | "butter" {
+  return status === "completed" ? "mint" : status === "failed" ? "terracotta" : "butter";
+}
+function activityTone(status: string): "mint" | "terracotta" | "butter" | "neutral" {
+  return status === "success"
+    ? "mint"
+    : status === "failure"
+      ? "terracotta"
+      : status === "pending"
+        ? "butter"
+        : "neutral";
+}
+
+/** 30 days of this account's runs as bars — the answer to "how often". Inline
+ *  SVG, colours through style so CSS var() resolves. Mirrors the Growth page. */
+function RunSparkline({ series }: { series: { day: string; runs: number }[] }) {
+  const max = Math.max(1, ...series.map((d) => d.runs));
+  const barW = 600 / series.length;
+  return (
+    <svg
+      viewBox="0 0 600 90"
+      preserveAspectRatio="none"
+      className="h-24 w-full"
+      role="img"
+      aria-label="Runs per day, last 30 days"
+    >
+      {series.map((d, i) => {
+        const h = d.runs === 0 ? 2 : Math.max(4, (d.runs / max) * 82);
+        return (
+          <rect
+            key={d.day}
+            x={i * barW + 1.5}
+            y={86 - h}
+            width={barW - 3}
+            height={h}
+            rx={1.5}
+            style={{
+              fill: d.runs === 0 ? "rgb(var(--c-ink) / 0.12)" : "rgb(var(--c-mint-bright))",
+            }}
+          >
+            <title>{`${d.day} — ${d.runs} run${d.runs === 1 ? "" : "s"}`}</title>
+          </rect>
+        );
+      })}
+    </svg>
+  );
+}
+
+function ColumnHeader({ children, className }: { children: React.ReactNode; className?: string }) {
+  return (
+    <span
+      className={`text-[10px] font-medium uppercase tracking-wider text-ink-faint ${className ?? ""}`}
+    >
+      {children}
+    </span>
+  );
+}
+
+export default async function AdminAccountPage({ params }: { params: { id: string } }) {
+  const admin = await requireAdmin();
+  if (!admin) notFound();
+  if (!UUID_RE.test(params.id)) notFound();
+
+  const svc = createServiceClient();
+  const { data: profile } = await svc
+    .from("profiles")
+    .select("id, email, created_at, trial_runs_used, trial_tokens_used, trial_spend_micros")
+    .eq("id", params.id)
+    .maybeSingle();
+  if (!profile) notFound();
+
+  const { data: projectRows } = await svc
+    .from("projects")
+    .select(
+      "id, name, brand_name, brand_domains, description, schedule, default_provider, default_model, replicates, use_web_search, last_run_at, created_at",
+    )
+    .eq("user_id", profile.id)
+    .order("created_at", { ascending: true });
+  const projects = (projectRows ?? []) as ProjectRow[];
+  const projectIds = projects.map((p) => p.id);
+
+  // now/since are needed by the cadence query below, so they're computed here
+  // rather than down in the derivation block.
+  const now = Date.now();
+  const since30d = new Date(now - 30 * DAY_MS).toISOString();
+
+  const emptyRows = Promise.resolve({ data: [] as unknown[] });
+  const [recentQ, totalRunsQ, cadenceQ, topicsQ, promptsQ, competitorsQ, watchQ, activityQ] =
+    await Promise.all([
+      // The Recent-runs list: the latest few, whatever their age. Capped at what
+      // the section renders so the count and the list can never disagree.
+      projectIds.length
+        ? svc
+            .from("runs")
+            .select(
+              "id, project_id, status, provider, model, prompt_count, completed_count, created_at",
+            )
+            .in("project_id", projectIds)
+            .order("created_at", { ascending: false })
+            .limit(60)
+        : emptyRows,
+      // Total runs, exact — the headline number, never capped.
+      projectIds.length
+        ? svc.from("runs").select("id", { count: "exact", head: true }).in("project_id", projectIds)
+        : Promise.resolve({ count: 0 }),
+      // Cadence: EVERY run in the last 30 days, date-filtered so runs30d/runs7d
+      // and the sparkline stay accurate for heavy accounts instead of saturating
+      // at a row cap (the whole reason this page exists is the busy ones). Mirrors
+      // the 30-day fetch the Growth top-accounts list uses.
+      projectIds.length
+        ? svc
+            .from("runs")
+            .select("created_at")
+            .in("project_id", projectIds)
+            .gte("created_at", since30d)
+            .limit(5_000)
+        : emptyRows,
+      projectIds.length
+        ? svc.from("topics").select("id, project_id, name").in("project_id", projectIds)
+        : emptyRows,
+    projectIds.length
+      ? svc
+          .from("prompts")
+          .select("id, project_id, topic_id, text, target_url")
+          .in("project_id", projectIds)
+          .eq("is_active", true)
+          .limit(1_000)
+      : emptyRows,
+    projectIds.length
+      ? svc.from("competitors").select("id, project_id, name, domain").in("project_id", projectIds)
+      : emptyRows,
+    projectIds.length
+      ? svc.from("web_mention_watch").select("project_id, enabled, sites").in("project_id", projectIds)
+      : emptyRows,
+    svc
+      .from("activity_logs")
+      .select("id, category, action, status, summary, channel, created_at")
+      .eq("user_id", profile.id)
+      .order("created_at", { ascending: false })
+      .limit(40),
+  ]);
+
+  const runs = (recentQ.data ?? []) as RunRow[];
+  const totalRuns = (totalRunsQ as { count: number | null }).count ?? runs.length;
+  const cadence = (cadenceQ.data ?? []) as { created_at: string }[];
+  const topics = (topicsQ.data ?? []) as TopicRow[];
+  const prompts = (promptsQ.data ?? []) as PromptRow[];
+  const competitors = (competitorsQ.data ?? []) as CompetitorRow[];
+  const watches = (watchQ.data ?? []) as WatchRow[];
+  const activity = (activityQ.data ?? []) as ActivityRow[];
+
+  // ---- Derived identity ----------------------------------------------------
+  const email = profile.email as string | null;
+  const emailClass = classifyEmail(email);
+  const brands = [...new Set(projects.map((p) => p.brand_name).filter(Boolean))];
+  const company = deriveCompany(email, emailClass, brands);
+
+  // ---- Cadence -------------------------------------------------------------
+  const projLast = projects.reduce<string | null>(
+    (acc, p) => (p.last_run_at && (!acc || p.last_run_at > acc) ? p.last_run_at : acc),
+    null,
+  );
+  const runLast = runs[0]?.created_at ?? null; // recent runs are ordered desc
+  const lastRunAt = projLast && runLast ? (projLast > runLast ? projLast : runLast) : (projLast ?? runLast);
+
+  // Derived from the date-filtered cadence fetch, not the 60-row recent list, so
+  // these stay accurate however many runs a heavy account fires.
+  const byDay = new Map<string, number>();
+  let runs30d = 0;
+  let runs7d = 0;
+  for (const r of cadence) {
+    const t = Date.parse(r.created_at);
+    if (!Number.isFinite(t) || t < now - 30 * DAY_MS || t > now) continue;
+    runs30d += 1;
+    if (t >= now - 7 * DAY_MS) runs7d += 1;
+    const day = r.created_at.slice(0, 10);
+    byDay.set(day, (byDay.get(day) ?? 0) + 1);
+  }
+  const series: { day: string; runs: number }[] = [];
+  for (let i = 29; i >= 0; i--) {
+    const day = new Date(now - i * DAY_MS).toISOString().slice(0, 10);
+    series.push({ day, runs: byDay.get(day) ?? 0 });
+  }
+  const bestDay = series.reduce((a, b) => (b.runs > a.runs ? b : a), series[0]);
+
+  // ---- Per-project rollups -------------------------------------------------
+  const topicName = new Map(topics.map((t) => [t.id, t.name]));
+  const projectName = new Map(projects.map((p) => [p.id, p.brand_name || p.name]));
+  const countBy = <T extends { project_id: string }>(rows: T[]) => {
+    const m = new Map<string, number>();
+    for (const r of rows) m.set(r.project_id, (m.get(r.project_id) ?? 0) + 1);
+    return m;
+  };
+  const topicCountByProject = countBy(topics);
+  const promptCountByProject = countBy(prompts);
+  const competitorsByProject = new Map<string, CompetitorRow[]>();
+  for (const c of competitors) {
+    const list = competitorsByProject.get(c.project_id) ?? [];
+    list.push(c);
+    competitorsByProject.set(c.project_id, list);
+  }
+  const watchByProject = new Map(watches.map((w) => [w.project_id, w]));
+  const promptsByProject = new Map<string, PromptRow[]>();
+  for (const p of prompts) {
+    const list = promptsByProject.get(p.project_id) ?? [];
+    list.push(p);
+    promptsByProject.set(p.project_id, list);
+  }
+
+  // trial_spend_micros and trial_tokens_used are bigint columns; PostgREST can
+  // hand a bigint back as a string, so coerce before arithmetic and formatting.
+  const spendUsd = Number(profile.trial_spend_micros ?? 0) / 1_000_000;
+  const trialRuns = Number(profile.trial_runs_used ?? 0);
+  const trialTokens = Number(profile.trial_tokens_used ?? 0);
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <Link
+          href="/admin/growth"
+          className="mb-3 inline-flex items-center gap-1.5 text-sm text-ink-faint hover:text-ink"
+        >
+          <ArrowLeft className="h-4 w-4" aria-hidden /> Growth
+        </Link>
+        <SectionHeading
+          title={company || email || "Account"}
+          description={
+            email
+              ? `${email} · ${emailClass} address · signed up ${timeAgo(profile.created_at)} (${formatDate(profile.created_at)})`
+              : "This account has no email on file."
+          }
+          action={<Badge tone={emailClass === "work" ? "teal" : emailClass === "burner" ? "terracotta" : "sand"}>{emailClass}</Badge>}
+        />
+      </div>
+
+      {/* ---- The numbers ---------------------------------------------------- */}
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        <StatCard
+          label="Total runs"
+          value={totalRuns.toLocaleString()}
+          hint={lastRunAt ? `last run ${timeAgo(lastRunAt)}` : "never run"}
+          accent="mint"
+        />
+        <StatCard
+          label="Last 30 days"
+          value={runs30d.toLocaleString()}
+          hint={`${runs7d} in the last 7d`}
+          accent="teal"
+        />
+        <StatCard
+          label="Monitoring"
+          value={projects.length.toLocaleString()}
+          hint={`${topics.length} topic${topics.length === 1 ? "" : "s"} · ${prompts.length} prompt${prompts.length === 1 ? "" : "s"}`}
+          accent="butter"
+        />
+        <StatCard
+          label="Trial spend"
+          value={spendUsd.toLocaleString(undefined, { style: "currency", currency: "USD" })}
+          hint={`${trialRuns} free run${trialRuns === 1 ? "" : "s"} · ${trialTokens.toLocaleString()} tokens`}
+          accent="sand"
+        />
+      </div>
+
+      {/* ---- Cadence -------------------------------------------------------- */}
+      <Card className="flex flex-col">
+        <div className="flex flex-col px-5 pb-4 pt-5">
+          <div className="flex items-baseline justify-between gap-3">
+            <h3 className="text-sm font-semibold text-ink">Runs per day</h3>
+            <span className="text-xs text-ink-faint">30d</span>
+          </div>
+          <div className="mt-3">
+            <RunSparkline series={series} />
+          </div>
+          <p className="mt-3 text-xs tabular-nums text-ink-faint">
+            {runs30d.toLocaleString()} runs in 30 days · best day {bestDay.runs} · hover bars for
+            counts
+          </p>
+        </div>
+      </Card>
+
+      {/* ---- What they monitor ---------------------------------------------- */}
+      <section className="space-y-3">
+        <div>
+          <h3 className="text-lg font-semibold text-ink">What they monitor</h3>
+          <p className="mt-1 max-w-3xl text-sm text-ink-faint">
+            The brands, cadence and competitors this account tracks — one card per organization.
+          </p>
+        </div>
+        {projects.length === 0 ? (
+          <Card>
+            <p className="px-5 py-8 text-sm text-ink-faint">
+              No organizations yet — this account signed up but never set one up.
+            </p>
+          </Card>
+        ) : (
+          <div className="grid gap-4 lg:grid-cols-2">
+            {projects.map((p) => {
+              const comps = competitorsByProject.get(p.id) ?? [];
+              const watch = watchByProject.get(p.id);
+              return (
+                <Card key={p.id}>
+                  <div className="space-y-3 px-5 py-4">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <p className="truncate font-semibold text-ink">{p.brand_name || p.name}</p>
+                        <p className="truncate text-xs text-ink-faint">
+                          {p.brand_domains.length > 0 ? p.brand_domains.join(" · ") : "no domains"}
+                        </p>
+                      </div>
+                      <Badge tone={SCHEDULE_TONE[p.schedule] ?? "sand"}>{p.schedule}</Badge>
+                    </div>
+                    {p.description && (
+                      <p className="line-clamp-2 text-xs text-ink-soft">{p.description}</p>
+                    )}
+                    <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-ink-faint">
+                      <span>{topicCountByProject.get(p.id) ?? 0} topics</span>
+                      <span>{promptCountByProject.get(p.id) ?? 0} prompts</span>
+                      <span>{comps.length} competitors</span>
+                      <span className="font-mono">
+                        {p.default_provider}/{p.default_model}
+                      </span>
+                      <span>×{p.replicates} replicates</span>
+                      <span>{p.use_web_search ? "web search on" : "web search off"}</span>
+                      {watch?.enabled && <span>web mentions: {watch.sites.join(", ")}</span>}
+                    </div>
+                    {comps.length > 0 && (
+                      <p className="text-xs text-ink-faint">
+                        <span className="text-ink-soft">Competitors:</span>{" "}
+                        {comps.map((c) => c.name).join(", ")}
+                      </p>
+                    )}
+                  </div>
+                </Card>
+              );
+            })}
+          </div>
+        )}
+      </section>
+
+      {/* ---- Their prompts -------------------------------------------------- */}
+      <section className="space-y-3">
+        <div className="flex flex-wrap items-baseline gap-x-3">
+          <h3 className="text-lg font-semibold text-ink">Their prompts</h3>
+          <span className="text-sm tabular-nums text-ink-faint">{prompts.length}</span>
+        </div>
+        <p className="max-w-3xl text-sm text-ink-faint">
+          The active questions they ask the engines every run — what they actually care about being
+          the answer to.
+        </p>
+        <Card>
+          {prompts.length === 0 ? (
+            <p className="px-5 py-8 text-sm text-ink-faint">No active prompts.</p>
+          ) : (
+            <div className="max-h-96 divide-y divide-ink/5 overflow-y-auto">
+              {prompts.map((p) => (
+                <div key={p.id} className="flex items-start gap-3 px-5 py-2.5">
+                  <span className="min-w-0 flex-1 text-sm text-ink">{p.text}</span>
+                  <div className="flex shrink-0 items-center gap-2">
+                    {p.topic_id && topicName.get(p.topic_id) && (
+                      <Badge tone="neutral">{topicName.get(p.topic_id)}</Badge>
+                    )}
+                    {projects.length > 1 && (
+                      <span className="hidden text-xs text-ink-faint sm:inline">
+                        {projectName.get(p.project_id)}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </Card>
+      </section>
+
+      {/* ---- Recent runs ---------------------------------------------------- */}
+      <section className="space-y-3">
+        <div className="flex flex-wrap items-baseline gap-x-3">
+          <h3 className="text-lg font-semibold text-ink">Recent runs</h3>
+          <span className="text-sm tabular-nums text-ink-faint">
+            {runs.length}
+            {totalRuns > runs.length ? ` of ${totalRuns.toLocaleString()}` : ""}
+          </span>
+        </div>
+        <Card>
+          {runs.length === 0 ? (
+            <p className="px-5 py-8 text-sm text-ink-faint">No runs yet.</p>
+          ) : (
+            <>
+              <div className="flex items-center gap-4 border-b border-ink/10 px-5 py-2">
+                <ColumnHeader className="flex-1">Organization · engine</ColumnHeader>
+                <ColumnHeader className="w-20 text-right">Status</ColumnHeader>
+                <ColumnHeader className="w-16 text-right">Answers</ColumnHeader>
+                <ColumnHeader className="w-20 text-right">When</ColumnHeader>
+                <span className="w-4" />
+              </div>
+              <div className="max-h-96 divide-y divide-ink/5 overflow-y-auto">
+                {runs.map((run, i) => (
+                  <Link
+                    key={run.id}
+                    href={`/admin/runs/${run.id}`}
+                    className="flex items-center gap-4 px-5 py-2.5 transition hover:bg-ink/[0.03]"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-[13px] text-ink">
+                        {projectName.get(run.project_id) ?? "(deleted org)"}
+                        {i === 0 && (
+                          <Flame
+                            className="ml-1 inline h-3.5 w-3.5 align-[-2px] text-terracotta"
+                            aria-hidden
+                          />
+                        )}
+                      </p>
+                      <p className="truncate font-mono text-xs text-ink-faint">
+                        {run.provider}/{run.model}
+                      </p>
+                    </div>
+                    <span className="w-20 shrink-0 text-right">
+                      <Badge tone={statusTone(run.status)}>{run.status}</Badge>
+                    </span>
+                    <span className="w-16 shrink-0 text-right font-mono text-xs tabular-nums text-ink-faint">
+                      {run.completed_count}/{run.prompt_count}
+                    </span>
+                    <span className="w-20 shrink-0 text-right text-xs tabular-nums text-ink-faint">
+                      {timeAgo(run.created_at)}
+                    </span>
+                    <ArrowUpRight className="h-4 w-4 shrink-0 text-ink-faint" aria-hidden />
+                  </Link>
+                ))}
+              </div>
+            </>
+          )}
+        </Card>
+      </section>
+
+      {/* ---- Activity log --------------------------------------------------- */}
+      <section className="space-y-3">
+        <div className="flex flex-wrap items-baseline gap-x-3">
+          <h3 className="text-lg font-semibold text-ink">Activity</h3>
+          <span className="text-sm tabular-nums text-ink-faint">{activity.length}</span>
+        </div>
+        <p className="max-w-3xl text-sm text-ink-faint">
+          Everything this account has done lately, whatever the surface — dashboard, API, CLI or the
+          scheduler.
+        </p>
+        <Card>
+          {activity.length === 0 ? (
+            <p className="px-5 py-8 text-sm text-ink-faint">
+              Nothing recorded — either this account is quiet, or activity logging is not populated
+              on this deployment.
+            </p>
+          ) : (
+            <div className="max-h-96 divide-y divide-ink/5 overflow-y-auto">
+              {activity.map((a) => (
+                <div key={a.id} className="flex items-start gap-3 px-5 py-2.5">
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-[13px] text-ink">{a.summary}</span>
+                    <span className="block truncate font-mono text-xs text-ink-faint">
+                      {a.category} · {a.channel}
+                    </span>
+                  </span>
+                  <Badge tone={activityTone(a.status)}>{a.status}</Badge>
+                  <span className="w-16 shrink-0 text-right text-xs tabular-nums text-ink-faint">
+                    {timeAgo(a.created_at)}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </Card>
+      </section>
+
+      <p className="text-xs text-ink-faint">
+        Operator view — this page shows one account’s own content so you can see who is using the
+        product and what they monitor.{" "}
+        <Link href="/admin/growth" className="underline">
+          Back to Growth
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/app/admin/growth/page.tsx
+++ b/app/admin/growth/page.tsx
@@ -5,6 +5,7 @@ import { requireAdmin } from "@/lib/admin";
 import { growthReport, type EmailClass, type Lead } from "@/lib/growth";
 import { Badge, Card, SectionHeading, StatCard } from "@/components/ui";
 import { timeAgo } from "@/lib/utils";
+import { PeopleDirectory } from "../people";
 
 export const dynamic = "force-dynamic";
 export const metadata = { robots: { index: false, follow: false } };
@@ -107,6 +108,7 @@ export default async function GrowthPage({ searchParams }: { searchParams: SP })
       <SectionHeading
         title="Growth"
         description="Activity measured in runs, and the lead list it produces. Emails are shown in the clear here — this page exists for outbound."
+        action={<PeopleDirectory accounts={report.accounts} />}
       />
 
       {report.degraded && (

--- a/app/admin/nav.tsx
+++ b/app/admin/nav.tsx
@@ -9,15 +9,18 @@ import { cn } from "@/lib/utils";
  * layout became these tabs. Client-side only for usePathname — there is no
  * state here.
  *
- * A run detail page is reached from Growth, so it highlights Growth: the tab
- * answers "which section am I in", not "which URL is this".
+ * A run or account detail page is reached from Growth, so both highlight
+ * Growth: the tab answers "which section am I in", not "which URL is this".
  */
 const TABS = [
   { href: "/admin", label: "Operations", match: (p: string) => p === "/admin" },
   {
     href: "/admin/growth",
     label: "Growth",
-    match: (p: string) => p.startsWith("/admin/growth") || p.startsWith("/admin/runs"),
+    match: (p: string) =>
+      p.startsWith("/admin/growth") ||
+      p.startsWith("/admin/runs") ||
+      p.startsWith("/admin/accounts"),
   },
 ];
 

--- a/app/admin/people.tsx
+++ b/app/admin/people.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import Link from "next/link";
+import { ArrowUpRight, Search, Users, X } from "lucide-react";
+import { cn, timeAgo } from "@/lib/utils";
+import type { AccountRow } from "@/lib/accounts";
+import type { EmailClass } from "@/lib/growth";
+
+/**
+ * The People directory: every account, in a modal, searchable and ranked by
+ * last used. A client island so the server-rendered Growth page stays a server
+ * component — the rows are computed once on the server (see shapeAccounts) and
+ * handed down; all this does is filter, search and open one.
+ *
+ * It reads as a THIN list on purpose. The operator is scanning names and
+ * hunting for one address, not reading cards, so every row is a single dense
+ * line: company, email, how recently, how much. Clicking a row leaves the modal
+ * for that account's full history at /admin/accounts/[id].
+ *
+ * Gmails are kept. The class chips are the answer to "actually, hide them" —
+ * the default is All (everyone is a user), and Work narrows to the outbound
+ * list in one click without the directory having to decide for you.
+ */
+
+const CLASS_DOT: Record<EmailClass, string> = {
+  work: "bg-teal",
+  personal: "bg-sand",
+  burner: "bg-terracotta",
+};
+
+const CLASS_FILTERS: { key: "all" | EmailClass; label: string }[] = [
+  { key: "all", label: "All" },
+  { key: "work", label: "Work" },
+  { key: "personal", label: "Personal" },
+  { key: "burner", label: "Burner" },
+];
+
+// Rendered-row cap. Search filters the FULL list; only the DOM is bounded, so a
+// directory of thousands never paints thousands of rows at once. When the cut
+// bites, the list says so rather than pretending the tail isn't there.
+const RENDER_CAP = 300;
+
+export function PeopleDirectory({ accounts }: { accounts: AccountRow[] }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="inline-flex items-center gap-2 rounded border border-ink/15 bg-surface px-3 py-1.5 text-sm text-ink-soft transition hover:border-ink/25 hover:text-ink"
+      >
+        <Users className="h-4 w-4" aria-hidden />
+        People
+        <span className="text-ink-faint tabular-nums">{accounts.length}</span>
+      </button>
+      {open && <PeopleDialog accounts={accounts} onClose={() => setOpen(false)} />}
+    </>
+  );
+}
+
+function PeopleDialog({ accounts, onClose }: { accounts: AccountRow[]; onClose: () => void }) {
+  const [mounted, setMounted] = useState(false);
+  const [q, setQ] = useState("");
+  const [cls, setCls] = useState<"all" | EmailClass>("all");
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => setMounted(true), []);
+
+  // Put the cursor in search — this modal exists to be typed into. Keyed on
+  // `mounted`, NOT run inline below, because the mount gate returns null on the
+  // first render: focusing then hits a ref that isn't attached yet. This fires
+  // on the render that actually paints the input.
+  useEffect(() => {
+    if (mounted) searchRef.current?.focus();
+  }, [mounted]);
+
+  // Escape to close, and lock body scroll while the modal is up.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prev;
+    };
+  }, [onClose]);
+
+  const counts = useMemo(() => {
+    const c = { all: accounts.length, work: 0, personal: 0, burner: 0 };
+    for (const a of accounts) c[a.emailClass] += 1;
+    return c;
+  }, [accounts]);
+
+  const needle = q.trim().toLowerCase();
+  const filtered = useMemo(() => {
+    return accounts.filter((a) => {
+      if (cls !== "all" && a.emailClass !== cls) return false;
+      if (!needle) return true;
+      return (
+        (a.email ?? "").toLowerCase().includes(needle) ||
+        (a.company ?? "").toLowerCase().includes(needle) ||
+        a.brands.some((b) => b.toLowerCase().includes(needle))
+      );
+    });
+  }, [accounts, cls, needle]);
+
+  const shown = filtered.slice(0, RENDER_CAP);
+  const clipped = filtered.length - shown.length;
+
+  if (!mounted) return null;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[60] flex items-start justify-center p-4 sm:p-6"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="people-title"
+    >
+      <div className="absolute inset-0 bg-ink/40 backdrop-blur-sm animate-fade-up" onClick={onClose} />
+      <div className="relative mt-8 flex max-h-[85vh] w-full max-w-2xl flex-col overflow-hidden rounded border border-ink/10 bg-paper shadow-lift animate-fade-up">
+        {/* ---- Header --------------------------------------------------------- */}
+        <div className="flex items-start justify-between gap-4 border-b border-ink/10 px-5 py-4">
+          <div>
+            <h2 id="people-title" className="text-lg font-semibold tracking-tight text-ink">
+              People
+            </h2>
+            <p className="mt-0.5 text-xs text-ink-faint">
+              Everyone who has signed up, ranked by last used. Click a row for their full history.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-[2px] text-ink-soft transition hover:bg-ink/[0.05] hover:text-ink"
+          >
+            <X className="h-4 w-4" aria-hidden />
+          </button>
+        </div>
+
+        {/* ---- Toolbar: search + class chips --------------------------------- */}
+        <div className="space-y-3 border-b border-ink/10 px-5 py-3">
+          <div className="relative">
+            <Search
+              className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-ink-faint"
+              aria-hidden
+            />
+            <input
+              ref={searchRef}
+              type="search"
+              value={q}
+              onChange={(e) => setQ(e.target.value)}
+              placeholder="Search an address, company or brand…"
+              aria-label="Search people"
+              className="w-full rounded border border-ink/15 bg-surface py-2 pl-9 pr-3 text-sm text-ink placeholder:text-ink-faint focus:border-ink/30 focus:outline-none"
+            />
+          </div>
+          <div className="flex items-center gap-1 rounded border border-ink/10 bg-surface p-1">
+            {CLASS_FILTERS.map((f) => (
+              <button
+                key={f.key}
+                type="button"
+                onClick={() => setCls(f.key)}
+                aria-pressed={cls === f.key}
+                className={cn(
+                  "rounded-sm px-2.5 py-1 text-xs transition",
+                  cls === f.key
+                    ? "bg-ink/[0.08] font-medium text-ink"
+                    : "text-ink-faint hover:text-ink-soft",
+                )}
+              >
+                {f.label}
+                <span className="ml-1 tabular-nums opacity-60">{counts[f.key]}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* ---- The list ------------------------------------------------------ */}
+        {shown.length === 0 ? (
+          <p className="px-5 py-10 text-center text-sm text-ink-faint">
+            {needle ? `Nobody matches “${q}”.` : "No accounts yet."}
+          </p>
+        ) : (
+          <div className="min-h-0 flex-1 divide-y divide-ink/5 overflow-y-auto">
+            {shown.map((a) => (
+              <Link
+                key={a.userId}
+                href={`/admin/accounts/${a.userId}`}
+                className="flex items-center gap-3 px-5 py-1.5 transition hover:bg-ink/[0.03]"
+              >
+                <span
+                  className={cn("h-2 w-2 shrink-0 rounded-sm", CLASS_DOT[a.emailClass])}
+                  title={a.emailClass}
+                  aria-hidden
+                />
+                <span className="min-w-0 flex-1 truncate text-[13px]">
+                  <span className="text-ink">{a.company ?? a.email ?? "(no email)"}</span>
+                  {a.company && a.email && (
+                    <span className="ml-2 font-mono text-xs text-ink-faint">{a.email}</span>
+                  )}
+                </span>
+                <span
+                  className="w-10 shrink-0 text-right font-mono text-xs tabular-nums text-ink-faint"
+                  title={`${a.runs30d} run${a.runs30d === 1 ? "" : "s"} in 30d`}
+                >
+                  {a.runs30d || "—"}
+                </span>
+                <span className="w-16 shrink-0 text-right text-xs tabular-nums text-ink-faint">
+                  {a.lastRunAt ? timeAgo(a.lastRunAt) : "never"}
+                </span>
+                <ArrowUpRight className="h-3.5 w-3.5 shrink-0 text-ink-faint" aria-hidden />
+              </Link>
+            ))}
+          </div>
+        )}
+
+        {/* ---- Footer -------------------------------------------------------- */}
+        <div className="border-t border-ink/10 px-5 py-2.5 text-xs text-ink-faint">
+          {clipped > 0 ? (
+            <>
+              Showing the first {shown.length.toLocaleString()} of{" "}
+              {filtered.length.toLocaleString()} — refine the search to reach the rest.
+            </>
+          ) : (
+            <>
+              {filtered.length.toLocaleString()}{" "}
+              {filtered.length === 1 ? "account" : "accounts"}
+              {cls !== "all" || needle ? " shown" : " total"}. Runs count the last 30 days.
+            </>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/lib/accounts.test.ts
+++ b/lib/accounts.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import { companyFromDomain, deriveCompany, shapeAccounts } from "./accounts";
+import type { GrowthProfileRow, GrowthProjectRow, GrowthRunRow } from "./growth";
+
+const DAY_MS = 86_400_000;
+const NOW = Date.parse("2026-08-15T12:00:00.000Z");
+
+function iso(daysAgo: number, hoursAgo = 0): string {
+  return new Date(NOW - daysAgo * DAY_MS - hoursAgo * 3_600_000).toISOString();
+}
+
+function run(overrides: Partial<GrowthRunRow>): GrowthRunRow {
+  return {
+    id: "r-" + Math.abs(JSON.stringify(overrides).length + (overrides.created_at?.length ?? 0)),
+    project_id: "proj-a",
+    status: "completed",
+    provider: "anthropic",
+    model: "claude-sonnet-4-6",
+    prompt_count: 10,
+    completed_count: 10,
+    created_at: iso(0, 1),
+    ...overrides,
+  };
+}
+
+describe("companyFromDomain", () => {
+  it("titles the registrable label of a plain domain", () => {
+    expect(companyFromDomain("acme.io")).toBe("Acme");
+    expect(companyFromDomain("corp.com")).toBe("Corp");
+  });
+
+  it("skips a second-level public suffix", () => {
+    expect(companyFromDomain("acme.co.uk")).toBe("Acme");
+    expect(companyFromDomain("sub.corp.co.uk")).toBe("Corp");
+    expect(companyFromDomain("shop.example.com.au")).toBe("Example");
+  });
+
+  it("uses the registrable label under subdomains", () => {
+    expect(companyFromDomain("mail.corp.com")).toBe("Corp");
+  });
+
+  it("leaves interior casing alone, only capitalising the first letter", () => {
+    expect(companyFromDomain("gitHub.com")).toBe("GitHub");
+  });
+
+  it("returns null for a bare label or nothing", () => {
+    expect(companyFromDomain("localhost")).toBeNull();
+    expect(companyFromDomain(null)).toBeNull();
+    expect(companyFromDomain("")).toBeNull();
+  });
+});
+
+describe("deriveCompany", () => {
+  it("uses the email domain for work addresses", () => {
+    expect(deriveCompany("alice@acme.io", "work", ["Nike"])).toBe("Acme");
+  });
+
+  it("falls back to the monitored brand for personal addresses", () => {
+    expect(deriveCompany("sam@gmail.com", "personal", ["BetaCo"])).toBe("BetaCo");
+    expect(deriveCompany("x@mailinator.com", "burner", ["Probe"])).toBe("Probe");
+  });
+
+  it("falls back to the brand when a work domain is unparseable", () => {
+    expect(deriveCompany("weird", "work", ["Fallback"])).toBe("Fallback");
+  });
+
+  it("is null when there is nothing but a consumer email", () => {
+    expect(deriveCompany("sam@gmail.com", "personal", [])).toBeNull();
+  });
+});
+
+describe("shapeAccounts", () => {
+  const PROJECTS: GrowthProjectRow[] = [
+    { id: "proj-a", user_id: "u1", name: "Acme", brand_name: "Acme", last_run_at: iso(0, 1) },
+    { id: "proj-b", user_id: "u2", name: "Beta", brand_name: "BetaCo", last_run_at: iso(2) },
+    { id: "proj-c", user_id: "u2", name: "Beta EU", brand_name: "BetaEU", last_run_at: iso(40) },
+    { id: "proj-d", user_id: "u3", name: "Probe", brand_name: "Probe", last_run_at: null },
+  ];
+  const PROFILES: GrowthProfileRow[] = [
+    { id: "u1", email: "jo@acme.io", created_at: iso(60) },
+    { id: "u2", email: "sam@gmail.com", created_at: iso(20) },
+    { id: "u3", email: "eval@mailinator.com", created_at: iso(3) },
+    { id: "u4", email: "never@newco.com", created_at: iso(1) },
+  ];
+
+  it("emits one row per profile, keeping consumer and burner addresses", () => {
+    const rows = shapeAccounts([], PROJECTS, PROFILES);
+    expect(rows).toHaveLength(4);
+    expect(rows.map((r) => r.userId).sort()).toEqual(["u1", "u2", "u3", "u4"]);
+  });
+
+  it("ranks by last used, with never-ran accounts last by newest signup", () => {
+    const runs = [
+      run({ project_id: "proj-b", created_at: iso(0, 2) }), // u2 ran 2h ago
+      run({ project_id: "proj-a", created_at: iso(1) }), // u1 ran 1d ago (in-window)
+    ];
+    const rows = shapeAccounts(runs, PROJECTS, PROFILES);
+    // u1 leads: proj-a.last_run_at is 1h ago, more recent than either window run,
+    // so recency reaches past the window. Then u2 (2h) > never-ran: u4 (signup
+    // 1d) before u3 (signup 3d) — u3's project last_run_at is null with no window
+    // run, so it too is "never".
+    expect(rows.map((r) => r.userId)).toEqual(["u1", "u2", "u4", "u3"]);
+  });
+
+  it("counts window runs and reaches past the window for recency", () => {
+    // u2 has a project whose last_run_at is 40d ago — older than the 30d window,
+    // but it must still date the account rather than reading as never-ran.
+    const rows = shapeAccounts([], PROJECTS, PROFILES);
+    const u2 = rows.find((r) => r.userId === "u2")!;
+    expect(u2.runs30d).toBe(0);
+    expect(u2.lastRunAt).toBe(iso(2)); // most recent of its two projects
+    expect(u2.projects).toBe(2);
+    expect(u2.brands).toEqual(["BetaCo", "BetaEU"]);
+  });
+
+  it("prefers a fresh window run over a staler projects.last_run_at", () => {
+    const runs = [run({ project_id: "proj-b", created_at: iso(0, 1) })];
+    const rows = shapeAccounts(runs, PROJECTS, PROFILES);
+    const u2 = rows.find((r) => r.userId === "u2")!;
+    expect(u2.runs30d).toBe(1);
+    expect(u2.lastRunAt).toBe(iso(0, 1));
+  });
+
+  it("labels the company from the work domain, and the brand for consumer mail", () => {
+    const rows = shapeAccounts([], PROJECTS, PROFILES);
+    expect(rows.find((r) => r.userId === "u1")!.company).toBe("Acme"); // work -> domain
+    expect(rows.find((r) => r.userId === "u2")!.company).toBe("BetaCo"); // gmail -> brand
+    expect(rows.find((r) => r.userId === "u3")!.company).toBe("Probe"); // burner -> brand
+    expect(rows.find((r) => r.userId === "u4")!.company).toBe("Newco"); // work, no project
+  });
+});

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -1,0 +1,196 @@
+import {
+  classifyEmail,
+  emailDomain,
+  type EmailClass,
+  type GrowthProfileRow,
+  type GrowthProjectRow,
+  type GrowthRunRow,
+} from "./growth";
+
+/**
+ * The people behind the runs, as a directory.
+ *
+ * The Growth page answers "is the product being used" in aggregate; this
+ * answers "by whom" one account at a time. It exists so the operator can open a
+ * modal, search for a specific address, and jump into one person's whole story
+ * — how often they run, what they monitor, what they've done.
+ *
+ * A row's headline is the COMPANY, not the email: "who is this account" is a
+ * company question, and the company is what the operator is really scanning
+ * for. The email rides alongside it (and Gmails are kept, not dropped — a
+ * consumer address is still a user, just a weaker outbound target), and the
+ * class filter in the modal is what lets the operator hide them when the
+ * question is outbound rather than usage.
+ *
+ * Everything here is pure and unit-tested; it reuses the row shapes and the
+ * email classifier from lib/growth so the two pages agree on what "work" means.
+ */
+
+// ---------------------------------------------------------------------------
+// Company label
+// ---------------------------------------------------------------------------
+
+/**
+ * Second-level public suffixes — domains where the registrable name sits one
+ * label FURTHER left than usual. Without this, `acme.co.uk` reads as company
+ * "Co" and every British company collapses into one row. Not exhaustive (the
+ * full Public Suffix List is thousands of entries and a dependency we don't
+ * want for a hint label); it covers the suffixes a real signup list actually
+ * carries, and an unlisted one degrades to a slightly-off label, never a crash.
+ */
+const MULTI_PART_SUFFIXES = new Set([
+  "co.uk",
+  "org.uk",
+  "ac.uk",
+  "gov.uk",
+  "me.uk",
+  "net.uk",
+  "sch.uk",
+  "com.au",
+  "net.au",
+  "org.au",
+  "edu.au",
+  "gov.au",
+  "co.nz",
+  "co.za",
+  "co.in",
+  "co.jp",
+  "or.jp",
+  "ne.jp",
+  "com.br",
+  "com.mx",
+  "com.sg",
+  "com.hk",
+  "com.tr",
+  "com.cn",
+  "com.tw",
+  "co.kr",
+  "co.id",
+  "co.th",
+]);
+
+/**
+ * A human-ish company label from an email domain: the registrable name with a
+ * capital first letter. "alice@acme.io" -> "Acme"; "x@sub.corp.co.uk" ->
+ * "Corp". Deliberately only touches the first letter — the rest of the label is
+ * left as the domain wrote it, because lowercasing it would turn "GitHub" into
+ * "Github" and we have no way to know the real casing. A hint, not a legal name.
+ */
+export function companyFromDomain(domain: string | null): string | null {
+  if (!domain) return null;
+  const labels = domain.split(".").filter(Boolean);
+  if (labels.length < 2) return null;
+  const lastTwo = labels.slice(-2).join(".");
+  const nameIdx = MULTI_PART_SUFFIXES.has(lastTwo) ? labels.length - 3 : labels.length - 2;
+  const name = labels[nameIdx];
+  if (!name) return null;
+  return name.charAt(0).toUpperCase() + name.slice(1);
+}
+
+/**
+ * The company shown as the row's headline. A work address IS its company, so
+ * the domain wins there; a consumer address has no company in it, so we borrow
+ * the brand they monitor instead (an agency on a Gmail still reads as the brand
+ * they watch). Null when there is nothing to show but the email.
+ */
+export function deriveCompany(
+  email: string | null | undefined,
+  emailClass: EmailClass,
+  brands: string[],
+): string | null {
+  if (emailClass === "work") {
+    return companyFromDomain(emailDomain(email)) ?? brands[0] ?? null;
+  }
+  return brands[0] ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Account rows
+// ---------------------------------------------------------------------------
+
+export interface AccountRow {
+  userId: string;
+  email: string | null;
+  emailClass: EmailClass;
+  /** Headline label — see deriveCompany. Null falls back to the email in the UI. */
+  company: string | null;
+  /** Brands this account monitors, for the subtitle and for search. */
+  brands: string[];
+  projects: number;
+  /** Runs inside the fetched window (30d). Volume, next to recency. */
+  runs30d: number;
+  /** Last used = last run, reaching back past the window via projects.last_run_at. */
+  lastRunAt: string | null;
+  signedUpAt: string;
+}
+
+/**
+ * One row per account, ranked by last used (most recent first; never-ran
+ * accounts sink to the bottom, ordered by signup so the newest arrival leads
+ * them). Every profile is included — the directory is the whole audience, and
+ * search only works if the account you're hunting is actually in the list.
+ *
+ * lastRunAt is the max of the run window and projects.last_run_at for the same
+ * reason the growth lists do it: a run older than the fetched window still
+ * dates the account correctly even though its 30d count is zero.
+ */
+export function shapeAccounts(
+  runs: GrowthRunRow[],
+  projects: GrowthProjectRow[],
+  profiles: GrowthProfileRow[],
+): AccountRow[] {
+  const projectOwner = new Map(projects.map((p) => [p.id, p.user_id]));
+
+  const runsByUser = new Map<string, number>();
+  const lastRunByUser = new Map<string, string>();
+  for (const run of runs) {
+    const owner = projectOwner.get(run.project_id);
+    if (!owner) continue;
+    runsByUser.set(owner, (runsByUser.get(owner) ?? 0) + 1);
+    const prev = lastRunByUser.get(owner);
+    if (!prev || run.created_at > prev) lastRunByUser.set(owner, run.created_at);
+  }
+
+  const meta = new Map<string, { projects: number; brands: string[]; lastRunAt: string | null }>();
+  for (const p of projects) {
+    const entry = meta.get(p.user_id) ?? { projects: 0, brands: [], lastRunAt: null };
+    entry.projects += 1;
+    if (p.brand_name && !entry.brands.includes(p.brand_name)) entry.brands.push(p.brand_name);
+    if (p.last_run_at && (!entry.lastRunAt || p.last_run_at > entry.lastRunAt)) {
+      entry.lastRunAt = p.last_run_at;
+    }
+    meta.set(p.user_id, entry);
+  }
+
+  return profiles
+    .map((profile) => {
+      const info = meta.get(profile.id);
+      const brands = info?.brands ?? [];
+      const emailClass = classifyEmail(profile.email);
+      const windowLast = lastRunByUser.get(profile.id) ?? null;
+      const metaLast = info?.lastRunAt ?? null;
+      const lastRunAt =
+        windowLast && metaLast
+          ? windowLast > metaLast
+            ? windowLast
+            : metaLast
+          : (windowLast ?? metaLast);
+      return {
+        userId: profile.id,
+        email: profile.email,
+        emailClass,
+        company: deriveCompany(profile.email, emailClass, brands),
+        brands,
+        projects: info?.projects ?? 0,
+        runs30d: runsByUser.get(profile.id) ?? 0,
+        lastRunAt,
+        signedUpAt: profile.created_at,
+      };
+    })
+    .sort((a, b) => {
+      if (a.lastRunAt && b.lastRunAt) return b.lastRunAt.localeCompare(a.lastRunAt);
+      if (a.lastRunAt) return -1;
+      if (b.lastRunAt) return 1;
+      return b.signedUpAt.localeCompare(a.signedUpAt);
+    });
+}

--- a/lib/growth.ts
+++ b/lib/growth.ts
@@ -1,4 +1,5 @@
 import { createServiceClient } from "@/lib/supabase/service";
+import { shapeAccounts, type AccountRow } from "./accounts";
 
 /**
  * The growth half of the operations picture: who is actually using the
@@ -439,6 +440,8 @@ export interface GrowthReport {
   topAccounts: TopAccount[];
   recentRuns: RecentRun[];
   leads: Lead[];
+  /** Every account, ranked by last used — the People directory behind the modal. */
+  accounts: AccountRow[];
   totalUsers: number;
   /** Set when a query failed — the page says "incomplete", never fake zero. */
   degraded: string | null;
@@ -461,7 +464,15 @@ export async function growthReport(now = Date.now()): Promise<GrowthReport> {
       .gte("created_at", since)
       .order("created_at", { ascending: false })
       .limit(RUNS_CAP),
-    svc.from("projects").select("id, user_id, name, brand_name, last_run_at").limit(ROWS_CAP),
+    // Ordered oldest-first so shapeAccounts' brands[0] (the company label for a
+    // consumer-email account) is the oldest project's brand — the same brand the
+    // account detail page headlines, which also orders projects created_at asc.
+    // Without a stable order the two surfaces can disagree on the label.
+    svc
+      .from("projects")
+      .select("id, user_id, name, brand_name, last_run_at")
+      .order("created_at", { ascending: true })
+      .limit(ROWS_CAP),
     svc
       .from("profiles")
       .select("id, email, created_at")
@@ -485,6 +496,7 @@ export async function growthReport(now = Date.now()): Promise<GrowthReport> {
     topAccounts: shapeTopAccounts(runs, projects, profiles),
     recentRuns: shapeRecentRuns(runs, projects, profiles),
     leads: shapeLeads(runs, projects, profiles, now),
+    accounts: shapeAccounts(runs, projects, profiles),
     totalUsers: profiles.length,
     degraded: failed.length > 0 ? failed.join(", ") : null,
   };


### PR DESCRIPTION
Adds a **People** button on the admin Growth page that opens a searchable, last-used-ranked modal of every account, showing company plus email with work/personal/burner filters (Gmails kept, hidable in one click). Each row links to a new `/admin/accounts/[id]` page showing run cadence (30-day sparkline), trial spend, what they monitor (orgs, prompts, competitors), recent runs linking into the run view, and their activity log. New pure logic lives in `lib/accounts.ts` (company-from-domain and `shapeAccounts`) with unit tests, and `growthReport()` now also returns the account rows behind the modal. All data stays server-side behind `requireAdmin()`, matching the existing `/admin/runs/[id]` page. Verified: typecheck, 33 unit tests, lint, and a production build all pass, and an adversarial multi-agent review of the diff surfaced three low/medium issues that are all fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789511548&installation_model_id=431526&pr_number=120&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F120&signature=c7eae306d290429549a5321ef20b671001bfd5ae8d72cd5c66798ac23d1b2d92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->