### PR TITLE
fix(settings): compute the router 'needs its own key' note (Gemini is no longer one)

### DIFF
--- a/app/dashboard/settings/routers-manager.tsx
+++ b/app/dashboard/settings/routers-manager.tsx
@@ -297,6 +297,20 @@ function EngineStatus({
   searchVerified: Provider[];
   checks: Check[] | null;
 }) {
+  // Engines that still need a direct key on this router: the base providers it
+  // doesn't serve, plus Google AI Overviews — a pseudo-model that never routes
+  // through any gateway (routerSlug is null for it), even when the router serves
+  // the Gemini assistant. Computed rather than hardcoded so it stays truthful as
+  // a router gains coverage (e.g. Concentrate now grounds Gemini).
+  const needsOwnKey = [
+    ...(Object.keys(PROVIDERS) as Provider[]).filter((p) => !served.includes(p)).map((p) => PROVIDERS[p].label),
+    "Google AI Overviews",
+  ];
+  const needsOwnKeyList =
+    needsOwnKey.length === 1
+      ? needsOwnKey[0]
+      : `${needsOwnKey.slice(0, -1).join(", ")} and ${needsOwnKey[needsOwnKey.length - 1]}`;
+
   return (
     <div className="space-y-2">
       <ul className="space-y-1.5">
@@ -330,7 +344,7 @@ function EngineStatus({
           worth naming once, because "my router does 400 models" makes their
           absence surprising. */}
       <p className="text-xs text-ink-faint">
-        Gemini, Google AI Overviews and Perplexity need their own keys — their answers
+        {needsOwnKeyList} {needsOwnKey.length === 1 ? "needs its own key" : "need their own keys"} — their answers
         aren&apos;t comparable when routed through a gateway.
       </p>
     </div>


### PR DESCRIPTION
## Why
After enabling Concentrate to ground Gemini (#122), the Concentrate card's footer still hardcoded **"Gemini, Google AI Overviews and Perplexity need their own keys."** Listing **Gemini** is now wrong — the Gemini assistant routes through Concentrate.

## What
Compute the "needs its own key" list instead of hardcoding it: **base providers the router doesn't serve + "Google AI Overviews"** (a pseudo-model that never routes through any gateway — `routerSlug` is null for it — even when the router serves the Gemini *assistant*).

For Concentrate this now reads **"Perplexity (Sonar) and Google AI Overviews need their own keys"** and stays truthful as any router's coverage changes.

## The other message in the screenshot (not a code change)
The per-engine line **"Google (Gemini) reachable, but web search isn't confirmed"** is **dynamic** — driven by the credential's stored `search_verified`, which was written *before* Concentrate could ground Google. It flips to **"measurable, live web search confirmed"** once this + #122 are deployed and the Concentrate key is **Replace → Save**'d (re-runs the save-time probe). No code change needed for that line.

## Verification
- `tsc --noEmit`: 0 errors · `eslint`: clean (one pre-existing `<img>` warning on an unrelated line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/123"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789585898&installation_model_id=431526&pr_number=123&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F123&signature=45daacf55fea980ca9598186f0806a7fdc8475bfba3cdeddcb7bfe7b145657e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->