### PR TITLE
fix(letterprove): point at app.letterprove.com — the .vercel.app alias 404s

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,7 +67,10 @@ NEXT_PUBLIC_RB2B_KEY=
 # when set.
 NEXT_PUBLIC_LETTERPROVE_KEY=
 # Override only if pointing at a non-production Letterprove.
-# Defaults to https://letterprove.vercel.app
+# Defaults to https://app.letterprove.com — Letterprove's own domain, not a
+# *.vercel.app alias. Those aliases move between projects, and when the old one
+# started 404ing the script stopped loading with no error anywhere; collection
+# just went quiet. If this ever needs changing, prefer a domain someone owns.
 NEXT_PUBLIC_LETTERPROVE_ORIGIN=
 
 # --- OAuth (optional) ---

--- a/components/letterprove-attest.tsx
+++ b/components/letterprove-attest.tsx
@@ -30,7 +30,19 @@ import { useEffect } from "react";
  */
 
 const SCRIPT_ID = "letterprove-attest";
-const DEFAULT_ORIGIN = "https://letterprove.vercel.app";
+
+/**
+ * Letterprove's own custom domain — deliberately NOT a `*.vercel.app` alias.
+ *
+ * This defaulted to `letterprove.vercel.app`, which broke collection silently:
+ * that alias has moved between Letterprove projects more than once and now
+ * 404s entirely, so the script simply never loaded. Because telemetry fails
+ * quietly by design, nothing surfaced it — the only symptom was `hot_events`
+ * staying flat for two and a half days.
+ *
+ * A generated alias is not a stable contract. Point at a domain someone owns.
+ */
+const DEFAULT_ORIGIN = "https://app.letterprove.com";
 
 declare global {
   interface Window {


### PR DESCRIPTION
**Collection has been dead since 2026-08-14 22:05 UTC.**

```
2026-08-14 18:02:36  tenevents.com        session
2026-08-14 18:18:45  snappykraken.com     session
2026-08-14 18:38:39  gmail.com            session
2026-08-14 19:18:40  gmail.com            session
2026-08-14 19:39:15  gmail.com            session
2026-08-14 20:26:44  juvare.com           session
2026-08-14 20:43:00  k9sportsnation.com   session
2026-08-14 22:05:47  pricesmart.com       session
                     ← nothing for 65 hours
```

Eight real observations across six customer domains in four hours, then flat.

## Cause

This component defaulted to `https://letterprove.vercel.app`. Letterprove has since moved to its own domain, and that alias — which had already bounced between the landing project and the app project more than once — now **404s outright**. So the script tag pointed at a dead URL and `attest.js` never loaded.

| | |
|---|---|
| `https://letterprove.vercel.app/attest.js` | **404** |
| `https://app.letterprove.com/attest.js` | **200** |

The Letterprove side is entirely healthy: crons still running (newest frozen snapshot 15:05 today), signing mode `countersigned`, both vendors served. Only the client's URL was wrong.

## Why nobody noticed

Telemetry fails silently by design, so it can never break the host page — correct, and I'd keep it. But the `x-letterprove` diagnostic header only exists once a request is made, and a 404 on the script means **no request is ever attempted**. The only symptom was a table that stopped growing, which is indistinguishable from nobody logging in.

## The actual mistake

Not the deployment — the default. A generated `*.vercel.app` alias isn't a stable contract, and hardcoding one as a fallback was the error. `app.letterprove.com` is a domain someone owns.

## Follow-up worth doing separately

An alert on `hot_events` freshness — "no events in N hours" — since a silent stop is the one failure this pipeline can't report on itself. Happy to add it if you want it.

## Verification

`tsc` clean, `next build` succeeds, and `app.letterprove.com` confirmed serving the real `attest.js` with the collector accepting our origin and validating event types.

Note this takes effect on the next production deploy — the origin is read at build time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789573616&installation_model_id=431526&pr_number=121&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F121&signature=4995e74bdfccd00ac0fa85a1207df8c0aac811fb57389ce7531001dec0c760e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->