### PR TITLE
Add xAI, DeepSeek, and Meta as answer engines

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,6 +65,7 @@ TRIAL_OPENAI_API_KEY=
 TRIAL_GOOGLE_API_KEY=
 TRIAL_PERPLEXITY_API_KEY=
 TRIAL_XAI_API_KEY=
+TRIAL_DEEPSEEK_API_KEY=
 # Free monitoring runs per user before they must add their own key (default 5).
 # THIS is the configurable trial threshold. Consumed atomically at run start.
 TRIAL_RUN_LIMIT=5
@@ -92,6 +93,7 @@ TRIAL_OPENAI_MODEL=gpt-4o-mini
 TRIAL_GOOGLE_MODEL=gemini-flash-lite-latest
 TRIAL_PERPLEXITY_MODEL=sonar
 TRIAL_XAI_MODEL=grok-4.3
+TRIAL_DEEPSEEK_MODEL=deepseek-v4-flash
 # Optional: embeddable video URL (e.g. a YouTube embed link) explaining the
 # bring-your-own-key model, shown when a user's free runs are used up.
 NEXT_PUBLIC_BYOK_VIDEO_URL=
@@ -105,6 +107,7 @@ ANALYSIS_OPENAI_MODEL=
 ANALYSIS_GOOGLE_MODEL=
 ANALYSIS_PERPLEXITY_MODEL=
 ANALYSIS_XAI_MODEL=
+ANALYSIS_DEEPSEEK_MODEL=
 
 # ------------------------------------------------------------------
 # Operator alerts (optional)

--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,7 @@ TRIAL_ANTHROPIC_API_KEY=
 TRIAL_OPENAI_API_KEY=
 TRIAL_GOOGLE_API_KEY=
 TRIAL_PERPLEXITY_API_KEY=
+TRIAL_XAI_API_KEY=
 # Free monitoring runs per user before they must add their own key (default 5).
 # THIS is the configurable trial threshold. Consumed atomically at run start.
 TRIAL_RUN_LIMIT=5
@@ -90,6 +91,7 @@ TRIAL_ANTHROPIC_MODEL=claude-haiku-4-5
 TRIAL_OPENAI_MODEL=gpt-4o-mini
 TRIAL_GOOGLE_MODEL=gemini-flash-lite-latest
 TRIAL_PERPLEXITY_MODEL=sonar
+TRIAL_XAI_MODEL=grok-4.3
 # Optional: embeddable video URL (e.g. a YouTube embed link) explaining the
 # bring-your-own-key model, shown when a user's free runs are used up.
 NEXT_PUBLIC_BYOK_VIDEO_URL=
@@ -102,6 +104,7 @@ ANALYSIS_ANTHROPIC_MODEL=
 ANALYSIS_OPENAI_MODEL=
 ANALYSIS_GOOGLE_MODEL=
 ANALYSIS_PERPLEXITY_MODEL=
+ANALYSIS_XAI_MODEL=
 
 # ------------------------------------------------------------------
 # Operator alerts (optional)

--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,7 @@ TRIAL_GOOGLE_API_KEY=
 TRIAL_PERPLEXITY_API_KEY=
 TRIAL_XAI_API_KEY=
 TRIAL_DEEPSEEK_API_KEY=
+TRIAL_META_API_KEY=
 # Free monitoring runs per user before they must add their own key (default 5).
 # THIS is the configurable trial threshold. Consumed atomically at run start.
 TRIAL_RUN_LIMIT=5
@@ -94,6 +95,9 @@ TRIAL_GOOGLE_MODEL=gemini-flash-lite-latest
 TRIAL_PERPLEXITY_MODEL=sonar
 TRIAL_XAI_MODEL=grok-4.3
 TRIAL_DEEPSEEK_MODEL=deepseek-v4-flash
+# No cheap tier exists for Meta; the cost lever is the adapter's hardcoded
+# reasoning_effort, not model choice. See lib/models.ts ANALYSIS_MODEL_DEFAULT.
+TRIAL_META_MODEL=muse-spark-1.2
 # Optional: embeddable video URL (e.g. a YouTube embed link) explaining the
 # bring-your-own-key model, shown when a user's free runs are used up.
 NEXT_PUBLIC_BYOK_VIDEO_URL=
@@ -108,6 +112,7 @@ ANALYSIS_GOOGLE_MODEL=
 ANALYSIS_PERPLEXITY_MODEL=
 ANALYSIS_XAI_MODEL=
 ANALYSIS_DEEPSEEK_MODEL=
+ANALYSIS_META_MODEL=
 
 # ------------------------------------------------------------------
 # Operator alerts (optional)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ treats that as a property of the engine rather than something to paper over:
 |---|---|---|
 | **Always searches** | Perplexity Sonar, Google AI Overviews | Grounded; the project toggle is ignored |
 | **Searches on request** | Claude, ChatGPT, Gemini, Grok | Grounded, and the browse is **forced** rather than offered |
-| **Searches on request, not forced** | Meta (Muse Spark) | The tool is offered; no forcing parameter is documented, so the model decides whether to use it |
+| **Searches on request, not forced** | Meta (Muse Spark) | The tool is offered (Meta rejects forcing); an answer in which the model didn't search is refused rather than stored as grounded |
 | **Cannot search** | DeepSeek | **The run is refused** |
 
 DeepSeek's API has no server-side browsing — its documented tools are
@@ -301,9 +301,9 @@ By default Lettertrace is bring-your-own-key: a user must add a key before runni
 
 Set in your environment:
 
-- `TRIAL_ANTHROPIC_API_KEY` / `TRIAL_OPENAI_API_KEY` / `TRIAL_GOOGLE_API_KEY`: the shared key(s) to lend out (set the provider(s) you want to offer). Leave unset to keep the app BYOK-only.
+- `TRIAL_<PROVIDER>_API_KEY` (`ANTHROPIC`, `OPENAI`, `GOOGLE`, `PERPLEXITY`, `XAI`, `DEEPSEEK`, `META`): the shared key(s) to lend out (set the provider(s) you want to offer). Leave unset to keep the app BYOK-only.
 - `TRIAL_RUN_LIMIT`: free monitoring runs per user before they must add their own key (default `5`). **This is the configurable threshold.** A run counts when it starts (consumed atomically, so parallel requests can't exceed the cap).
-- `TRIAL_ANTHROPIC_MODEL` / `TRIAL_OPENAI_MODEL` / `TRIAL_GOOGLE_MODEL`: optional cheaper models to cap your cost during the trial (default to the user's selected model).
+- `TRIAL_<PROVIDER>_MODEL`: optional cheaper models to cap your cost during the trial (default to the user's selected model). Meta has no cheaper tier; its cost lever is the adapter's fixed `reasoning_effort`.
 - `NEXT_PUBLIC_BYOK_VIDEO_URL`: optional embeddable video URL explaining the BYOK model, shown once the free runs are used up.
 
 While a user has free runs left and no key of their own, monitoring runs and variation generation use the shared key. Completed runs are counted on `profiles.trial_runs_used` (token spend is also recorded on `profiles.trial_tokens_used` so you can watch cost). A banner in the dashboard shows how many free runs are left; once they're gone, data collection stops with a clear prompt (and optional video) to add their own key. Adding a key removes the limit entirely. Scheduled (cron) runs always use the owner's own key, never the trial.

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Track topics · auto-generate the questions people actually ask AI · watch tren
 
 Lettertrace is a self-hostable AEO tool, focused purely on **diagnosing and monitoring AI mentions** (a.k.a. Answer Engine Optimization / Generative Engine Optimization). You describe your brand and a few topics; Lettertrace generates realistic prompts a person might ask ChatGPT or Claude, runs them against those models **with your own API key**, detects when your brand and your competitors get mentioned, and charts how your visibility, sentiment, and share of voice move over time.
 
-- 🔓 **Open source** (MIT) and **BYOK**, you bring your own Anthropic / OpenAI / Google / Perplexity / xAI keys — or a single **LLM router** key ([Concentrate](https://concentrate.ai/)) instead. Either way they're encrypted at rest and never leave your infrastructure.
-- 🧠 **Multi-model**, query Claude (Anthropic), ChatGPT (OpenAI), Gemini and Google AI Overviews (both on your Google key), Perplexity Sonar, and Grok (xAI). Add more providers easily.
+- 🔓 **Open source** (MIT) and **BYOK**, you bring your own Anthropic / OpenAI / Google / Perplexity / xAI / DeepSeek keys — or a single **LLM router** key ([Concentrate](https://concentrate.ai/)) instead. Either way they're encrypted at rest and never leave your infrastructure.
+- 🧠 **Multi-model**, query Claude (Anthropic), ChatGPT (OpenAI), Gemini and Google AI Overviews (both on your Google key), Perplexity Sonar, Grok (xAI), and DeepSeek. Add more providers easily.
 - 🧩 **Topics → variations**, auto-generate the different questions people ask AI about each topic.
 - 📈 **Trends over time**, visibility, share of voice, prominence, and sentiment across runs.
 - ⚔️ **Competitor benchmarking**, ingest competitors and see how often each shows up.
@@ -40,12 +40,32 @@ For each answer the model returns, Lettertrace:
 2. **LLM enrichment**, for the entities that were mentioned, a structured call classifies **sentiment** and whether the answer **recommended** them.
 3. **Aggregation**, visibility (mention rate), **share of voice**, average prominence, and sentiment are computed per run and trended over time.
 
+### Not every engine can browse
+
+Answer engines differ in whether they can search the live web, and Lettertrace
+treats that as a property of the engine rather than something to paper over:
+
+| | Engines | With web search **on** |
+|---|---|---|
+| **Always searches** | Perplexity Sonar, Google AI Overviews | Grounded; the project toggle is ignored |
+| **Searches on request** | Claude, ChatGPT, Gemini, Grok | Grounded, and the browse is **forced** rather than offered |
+| **Cannot search** | DeepSeek | **The run is refused** |
+
+DeepSeek's API has no server-side browsing — its documented tools are
+caller-executed functions, and web search exists only in its consumer app.
+Running your prompts through it with web search on would answer from the model's
+memory and record that as a search-grounded measurement, so Lettertrace refuses
+instead and tells you the two fixes: turn web search off for that project, or
+pick another engine. With web search off, DeepSeek measures exactly what it is —
+what the model recalls about your brand — and that is a legitimate thing to
+track, just not the same number as a grounded run.
+
 ## Tech stack
 
 - **Next.js 14** (App Router, TypeScript) · **Tailwind CSS** · **Recharts**
 - **Supabase**, Postgres, Auth, and Row Level Security
 - **BYOK** provider keys encrypted with **AES-256-GCM** at rest
-- Anthropic (`@anthropic-ai/sdk`) + OpenAI (`openai`) SDK adapters, plus dependency-free REST adapters for Google Gemini (Gemini models + Google AI Overviews, via Google Search grounding), Perplexity Sonar (always search-grounded, real source URLs), and xAI Grok (Responses-API server-side `web_search`, `url_citation` annotations)
+- Anthropic (`@anthropic-ai/sdk`) + OpenAI (`openai`) SDK adapters, plus dependency-free REST adapters for Google Gemini (Gemini models + Google AI Overviews, via Google Search grounding), Perplexity Sonar (always search-grounded, real source URLs), xAI Grok (Responses-API server-side `web_search`, `url_citation` annotations), and DeepSeek (memory-only — see below)
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Track topics · auto-generate the questions people actually ask AI · watch tren
 
 Lettertrace is a self-hostable AEO tool, focused purely on **diagnosing and monitoring AI mentions** (a.k.a. Answer Engine Optimization / Generative Engine Optimization). You describe your brand and a few topics; Lettertrace generates realistic prompts a person might ask ChatGPT or Claude, runs them against those models **with your own API key**, detects when your brand and your competitors get mentioned, and charts how your visibility, sentiment, and share of voice move over time.
 
-- 🔓 **Open source** (MIT) and **BYOK**, you bring your own Anthropic / OpenAI / Google / Perplexity / xAI / DeepSeek keys — or a single **LLM router** key ([Concentrate](https://concentrate.ai/)) instead. Either way they're encrypted at rest and never leave your infrastructure.
-- 🧠 **Multi-model**, query Claude (Anthropic), ChatGPT (OpenAI), Gemini and Google AI Overviews (both on your Google key), Perplexity Sonar, Grok (xAI), and DeepSeek. Add more providers easily.
+- 🔓 **Open source** (MIT) and **BYOK**, you bring your own Anthropic / OpenAI / Google / Perplexity / xAI / DeepSeek / Meta keys — or a single **LLM router** key ([Concentrate](https://concentrate.ai/)) instead. Either way they're encrypted at rest and never leave your infrastructure.
+- 🧠 **Multi-model**, query Claude (Anthropic), ChatGPT (OpenAI), Gemini and Google AI Overviews (both on your Google key), Perplexity Sonar, Grok (xAI), DeepSeek, and Meta (Muse Spark). Add more providers easily.
 - 🧩 **Topics → variations**, auto-generate the different questions people ask AI about each topic.
 - 📈 **Trends over time**, visibility, share of voice, prominence, and sentiment across runs.
 - ⚔️ **Competitor benchmarking**, ingest competitors and see how often each shows up.
@@ -49,6 +49,7 @@ treats that as a property of the engine rather than something to paper over:
 |---|---|---|
 | **Always searches** | Perplexity Sonar, Google AI Overviews | Grounded; the project toggle is ignored |
 | **Searches on request** | Claude, ChatGPT, Gemini, Grok | Grounded, and the browse is **forced** rather than offered |
+| **Searches on request, not forced** | Meta (Muse Spark) | The tool is offered; no forcing parameter is documented, so the model decides whether to use it |
 | **Cannot search** | DeepSeek | **The run is refused** |
 
 DeepSeek's API has no server-side browsing — its documented tools are
@@ -65,7 +66,7 @@ track, just not the same number as a grounded run.
 - **Next.js 14** (App Router, TypeScript) · **Tailwind CSS** · **Recharts**
 - **Supabase**, Postgres, Auth, and Row Level Security
 - **BYOK** provider keys encrypted with **AES-256-GCM** at rest
-- Anthropic (`@anthropic-ai/sdk`) + OpenAI (`openai`) SDK adapters, plus dependency-free REST adapters for Google Gemini (Gemini models + Google AI Overviews, via Google Search grounding), Perplexity Sonar (always search-grounded, real source URLs), xAI Grok (Responses-API server-side `web_search`, `url_citation` annotations), and DeepSeek (memory-only — see below)
+- Anthropic (`@anthropic-ai/sdk`) + OpenAI (`openai`) SDK adapters, plus dependency-free REST adapters for Google Gemini (Gemini models + Google AI Overviews, via Google Search grounding), Perplexity Sonar (always search-grounded, real source URLs), xAI Grok (Responses-API server-side `web_search`, `url_citation` annotations), DeepSeek (memory-only — see below), and Meta Muse Spark (Responses-API-shaped `web_search`, offered not forced, `url_citation` annotations)
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Track topics · auto-generate the questions people actually ask AI · watch tren
 
 Lettertrace is a self-hostable AEO tool, focused purely on **diagnosing and monitoring AI mentions** (a.k.a. Answer Engine Optimization / Generative Engine Optimization). You describe your brand and a few topics; Lettertrace generates realistic prompts a person might ask ChatGPT or Claude, runs them against those models **with your own API key**, detects when your brand and your competitors get mentioned, and charts how your visibility, sentiment, and share of voice move over time.
 
-- 🔓 **Open source** (MIT) and **BYOK**, you bring your own Anthropic / OpenAI / Google / Perplexity keys — or a single **LLM router** key ([Concentrate](https://concentrate.ai/)) instead. Either way they're encrypted at rest and never leave your infrastructure.
-- 🧠 **Multi-model**, query Claude (Anthropic), ChatGPT (OpenAI), Gemini and Google AI Overviews (both on your Google key), and Perplexity Sonar. Add more providers easily.
+- 🔓 **Open source** (MIT) and **BYOK**, you bring your own Anthropic / OpenAI / Google / Perplexity / xAI keys — or a single **LLM router** key ([Concentrate](https://concentrate.ai/)) instead. Either way they're encrypted at rest and never leave your infrastructure.
+- 🧠 **Multi-model**, query Claude (Anthropic), ChatGPT (OpenAI), Gemini and Google AI Overviews (both on your Google key), Perplexity Sonar, and Grok (xAI). Add more providers easily.
 - 🧩 **Topics → variations**, auto-generate the different questions people ask AI about each topic.
 - 📈 **Trends over time**, visibility, share of voice, prominence, and sentiment across runs.
 - ⚔️ **Competitor benchmarking**, ingest competitors and see how often each shows up.
@@ -45,7 +45,7 @@ For each answer the model returns, Lettertrace:
 - **Next.js 14** (App Router, TypeScript) · **Tailwind CSS** · **Recharts**
 - **Supabase**, Postgres, Auth, and Row Level Security
 - **BYOK** provider keys encrypted with **AES-256-GCM** at rest
-- Anthropic (`@anthropic-ai/sdk`) + OpenAI (`openai`) SDK adapters, plus dependency-free REST adapters for Google Gemini (Gemini models + Google AI Overviews, via Google Search grounding) and Perplexity Sonar (always search-grounded, real source URLs)
+- Anthropic (`@anthropic-ai/sdk`) + OpenAI (`openai`) SDK adapters, plus dependency-free REST adapters for Google Gemini (Gemini models + Google AI Overviews, via Google Search grounding), Perplexity Sonar (always search-grounded, real source URLs), and xAI Grok (Responses-API server-side `web_search`, `url_citation` annotations)
 
 ## Getting started
 
@@ -256,7 +256,7 @@ ROUTER_API_KEY_OPENROUTER=...  npx tsx scripts/probe-router.ts openrouter
 
 The distinction that matters is **forced** versus merely enabled, and it is worth testing rather than reading off a gateway's docs. Probed against Concentrate on 2026-07-30: asked "what is the capital of France?" — a question the model answers from memory — its Responses endpoint with a forced `tool_choice` still returned two cited sources, while the same request with the tool only offered returned none, and so did chat-completions with `web_search_options`. A router that permits searching but can't be made to search will drift against a direct key, since the model answers familiar questions from recall and cites nothing.
 
-**Gemini, Google AI Overviews and Perplexity still need their own keys.** Not because the models are unreachable through a router, but because their measurement paths don't survive normalization: Gemini's grounding arrives as Google-specific chunks behind a redirect host, AI Overviews is a Gemini call plus a forced-search system prompt of ours, and Perplexity's search is the product rather than a parameter. Routed, all three would return an answer that is a different measurement wearing the same label.
+**Gemini, Google AI Overviews, Perplexity and Grok still need their own keys.** Not because the models are unreachable through a router, but because their measurement paths don't survive normalization: Gemini's grounding arrives as Google-specific chunks behind a redirect host, AI Overviews is a Gemini call plus a forced-search system prompt of ours, and Perplexity's search is the product rather than a parameter. Routed, all three would return an answer that is a different measurement wearing the same label. Grok is absent from the router registry for a plainer reason — no gateway has been probed for it yet, and an entry there is a claim about what survives the trip, not a guess.
 
 Router keys are encrypted at rest exactly like provider keys, and resolution order is: your own provider key → your router key → the operator's trial key (if any) → nothing.
 

--- a/app/api/onboarding/complete/route.ts
+++ b/app/api/onboarding/complete/route.ts
@@ -131,11 +131,14 @@ export async function POST(request: Request) {
   // New projects are created grounded (use_web_search defaults on in the
   // database), so coverage is asked for the grounded case.
   const routerKeys = await getRouterKeysPublic(supabase, user.id);
-  const runnable = coveredProviders({
+  const credentials = {
     direct: providers,
     routers: routerKeys.map((k) => ({ router: k.router, searchVerified: k.search_verified ?? [] })),
-    webSearch: true,
-  });
+  };
+  const grounded = coveredProviders({ ...credentials, webSearch: true });
+  // An engine the user can only run ungrounded (DeepSeek) still beats the env default:
+  // Settings and the run page then name the exact fix instead of "no key" for an engine they never chose.
+  const runnable = grounded.length > 0 ? grounded : coveredProviders({ ...credentials, webSearch: false });
   const envDefault = pickDefaultProvider();
   const provider =
     runnable.length === 0 || runnable.includes(envDefault) ? envDefault : runnable[0];

--- a/app/api/onboarding/onboarding-route.test.ts
+++ b/app/api/onboarding/onboarding-route.test.ts
@@ -2,12 +2,15 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // The route pulls in the Supabase server client (next/headers) and the trial
 // layer; we only care about the request validation that runs before any of it.
+const db = vi.hoisted(() => ({
+  from: (_table: string): unknown => {
+    throw new Error("validation should reject before touching the database");
+  },
+}));
 vi.mock("@/lib/supabase/server", () => ({
   createClient: () => ({
     auth: { getUser: async () => ({ data: { user: { id: "user-1" } } }) },
-    from: () => {
-      throw new Error("validation should reject before touching the database");
-    },
+    from: (table: string) => db.from(table),
   }),
 }));
 // lib/data uses React's cache(), which only exists in a server-component
@@ -39,7 +42,11 @@ function req(body: unknown) {
 
 const BASE = { brand_name: "Acme", name: "Acme", brand_domains: ["acme.com"] };
 
-beforeEach(() => vi.clearAllMocks());
+const throwingFrom = db.from;
+beforeEach(() => {
+  vi.clearAllMocks();
+  db.from = throwingFrom;
+});
 
 describe("POST /api/onboarding/complete — topic validation", () => {
   // The reported bug: both of these used to be silently dropped, the request
@@ -124,5 +131,49 @@ describe("POST /api/onboarding/complete, creating more organizations", () => {
     vi.mocked(getConfiguredProviders).mockResolvedValue([]);
     const res = await POST(req({ ...BASE, topics: [{ name: "", prompts: [] }] }));
     expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /api/onboarding/complete, picking the default engine", () => {
+  const good = { ...BASE, topics: [{ name: "CDN", prompts: ["best cdn?"] }] };
+
+  /** Record the projects insert, then stop the request there. */
+  function captureInsert() {
+    let inserted: Record<string, unknown> | null = null;
+    db.from = (table: string) => {
+      if (table !== "projects") throw new Error(`unexpected table ${table}`);
+      return {
+        insert: (values: Record<string, unknown>) => {
+          inserted = values;
+          return { select: () => ({ single: async () => ({ data: null, error: { message: "stop" } }) }) };
+        },
+      };
+    };
+    return () => inserted;
+  }
+
+  it("starts on the engine the user's own key can run grounded", async () => {
+    vi.mocked(getConfiguredProviders).mockResolvedValue(["openai"]);
+    const inserted = captureInsert();
+    await POST(req(good));
+    expect(inserted()).toMatchObject({ default_provider: "openai" });
+  });
+
+  // DeepSeek can't ground, so it isn't grounded-runnable — but it is still the
+  // only engine this user holds a key for. Pinning the project to it lets the
+  // settings form and run page name the exact fix (turn off web search); the
+  // env default would just report "no key" for an engine they never chose.
+  it("still prefers the user's only key when that engine can't ground", async () => {
+    vi.mocked(getConfiguredProviders).mockResolvedValue(["deepseek"]);
+    const inserted = captureInsert();
+    await POST(req(good));
+    expect(inserted()).toMatchObject({ default_provider: "deepseek" });
+  });
+
+  it("falls back to the env default when the user holds no key at all", async () => {
+    vi.mocked(getConfiguredProviders).mockResolvedValue([]);
+    const inserted = captureInsert();
+    await POST(req(good));
+    expect(inserted()).toMatchObject({ default_provider: "anthropic" });
   });
 });

--- a/app/api/runs/route.ts
+++ b/app/api/runs/route.ts
@@ -40,7 +40,15 @@ export async function POST() {
   // 'unroutable' belongs here too: the user holds a credential that reaches this
   // engine, but not one that can measure it comparably. engineKeyMessage carries
   // the reason and the fix.
-  if (key.source === "none" || key.source === "mismatch" || key.source === "unroutable") {
+  // 'ungrounded' joins them for the same reason, one layer further down: the
+  // engine itself can't search, so no credential would make this run
+  // comparable with the ones already on the trend line.
+  if (
+    key.source === "none" ||
+    key.source === "mismatch" ||
+    key.source === "unroutable" ||
+    key.source === "ungrounded"
+  ) {
     return NextResponse.json(
       {
         error: engineKeyMessage(key),

--- a/app/api/v1/projects/[id]/runs/route.ts
+++ b/app/api/v1/projects/[id]/runs/route.ts
@@ -84,9 +84,9 @@ export async function POST(
       { ...options, context: apiActor(auth, "v1") },
     );
     if (!outcome.ok) {
-      // not_found -> 404, a bad engine override -> 400, no key -> 402 (billing).
+      // not_found -> 404, no key -> 402 (billing), anything else about the request/config -> 400.
       const status =
-        outcome.code === "not_found" ? 404 : outcome.code === "invalid_engine" ? 400 : 402;
+        outcome.code === "not_found" ? 404 : outcome.code === "no_key" ? 402 : 400;
       await logApiRequest(auth, request, "v1", {
         category: "run",
         action: "api.trigger_run",

--- a/app/api/v1/v1-routes.test.ts
+++ b/app/api/v1/v1-routes.test.ts
@@ -398,6 +398,22 @@ describe("POST /api/v1/projects/:id/runs", () => {
     expect(res.status).toBe(402);
   });
 
+  it("400s, not 402s, when the engine can't ground the project — a key won't fix it", async () => {
+    vi.mocked(triggerRunForProject).mockResolvedValue({
+      ok: false,
+      code: "ungrounded",
+      message: "DeepSeek can't search. Turn off web search for this project.",
+    });
+    const res = await postRunRoute(
+      req("/api/v1/projects/p1/runs", { method: "POST" }),
+      { params: { id: "p1" } },
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: "DeepSeek can't search. Turn off web search for this project.",
+    });
+  });
+
   it("returns the run result on success", async () => {
     vi.mocked(triggerRunForProject).mockResolvedValue({
       ok: true,

--- a/app/dashboard/runs/run-now.tsx
+++ b/app/dashboard/runs/run-now.tsx
@@ -97,6 +97,19 @@ export function RunNow({
           .
         </p>
       )}
+      {/* The engine can't browse at all, so no key changes anything. The fix is
+          the project's own web-search setting, which is why this points at
+          Settings rather than at adding a credential. */}
+      {keySource === "ungrounded" && (
+        <p className="text-xs text-ink-faint">
+          {providerLabel} can&apos;t search the web, so it can&apos;t answer a project that asks
+          for live results. Turn off web search, or pick another engine, in{" "}
+          <Link href="/dashboard/settings" className="text-terracotta-dark hover:text-terracotta">
+            Settings
+          </Link>
+          .
+        </p>
+      )}
       {canRun && activePrompts === 0 && (
         <p className="text-xs text-ink-faint">
           Add active prompts in{" "}

--- a/app/dashboard/settings/keys-manager.tsx
+++ b/app/dashboard/settings/keys-manager.tsx
@@ -72,6 +72,14 @@ const PROVIDER_STYLE: Record<
     chipClass: "bg-ink/5 border border-ink/10",
     monogram: "xAI",
   },
+  deepseek: {
+    title: "DeepSeek",
+    // Says the limitation on the card, where the choice is actually being made,
+    // rather than leaving it to be discovered as a refused run later.
+    subtitle: "DeepSeek API key · answers from memory, no web search",
+    chipClass: "bg-ink/5 border border-ink/10",
+    monogram: "DS",
+  },
 };
 
 export default function KeysManager({

--- a/app/dashboard/settings/keys-manager.tsx
+++ b/app/dashboard/settings/keys-manager.tsx
@@ -80,6 +80,12 @@ const PROVIDER_STYLE: Record<
     chipClass: "bg-ink/5 border border-ink/10",
     monogram: "DS",
   },
+  meta: {
+    title: "Meta",
+    subtitle: "Meta Model API key · Muse Spark",
+    chipClass: "bg-ink/5 border border-ink/10",
+    monogram: "M",
+  },
 };
 
 export default function KeysManager({

--- a/app/dashboard/settings/keys-manager.tsx
+++ b/app/dashboard/settings/keys-manager.tsx
@@ -22,9 +22,23 @@ import type { Provider, ProviderKeyPublic } from "@/lib/types";
 // Brand glyphs (transparent PNGs in /public/providers) on the cards' tinted
 // chips. OpenAI's mark is monochrome, so it carries a per-theme pair swapped by
 // the .logo-for-* rules in globals.css; the others read on both themes as-is.
+// `logo` is optional: a provider whose mark we don't have falls back to a
+// monogram on the same tinted plate. Drawing an approximation of a company's
+// trademark from memory is worse than not showing one — it ships a wrong mark
+// under their name — and a required field would have forced exactly that to
+// get the card rendering. Dropping a real PNG into /public/providers and
+// naming it here is then a one-line change.
 const PROVIDER_STYLE: Record<
   Provider,
-  { title: string; subtitle: string; chipClass: string; logo: string; darkLogo?: string }
+  {
+    title: string;
+    subtitle: string;
+    chipClass: string;
+    logo?: string;
+    darkLogo?: string;
+    /** Shown when there is no logo. One or two characters. */
+    monogram?: string;
+  }
 > = {
   anthropic: {
     title: "Claude",
@@ -51,6 +65,12 @@ const PROVIDER_STYLE: Record<
     chipClass: "bg-mint-tint",
     logo: "/providers/perplexity-black.png",
     darkLogo: "/providers/perplexity-teal.png",
+  },
+  xai: {
+    title: "Grok",
+    subtitle: "xAI API key",
+    chipClass: "bg-ink/5 border border-ink/10",
+    monogram: "xAI",
   },
 };
 
@@ -154,13 +174,17 @@ function ProviderCard({
             )}
             aria-hidden
           >
-            {style.darkLogo ? (
+            {style.logo && style.darkLogo ? (
               <>
                 <img src={style.logo} alt="" className="logo-for-light h-6 w-6 object-contain" />
                 <img src={style.darkLogo} alt="" className="logo-for-dark h-6 w-6 object-contain" />
               </>
-            ) : (
+            ) : style.logo ? (
               <img src={style.logo} alt="" className="h-6 w-6 object-contain" />
+            ) : (
+              <span className="text-[11px] font-semibold tracking-tight text-ink-faint">
+                {style.monogram ?? style.title.slice(0, 2)}
+              </span>
             )}
           </span>
           <div>

--- a/app/dashboard/settings/project-form.tsx
+++ b/app/dashboard/settings/project-form.tsx
@@ -107,6 +107,8 @@ export default function ProjectForm({
   // hidden, because two of the three fixes (turn web search off, re-check the
   // key) leave this engine selected.
   const unroutable = coverage.kind === "unroutable" ? coverage : null;
+  // The engine can't browse at all; the fix is the web-search toggle on this form.
+  const ungrounded = coverage.kind === "ungrounded" ? coverage : null;
   // Which credential will carry the run, when one can. Worth saying: a user who
   // set up a gateway shouldn't have to infer that it covers the engine they just
   // picked from the absence of a warning.
@@ -282,6 +284,8 @@ export default function ProjectForm({
           // it here — while the toggle that causes it is on screen — is the
           // difference between a fixable setting and a failed run.
           <p className="mt-1.5 text-xs text-butter-ink">{unroutable.reason}</p>
+        ) : ungrounded ? (
+          <p className="mt-1.5 text-xs text-butter-ink">{ungrounded.reason}</p>
         ) : (
           <div className="mt-1.5 space-y-1">
             <p className="text-xs text-ink-faint">
@@ -375,6 +379,8 @@ export default function ProjectForm({
                 Saved, but {ROUTERS[unroutable.router].label} can&apos;t measure{" "}
                 {providerLabel} on these settings
               </span>
+            ) : ungrounded ? (
+              <span>Saved, but {providerLabel} can&apos;t search the web, which this project asks for</span>
             ) : (
               "Saved"
             )}

--- a/lib/api-service.test.ts
+++ b/lib/api-service.test.ts
@@ -400,6 +400,25 @@ describe("triggerRunForProject", () => {
     },
   );
 
+  it("reports an engine that can't ground as 'ungrounded', with the resolver's fix, not as a missing key", async () => {
+    const db = fakeDb({ projects: () => ({ data: PROJECT }) });
+    vi.mocked(resolveRunKeyFor).mockResolvedValue({
+      source: "ungrounded",
+      provider: "deepseek",
+      model: "deepseek-v4-pro",
+      requested: { provider: "deepseek", model: "deepseek-v4-pro" },
+      refusal: "DeepSeek can't search. Turn off web search for this project.",
+    });
+    vi.mocked(engineKeyMessage).mockImplementation((k) => k.refusal ?? "");
+    const outcome = await triggerRunForProject(db as never, "user-1", "proj-1");
+    expect(outcome).toMatchObject({
+      ok: false,
+      code: "ungrounded",
+      message: "DeepSeek can't search. Turn off web search for this project.",
+    });
+    expect(executeRun).not.toHaveBeenCalled();
+  });
+
   it("executes with the user's own key", async () => {
     const db = fakeDb({ projects: () => ({ data: PROJECT }) });
     vi.mocked(resolveRunKeyFor).mockResolvedValue({

--- a/lib/api-service.ts
+++ b/lib/api-service.ts
@@ -1151,10 +1151,9 @@ export interface BackgroundRunStart {
 
 export type TriggerOutcome =
   | { ok: true; result: RunResult | BackgroundRunStart }
-  // `invalid_engine` is the caller's request being malformed (a model the
-  // provider doesn't offer), distinct from `no_key` which is about billing —
-  // routes map them to 400 and 402 respectively.
-  | { ok: false; code: "not_found" | "no_key" | "invalid_engine"; message: string };
+  // `no_key` is billing (402); `invalid_engine` (bad override) and `ungrounded`
+  // (engine can't search, project asks for it) are the request/config (400).
+  | { ok: false; code: "not_found" | "no_key" | "invalid_engine" | "ungrounded"; message: string };
 
 /**
  * Execute a monitoring run for one of the user's projects.
@@ -1203,6 +1202,9 @@ export async function triggerRunForProject(
   const key = await resolveRunKeyFor(supabase, userId, override.provider, override.model, {
     webSearch: project.use_web_search,
   });
+  if (key.source === "ungrounded") {
+    return { ok: false, code: "ungrounded", message: engineKeyMessage(key) };
+  }
   if (key.source !== "own") {
     const providerLabel = PROVIDERS[key.requested.provider].label;
     return {

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -186,6 +186,26 @@ export async function getDecryptedRouterKeys(
   return keys;
 }
 
+/** Decrypt every provider key the user has stored, in one query (server-only). Undecryptable rows are skipped. */
+export async function getDecryptedKeys(
+  supabase: SupabaseClient,
+  userId: string,
+): Promise<Partial<Record<Provider, string>>> {
+  const { data } = await supabase
+    .from("provider_keys")
+    .select("provider, encrypted_key")
+    .eq("user_id", userId);
+  const keys: Partial<Record<Provider, string>> = {};
+  for (const row of (data ?? []) as { provider: Provider; encrypted_key: string }[]) {
+    try {
+      keys[row.provider] = decryptSecret(row.encrypted_key);
+    } catch {
+      continue;
+    }
+  }
+  return keys;
+}
+
 /** Decrypt the user's key for a provider (server-only). Returns null if none. */
 export async function getDecryptedKey(
   supabase: SupabaseClient,

--- a/lib/llm/deepseek.test.ts
+++ b/lib/llm/deepseek.test.ts
@@ -1,0 +1,330 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  runQuery,
+  verifyKey,
+  generateVariations,
+  analyzeResponse,
+  humanError,
+  DeepseekAPIError,
+} from "./index";
+import {
+  PROVIDERS,
+  PROVIDER_LIST,
+  analysisModelFor,
+  defaultModelFor,
+  providerCanMeasure,
+  providerRefusalMessage,
+} from "@/lib/models";
+
+// ------------------------------------------------------------------
+// DeepSeek adapter. Mocked fetch throughout.
+//
+// The subject here is narrower than the other adapters and mostly about what
+// DeepSeek must NOT do. It is the only engine in the catalog whose API cannot
+// browse, so the tests that matter are the ones proving a grounded project can
+// never be served by it and that an ungrounded answer never acquires sources
+// it didn't earn.
+//
+// The transport is raw fetch rather than the OpenAI SDK with a base URL, even
+// though DeepSeek is OpenAI-compatible enough for the latter to work. The
+// deciding reason is visible right here: the SDK resolves its own fetch, so an
+// SDK-backed adapter cannot be asserted at the wire level by this harness — a
+// wrong host or a stray search parameter would pass silently.
+// ------------------------------------------------------------------
+
+const KEY = "sk-deepseek-test-key";
+
+function chatOk(content: string, usage?: Record<string, number>) {
+  return {
+    id: "x",
+    choices: [{ index: 0, message: { role: "assistant", content }, finish_reason: "stop" }],
+    usage: usage ?? { total_tokens: 42 },
+  };
+}
+
+function reply(body: unknown, status = 200, headers: Record<string, string> = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    headers: { get: (k: string) => headers[k.toLowerCase()] ?? null },
+  } as unknown as Response;
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+/** Queue of responses; the last one repeats once exhausted. */
+function mockFetch(...responses: Response[]) {
+  let i = 0;
+  fetchMock = vi.fn(async () => responses[Math.min(i++, responses.length - 1)]);
+  vi.stubGlobal("fetch", fetchMock);
+}
+
+function sentUrl(call = 0): string {
+  return String(fetchMock.mock.calls[call][0]);
+}
+function sentBody(call = 0): Record<string, any> {
+  return JSON.parse(fetchMock.mock.calls[call][1].body as string);
+}
+
+const answer = (over: Record<string, unknown> = {}) =>
+  ({ provider: "deepseek" as const, model: "deepseek-v4-pro", apiKey: KEY, prompt: "q", ...over });
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+// --- the answer path ------------------------------------------------------
+
+describe("deepseek runQuery", () => {
+  it("talks to DeepSeek's host, not OpenAI's", async () => {
+    mockFetch(reply(chatOk("hello")));
+    const res = await runQuery(answer());
+    expect(sentUrl()).toContain("api.deepseek.com");
+    expect(sentUrl()).not.toContain("openai.com");
+    expect(res.text).toBe("hello");
+  });
+
+  // DeepSeek V4 has thinking mode ON by default (effort "high" per its docs),
+  // and reasoning shares the SAME max_tokens as the visible answer -- the same
+  // failure shape as Gemini's thinking tokens. Confirmed live 2026-08-14: a
+  // real verifyKey ping (8 tokens) came back "empty answer (finish_reason:
+  // length)" -- the whole budget was spent on hidden reasoning before any
+  // visible text. A mocked suite cannot catch a live vendor default; this
+  // pins the fix (thinking explicitly disabled) so it can't regress silently.
+  it("disables thinking mode, so a small token budget can't be silently eaten by reasoning", async () => {
+    mockFetch(reply(chatOk("hello")));
+    await runQuery(answer());
+    expect(sentBody().thinking).toEqual({ type: "disabled" });
+  });
+
+  it("never asks for tools or search, whatever the project setting says", async () => {
+    // webSearch:true cannot legitimately reach this function — resolveRunKeyFor
+    // refuses it first — but if it ever did, the request still must not claim
+    // to be grounded. Asserted for both settings so the answer is the same one.
+    for (const webSearch of [false, true]) {
+      mockFetch(reply(chatOk("from memory")));
+      await runQuery(answer({ webSearch }));
+      const body = sentBody();
+      expect(body.tools).toBeUndefined();
+      expect(body.tool_choice).toBeUndefined();
+      expect(body.web_search_options).toBeUndefined();
+    }
+  });
+
+  it("returns no sources, because it never looked anything up", async () => {
+    mockFetch(reply(chatOk("Acme and Globex are the main ones.")));
+    const res = await runQuery(answer({ webSearch: true }));
+    // Recording a citation here would be inventing one.
+    expect(res.sources).toEqual([]);
+  });
+
+  it("reports token usage", async () => {
+    mockFetch(reply(chatOk("hi", { total_tokens: 321 })));
+    expect((await runQuery(answer())).tokens).toBe(321);
+  });
+
+  // A 200 whose content is empty would be stored and then scanned for zero
+  // mentions, reading downstream as "the brand wasn't named" rather than "we
+  // never got an answer".
+  it("fails an empty answer instead of storing it", async () => {
+    mockFetch(reply(chatOk("")));
+    await expect(runQuery(answer())).rejects.toThrow(/empty answer/i);
+  });
+});
+
+// --- utility calls --------------------------------------------------------
+
+describe("deepseek utility calls", () => {
+  it("sends utility work to DeepSeek, never to OpenAI", async () => {
+    mockFetch(reply(chatOk('{"questions":["a","b"]}')));
+    await generateVariations({
+      provider: "deepseek",
+      model: "deepseek-v4-pro",
+      apiKey: KEY,
+      topicName: "cdn",
+      count: 2,
+    });
+    expect(sentUrl()).toContain("api.deepseek.com");
+    expect(sentUrl()).not.toContain("openai.com");
+  });
+
+  it("asks for a JSON object, the way the OpenAI-shaped surfaces do", async () => {
+    mockFetch(reply(chatOk('{"questions":["a"]}')));
+    await generateVariations({
+      provider: "deepseek",
+      model: "deepseek-v4-pro",
+      apiKey: KEY,
+      topicName: "cdn",
+      count: 1,
+    });
+    expect(sentBody().response_format).toEqual({ type: "json_object" });
+  });
+
+  it("classifies on the cheap model, not the answer model", async () => {
+    mockFetch(
+      reply(chatOk('{"results":[{"key":"brand","sentiment":"positive","recommended":true}]}')),
+    );
+    await analyzeResponse({
+      provider: "deepseek",
+      model: "deepseek-v4-pro",
+      apiKey: KEY,
+      question: "q",
+      responseText: "Acme is great",
+      entities: [{ key: "brand", name: "Acme" }],
+    });
+    expect(sentBody().model).toBe("deepseek-v4-flash");
+    expect(sentBody().model).not.toBe("deepseek-v4-pro");
+  });
+});
+
+// --- verifyKey ------------------------------------------------------------
+
+describe("deepseek verifyKey", () => {
+  it("accepts a working key", async () => {
+    mockFetch(reply(chatOk("pong")));
+    await expect(verifyKey("deepseek", KEY)).resolves.toEqual({ ok: true });
+  });
+
+  it("probes on the cheap model", async () => {
+    mockFetch(reply(chatOk("pong")));
+    await verifyKey("deepseek", KEY);
+    expect(sentBody().model).toBe("deepseek-v4-flash");
+  });
+
+  it("reports a bad key as invalid", async () => {
+    mockFetch(reply({ error: { message: "Authentication Fails" } }, 401));
+    await expect(verifyKey("deepseek", KEY)).resolves.toMatchObject({
+      ok: false,
+      error: "Invalid API key.",
+    });
+  });
+});
+
+// --- HTTP errors and retries ---------------------------------------------
+
+describe("deepseek HTTP errors", () => {
+  it("surfaces a bad key immediately, without retrying", async () => {
+    mockFetch(reply({ error: { message: "Authentication Fails" } }, 401));
+    await expect(runQuery(answer())).rejects.toThrow();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a 503 and succeeds", async () => {
+    vi.useFakeTimers();
+    mockFetch(reply({ error: { message: "overloaded" } }, 503), reply(chatOk("ok")));
+    const p = runQuery(answer());
+    await vi.runAllTimersAsync();
+    await expect(p).resolves.toMatchObject({ text: "ok" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("waits as long as Retry-After asks, not the exponential backoff", async () => {
+    vi.useFakeTimers();
+    mockFetch(
+      reply({ error: { message: "slow down" } }, 429, { "retry-after": "12" }),
+      reply(chatOk("ok")),
+    );
+    const p = runQuery(answer());
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(11_000);
+    await expect(p).resolves.toMatchObject({ text: "ok" });
+  });
+
+  it("gives up rather than sleeping past the single-wait ceiling", async () => {
+    vi.useFakeTimers();
+    mockFetch(reply({ error: { message: "daily cap" } }, 429, { "retry-after": "3600" }));
+    const p = runQuery(answer());
+    const rejected = expect(p).rejects.toThrow(/daily cap/);
+    await vi.runAllTimersAsync();
+    await rejected;
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  // DeepSeek runs on a prepaid balance, so a perfectly valid key stops working
+  // when it empties. "Provider error (402)" would send someone hunting for a
+  // bad key instead of topping up.
+  it("says a spent balance is a spent balance", () => {
+    expect(humanError(new DeepseekAPIError(402, "Insufficient Balance"))).toMatch(/balance/i);
+  });
+
+  it("explains a 429 instead of saying 'rate limited'", () => {
+    const msg = humanError(new DeepseekAPIError(429, "too many", 30));
+    expect(msg).toMatch(/rate limit/i);
+    expect(msg).toContain("30s");
+  });
+
+  it("maps auth and server errors", () => {
+    expect(humanError(new DeepseekAPIError(401, "nope"))).toBe("Invalid API key.");
+    expect(humanError(new DeepseekAPIError(503, "boom"))).toMatch(/temporary/i);
+  });
+});
+
+// --- the grounding gate ---------------------------------------------------
+//
+// The reason ProviderSearch exists. These are the tests that stop a memory
+// answer being charted as a search-grounded measurement.
+
+describe("provider grounding capability", () => {
+  it("refuses DeepSeek for a project that wants live-web answers", () => {
+    expect(providerCanMeasure("deepseek", { webSearch: true })).toBe(false);
+  });
+
+  it("allows DeepSeek when the project asked for no grounding", () => {
+    expect(providerCanMeasure("deepseek", { webSearch: false })).toBe(true);
+  });
+
+  it("lets every browsing engine serve a grounded project", () => {
+    for (const info of PROVIDER_LIST) {
+      if (info.search === "none") continue;
+      expect(providerCanMeasure(info.id, { webSearch: true })).toBe(true);
+    }
+  });
+
+  // The field documents behaviour the adapters already had; if one of these
+  // drifts, the catalog is lying about what a run measures.
+  it("describes each engine's real grounding behaviour", () => {
+    expect(PROVIDERS.perplexity.search).toBe("always"); // perplexityRunQuery has no ungrounded branch
+    expect(PROVIDERS.deepseek.search).toBe("none");
+    expect(PROVIDERS.anthropic.search).toBe("optional");
+    expect(PROVIDERS.openai.search).toBe("optional");
+    expect(PROVIDERS.google.search).toBe("optional");
+  });
+
+  it("names both fixes in the refusal, and never suggests retrying", () => {
+    const msg = providerRefusalMessage("deepseek");
+    expect(msg).toMatch(/turn off web search/i);
+    expect(msg).toMatch(/switch your answer engine/i);
+    expect(msg).not.toMatch(/try again/i);
+    // Never offers an engine that can't ground either.
+    expect(msg).not.toMatch(/DeepSeek(,| or)/);
+  });
+});
+
+// --- catalog guards -------------------------------------------------------
+
+describe("deepseek catalog", () => {
+  it("defaults to Pro and classifies on Flash", () => {
+    expect(defaultModelFor("deepseek")).toBe("deepseek-v4-pro");
+    expect(analysisModelFor("deepseek")).toBe("deepseek-v4-flash");
+    expect(analysisModelFor("deepseek")).not.toBe(defaultModelFor("deepseek"));
+  });
+
+  it("honours the analysis-model env override", () => {
+    vi.stubEnv("ANALYSIS_DEEPSEEK_MODEL", " deepseek-v4-pro ");
+    expect(analysisModelFor("deepseek")).toBe("deepseek-v4-pro"); // trimmed
+  });
+
+  // deepseek-chat and deepseek-reasoner were transitional aliases with an
+  // announced retirement date. Pinning an alias that the vendor moves or
+  // retires is what left every pinned Gemini id answering 404 on fresh keys.
+  it("keeps the retired transitional aliases out of the catalog", () => {
+    const ids = PROVIDERS.deepseek.models.map((m) => m.id);
+    expect(ids).not.toContain("deepseek-chat");
+    expect(ids).not.toContain("deepseek-reasoner");
+    for (const id of ids) expect(id).toMatch(/^deepseek-v\d/);
+  });
+});

--- a/lib/llm/index.ts
+++ b/lib/llm/index.ts
@@ -295,6 +295,9 @@ const DIRECT_SHAPE: Record<Provider, CallShape> = {
   xai: "openai-chat",
   // Genuinely chat-completions shaped, and wants OpenAI's JSON-object phrasing.
   deepseek: "openai-chat",
+  // Utility surface really is chat-completions; the answer path is the
+  // Responses API, mirroring xAI's split.
+  meta: "openai-chat",
 };
 
 function callShape(opts: BaseCall, model: string): CallShape {
@@ -343,6 +346,8 @@ async function utilityChat(
       return xaiChat(opts.apiKey, model, system, user, maxTokens, json);
     case "deepseek":
       return deepseekChat(opts.apiKey, model, system, user, maxTokens, json);
+    case "meta":
+      return metaChat(opts.apiKey, model, system, user, maxTokens, json);
     case "openai":
       return openaiChat(opts.apiKey, model, system, user, maxTokens, json);
   }
@@ -369,6 +374,17 @@ export async function verifyKey(
       await xaiChat(apiKey, "grok-4.3", undefined, "ping", 8);
     } else if (provider === "deepseek") {
       await deepseekChat(apiKey, "deepseek-v4-flash", undefined, "ping", 8);
+    } else if (provider === "meta") {
+      // NOT an 8-token ping like the others. Measured live 2026-08-15: even
+      // at reasoning_effort:"minimal", a trivial "ping" still spends a
+      // reasoning-token count that swings widely between calls (samples from
+      // 5 up to 79) before any visible token -- minimal reduces reasoning
+      // cost, it does not remove it the way DeepSeek's thinking:"disabled"
+      // does. 100 tokens looked safe across one batch of samples and then
+      // failed live in the dashboard on the very next real key save. 300
+      // still costs a fraction of a cent and comfortably clears every
+      // reasoning-token sample measured so far.
+      await metaChat(apiKey, "muse-spark-1.2", undefined, "ping", 300);
     } else {
       await openaiChat(apiKey, "gpt-4o-mini", undefined, "ping", 4);
     }
@@ -562,6 +578,11 @@ export async function runQuery(
   // providerCanMeasure — so this is the ungrounded case by construction.
   if (opts.provider === "deepseek") {
     return deepseekRunQuery(opts.apiKey, opts.model, opts.prompt);
+  }
+  // Meta answers on the Responses API whether or not it is browsing, same
+  // reasoning as xAI's branch above.
+  if (opts.provider === "meta") {
+    return metaRunQuery(opts.apiKey, opts.model, opts.prompt, webSearch);
   }
   if (!webSearch) {
     const res =
@@ -1828,6 +1849,264 @@ async function deepseekRunQuery(
   return { ...res, sources: [] };
 }
 
+// ==================================================================
+// Meta (Muse Spark, via the Meta Model API)
+//
+// Not the retired Llama API (llama.developer.meta.com, sunset 2026-07-06) --
+// a different, currently-active product Meta launched in its place. Raw fetch,
+// matching DeepSeek's and xAI's shape rather than the OpenAI SDK, for the same
+// reason: this suite asserts on the actual wire body, and an SDK-backed
+// adapter can only be checked through its return value.
+//
+// Two surfaces, mirroring xAI's split: /chat/completions for utility work,
+// /responses for monitored answers, since that is where Meta's own
+// search-grounding cookbook puts the web_search tool.
+//
+// reasoning_effort is set on EVERY call this adapter makes, never left unset.
+// Meta's own docs say the default "is still being finalized" -- an admitted
+// unknown, not a safe one to leave alone. That is the DeepSeek lesson applied
+// before a live call, not after one: DeepSeek's thinking mode defaulted to
+// "high" and reasoning shares the same token budget as the visible answer,
+// which turned an 8-token verifyKey ping into an empty answer. Muse Spark's
+// docs describe the identical budget-sharing behaviour ("reasoning_tokens are
+// part of completion_tokens"), so the same failure is available here on day
+// one if a default ever lands on something expensive. "minimal" for utility
+// calls (classification/suggestion have no use for chain-of-thought), "low"
+// for answers (some benefit for a real monitored question, without inviting
+// the failure mode a high default would risk).
+// ==================================================================
+
+const META_API_BASE = "https://api.meta.ai/v1";
+const META_TIMEOUT_MS = 60_000;
+const META_MAX_ATTEMPTS = 4;
+const META_RETRYABLE = new Set([429, 500, 502, 503, 504]);
+const META_MAX_RETRY_WAIT_MS = 45_000;
+const META_RETRY_BUDGET_MS = 90_000;
+
+export class MetaAPIError extends Error {
+  status: number;
+  /** From the Retry-After header on a 429, in seconds. */
+  retryAfterSec?: number;
+  constructor(status: number, message: string, retryAfterSec?: number) {
+    super(message);
+    this.name = "MetaAPIError";
+    this.status = status;
+    this.retryAfterSec = retryAfterSec;
+  }
+}
+
+interface MetaChatResponse {
+  choices?: { message?: { content?: string | null }; finish_reason?: string }[];
+  usage?: { prompt_tokens?: number; completion_tokens?: number; total_tokens?: number };
+  error?: { message?: string } | string;
+}
+
+async function metaFetch<T>(
+  path: "/chat/completions" | "/responses",
+  apiKey: string,
+  body: unknown,
+): Promise<T> {
+  let lastErr: unknown;
+  let sleptMs = 0;
+  for (let attempt = 0; attempt < META_MAX_ATTEMPTS; attempt++) {
+    try {
+      const res = await fetch(`${META_API_BASE}${path}`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${apiKey}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(META_TIMEOUT_MS),
+      });
+      if (res.ok) return (await res.json()) as T;
+      const errBody = (await res.json().catch(() => ({}))) as {
+        error?: { message?: string } | string;
+      };
+      const message =
+        (typeof errBody.error === "string" ? errBody.error : errBody.error?.message) ??
+        `Meta API error (${res.status}).`;
+      const merr = new MetaAPIError(res.status, message, retryAfterSeconds(res));
+      if (!META_RETRYABLE.has(res.status)) throw merr;
+      lastErr = merr;
+    } catch (err) {
+      if (err instanceof MetaAPIError && !META_RETRYABLE.has(err.status)) throw err;
+      lastErr = err;
+    }
+    if (attempt >= META_MAX_ATTEMPTS - 1) break;
+
+    const advised = lastErr instanceof MetaAPIError ? lastErr.retryAfterSec : undefined;
+    const backoffMs = 400 * 2 ** attempt;
+    const waitMs = advised !== undefined ? Math.max(advised * 1000, backoffMs) : backoffMs;
+    if (waitMs > META_MAX_RETRY_WAIT_MS || sleptMs + waitMs > META_RETRY_BUDGET_MS) break;
+    await sleep(waitMs);
+    sleptMs += waitMs;
+  }
+  throw lastErr ?? new Error("Meta request failed.");
+}
+
+/** Utility-call helper, matching the other providers' chat helpers. */
+async function metaChat(
+  apiKey: string,
+  model: string,
+  system: string | undefined,
+  user: string,
+  maxTokens: number,
+  json = false,
+): Promise<ChatResult> {
+  const messages: { role: string; content: string }[] = [];
+  if (system) messages.push({ role: "system", content: system });
+  messages.push({ role: "user", content: user });
+
+  const data = await metaFetch<MetaChatResponse>("/chat/completions", apiKey, {
+    model,
+    messages,
+    max_tokens: maxTokens,
+    // See the section header: never left unset. Every call this adapter makes
+    // for utility work is a structured-JSON judgment with no use for extended
+    // reasoning, so this is the cheapest tier rather than a guess at "safe".
+    reasoning_effort: "minimal",
+    ...(json ? { response_format: { type: "json_object" } } : {}),
+  });
+
+  const choice = data.choices?.[0];
+  const text = (choice?.message?.content ?? "").trim();
+  const usage = data.usage;
+  const tokens =
+    usage?.total_tokens ?? (usage?.prompt_tokens ?? 0) + (usage?.completion_tokens ?? 0);
+
+  // A 200 carrying no usable answer is an error, not an empty measurement --
+  // same guard as every other adapter here, and the exact shape of failure
+  // reasoning_effort above exists to prevent (reasoning eating the budget
+  // before any visible token is written).
+  if (!choice) {
+    throw new Error("Meta returned no answer (the response contained no choices).");
+  }
+  if (!text) {
+    throw new Error(
+      `Meta returned an empty answer (finish_reason: ${choice.finish_reason ?? "unspecified"}).`,
+    );
+  }
+  return { text, tokens };
+}
+
+interface MetaResponsesReply {
+  output?: {
+    type?: string;
+    // Present (value "commentary") on the throwaway "I'll look that up for
+    // you" message a search turn emits before its web_search_call items;
+    // absent on the real final answer and on every message when search is
+    // off. Measured live 2026-08-15: a 2-search grounded call returned TWO
+    // message items, commentary first, real answer last -- concatenating
+    // both (the original bug here) stored the commentary sentence glued
+    // onto the front of the real answer.
+    phase?: string;
+    content?: {
+      type?: string;
+      text?: string;
+      annotations?: { type?: string; url?: string; title?: string }[];
+    }[];
+  }[];
+  usage?: { input_tokens?: number; output_tokens?: number; total_tokens?: number };
+}
+
+/**
+ * Sources from a Meta answer. Exported for tests.
+ *
+ * Unlike xAI, Meta's own docs describe `annotations[].title` as the source's
+ * real page title, not a citation-number label. Measured live 2026-08-15
+ * across several grounded answers: presence is prompt-dependent, not
+ * missing. A plain "list the top 5..." prompt came back with empty
+ * annotations despite two completed web_search_call actions in the same
+ * reply, but two "what is the best X" / "how do I..." prompts through the
+ * real pilot harness both returned real citations -- one of them the
+ * project's own domain. Don't assume a Meta run has zero sources just
+ * because one earlier prompt shape didn't attach any.
+ */
+export function metaSources(reply: MetaResponsesReply): CitedSource[] {
+  const raw: CitedSource[] = [];
+  for (const item of reply.output ?? []) {
+    for (const c of item.content ?? []) {
+      for (const a of c.annotations ?? []) {
+        if (a.type && a.type !== "url_citation") continue;
+        const s = a.url ? safeSource(a.url, a.title ?? null, null) : null;
+        if (s) raw.push(s);
+      }
+    }
+  }
+  return dedupeSources(raw);
+}
+
+function metaText(reply: MetaResponsesReply): string {
+  let text = "";
+  for (const item of reply.output ?? []) {
+    if (item.type !== "message" || item.phase === "commentary") continue;
+    for (const c of item.content ?? []) {
+      if (typeof c.text === "string") text += (text ? "\n" : "") + c.text;
+    }
+  }
+  return text.trim();
+}
+
+// Probed live 2026-08-15, three real calls against Muse Spark: no tools, tools
+// offered with no tool_choice, then this shape. `tool_choice: {type:"web_search"}`
+// was rejected outright with HTTP 400 "`tool_choice` did not match any
+// supported type" -- not silently ignored, genuinely unsupported. Confirms
+// Meta's own docs ("the model decides autonomously") rather than just being
+// silent on the point the way Grok's were. Left permanently unset;
+// metaRunQuery only offers the tool.
+const META_FORCE_SEARCH: Record<string, unknown> | undefined = undefined;
+
+// A grounded call's tool-calling turns count against the SAME output budget
+// as the answer, same class of bug as the reasoning-token one above but far
+// bigger: measured live 2026-08-15 on an open-ended "best CDN" question, Muse
+// Spark ran one search plus THREE full open_page fetches before writing a
+// word of the answer, spending all 1200 tokens on tool orchestration and
+// leaving incomplete_details:{reason:"max_output_tokens"} with no message at
+// all -- every such prompt would refuse rather than measure anything.
+// search_context_size:"low" did not reduce the page-open count (tested, no
+// effect). 3000 tokens let the same prompt finish both the exploration and a
+// full final answer with ~774 tokens of headroom (2226 used); 4000 keeps
+// that margin under prompts that search more, still under 2 cents worst
+// case at Meta's own output rate. Ungrounded calls never hit this path (no
+// tools means no tool-calling turns), so they keep the shared budget.
+const META_GROUNDED_MAX_TOKENS = 4000;
+
+async function metaRunQuery(
+  apiKey: string,
+  model: string,
+  prompt: string,
+  webSearch: boolean,
+): Promise<QueryResult> {
+  const reply = await metaFetch<MetaResponsesReply>("/responses", apiKey, {
+    model,
+    input: prompt,
+    max_output_tokens: webSearch ? META_GROUNDED_MAX_TOKENS : ANSWER_MAX_TOKENS,
+    // NOT `reasoning_effort` -- that flat field is the chat-completions shape.
+    // The Responses API rejects it outright with HTTP 400 "unknown parameter"
+    // (measured live 2026-08-15); the nested form below is what it actually
+    // reads back in the reply. Getting this wrong doesn't degrade the
+    // answer, it fails every single monitored Meta run.
+    reasoning: { effort: "low" },
+    ...(webSearch
+      ? {
+          tools: [{ type: "web_search" }],
+          ...(META_FORCE_SEARCH ? { tool_choice: META_FORCE_SEARCH } : {}),
+        }
+      : {}),
+  });
+
+  const text = metaText(reply);
+  const usage = reply.usage;
+  const tokens =
+    usage?.total_tokens ?? (usage?.input_tokens ?? 0) + (usage?.output_tokens ?? 0);
+
+  if (!text) {
+    throw new Error("Meta returned an empty answer.");
+  }
+  return { text, tokens, sources: webSearch ? metaSources(reply) : [] };
+}
+
 // Prompt shape is the single biggest lever on whether a run measures anything.
 // Measured against a stealth-stage brand (24 queries per shape, both providers):
 //
@@ -2253,6 +2532,20 @@ export function humanError(err: unknown): string {
         `DeepSeek rejected the request: this key is over its rate limit.${wait} ` +
         `Check your rate limits and balance in the DeepSeek platform console, or wait and run again.`
       );
+    }
+    if (err.status >= 500) return "The AI provider had a temporary error. Please try again.";
+    if (err.status === 404) return "The requested model isn't available for this key.";
+    return err.message || `Provider error (${err.status}).`;
+  }
+  if (err instanceof MetaAPIError) {
+    if (err.status === 401 || err.status === 403) return "Invalid API key.";
+    if (err.status === 402) return "This Meta key has no credit left.";
+    if (err.status === 429) {
+      const wait =
+        err.retryAfterSec !== undefined && err.retryAfterSec > 0
+          ? ` Meta asked us to wait ${Math.ceil(err.retryAfterSec)}s.`
+          : "";
+      return `Meta rejected the request: this key is over its rate limit.${wait} Wait and run again.`;
     }
     if (err.status >= 500) return "The AI provider had a temporary error. Please try again.";
     if (err.status === 404) return "The requested model isn't available for this key.";

--- a/lib/llm/index.ts
+++ b/lib/llm/index.ts
@@ -293,6 +293,8 @@ const DIRECT_SHAPE: Record<Provider, CallShape> = {
   // response_format, so it wants OpenAI's phrasing rather than a shape of its
   // own. Only the ANSWER path differs (the Responses API, below).
   xai: "openai-chat",
+  // Genuinely chat-completions shaped, and wants OpenAI's JSON-object phrasing.
+  deepseek: "openai-chat",
 };
 
 function callShape(opts: BaseCall, model: string): CallShape {
@@ -339,6 +341,8 @@ async function utilityChat(
       return perplexityChat(opts.apiKey, model, system, user, maxTokens);
     case "xai":
       return xaiChat(opts.apiKey, model, system, user, maxTokens, json);
+    case "deepseek":
+      return deepseekChat(opts.apiKey, model, system, user, maxTokens, json);
     case "openai":
       return openaiChat(opts.apiKey, model, system, user, maxTokens, json);
   }
@@ -363,6 +367,8 @@ export async function verifyKey(
       // than send as-is — see XAI_MIN_MAX_TOKENS for why a too-small ping is how
       // a valid key gets reported invalid.
       await xaiChat(apiKey, "grok-4.3", undefined, "ping", 8);
+    } else if (provider === "deepseek") {
+      await deepseekChat(apiKey, "deepseek-v4-flash", undefined, "ping", 8);
     } else {
       await openaiChat(apiKey, "gpt-4o-mini", undefined, "ping", 4);
     }
@@ -550,6 +556,12 @@ export async function runQuery(
   // its own branch rather than splitting across the shared web-search one below.
   if (opts.provider === "xai") {
     return xaiRunQuery(opts.apiKey, opts.model, opts.prompt, webSearch);
+  }
+  // DeepSeek can't browse, so it ignores the toggle the way Perplexity ignores
+  // it in the other direction. A grounded project never gets this far — see
+  // providerCanMeasure — so this is the ungrounded case by construction.
+  if (opts.provider === "deepseek") {
+    return deepseekRunQuery(opts.apiKey, opts.model, opts.prompt);
   }
   if (!webSearch) {
     const res =
@@ -878,6 +890,26 @@ interface GoogleResponse {
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
+/**
+ * Seconds from a Retry-After header, in either form the spec allows: a delta in
+ * seconds, or an HTTP date.
+ *
+ * Shared by every adapter that honours the header (Perplexity, xAI, DeepSeek) —
+ * they had begun to accumulate byte-identical private copies, and the HTTP-date
+ * branch is the kind of thing that gets dropped when the third copy is written
+ * from memory. Google is the exception and stays separate: its wait arrives
+ * inside a google.rpc.RetryInfo detail rather than a header.
+ */
+function retryAfterSeconds(res: Response): number | undefined {
+  const raw = res.headers.get("retry-after");
+  if (!raw) return undefined;
+  const secs = Number(raw);
+  if (Number.isFinite(secs) && secs >= 0) return secs;
+  const when = Date.parse(raw);
+  if (!Number.isNaN(when)) return Math.max(0, (when - Date.now()) / 1000);
+  return undefined;
+}
+
 // Map the "google-ai-overviews" pseudo-model onto a real Gemini model so it
 // never reaches the wire; every other id passes through untouched.
 function resolveGoogleModel(model: string): string {
@@ -1164,17 +1196,6 @@ interface PerplexityResponse {
   detail?: unknown;
 }
 
-/** Seconds from a Retry-After header, which may be a delta or an HTTP date. */
-function perplexityRetryAfterSec(res: Response): number | undefined {
-  const raw = res.headers.get("retry-after");
-  if (!raw) return undefined;
-  const secs = Number(raw);
-  if (Number.isFinite(secs) && secs >= 0) return secs;
-  const when = Date.parse(raw);
-  if (!Number.isNaN(when)) return Math.max(0, (when - Date.now()) / 1000);
-  return undefined;
-}
-
 async function perplexityFetch(apiKey: string, body: unknown): Promise<PerplexityResponse> {
   let lastErr: unknown;
   let sleptMs = 0;
@@ -1196,7 +1217,7 @@ async function perplexityFetch(apiKey: string, body: unknown): Promise<Perplexit
         errBody.error?.message ??
           (typeof errBody.detail === "string" ? errBody.detail : undefined) ??
           `Perplexity API error (${res.status}).`,
-        perplexityRetryAfterSec(res),
+        retryAfterSeconds(res),
       );
       if (!PERPLEXITY_RETRYABLE.has(res.status)) throw perr;
       lastErr = perr;
@@ -1391,17 +1412,6 @@ export class XaiAPIError extends Error {
   }
 }
 
-/** Seconds from a Retry-After header, which may be a delta or an HTTP date. */
-function xaiRetryAfterSec(res: Response): number | undefined {
-  const raw = res.headers.get("retry-after");
-  if (!raw) return undefined;
-  const secs = Number(raw);
-  if (Number.isFinite(secs) && secs >= 0) return secs;
-  const when = Date.parse(raw);
-  if (!Number.isNaN(when)) return Math.max(0, (when - Date.now()) / 1000);
-  return undefined;
-}
-
 /** POST to one of xAI's two surfaces, with the shared retry policy. */
 async function xaiFetch<T>(path: "/chat/completions" | "/responses", apiKey: string, body: unknown): Promise<T> {
   let lastErr: unknown;
@@ -1426,7 +1436,7 @@ async function xaiFetch<T>(path: "/chat/completions" | "/responses", apiKey: str
         (typeof errBody.error === "string" ? errBody.error : errBody.error?.message) ??
         (typeof errBody.detail === "string" ? errBody.detail : undefined) ??
         `xAI API error (${res.status}).`;
-      const xerr = new XaiAPIError(res.status, message, xaiRetryAfterSec(res));
+      const xerr = new XaiAPIError(res.status, message, retryAfterSeconds(res));
       if (!XAI_RETRYABLE.has(res.status)) throw xerr;
       lastErr = xerr;
     } catch (err) {
@@ -1658,6 +1668,164 @@ async function xaiRunQuery(
     throw new Error("xAI returned an empty answer.");
   }
   return { text, tokens, sources: webSearch ? xaiSources(reply) : [] };
+}
+
+// ==================================================================
+// DeepSeek
+//
+// The only engine in the catalog that cannot browse, and the reason
+// ProviderSearch exists. DeepSeek's API documents `function` tools only —
+// caller-executed — so "grounding" would mean us running the search and handing
+// results back, which measures OUR search engine wearing DeepSeek's label. Web
+// search is a feature of their consumer app, not of the API. lib/models refuses
+// a grounded project on this provider (providerCanMeasure) before a call is
+// ever made; nothing here has to defend against it, but nothing here may
+// quietly answer one either.
+//
+// Raw fetch rather than the OpenAI SDK with a base URL, even though DeepSeek is
+// OpenAI-compatible enough for that to work. Two reasons, in order:
+//
+//   1. The SDK resolves its own fetch internally, so an SDK-backed adapter
+//      cannot be asserted at the wire level by this suite's mocked-fetch
+//      harness. Every other adapter here proves what it puts on the wire; one
+//      that can only be tested through its return value is the one where a
+//      wrong host or a stray search parameter would go unnoticed.
+//   2. DeepSeek's error semantics are its own — 402 is a spent prepaid balance,
+//      not a card problem — and mapping them needs its own error type.
+//
+// The cost is a retry loop that looks like googleFetch's and perplexityFetch's.
+// Those two are already near-identical for the same reason; per-provider
+// transports are the established shape in this file.
+// ==================================================================
+
+const DEEPSEEK_API_URL = "https://api.deepseek.com/chat/completions";
+const DEEPSEEK_TIMEOUT_MS = 60_000;
+const DEEPSEEK_MAX_ATTEMPTS = 4;
+const DEEPSEEK_RETRYABLE = new Set([429, 500, 502, 503, 504]);
+const DEEPSEEK_MAX_RETRY_WAIT_MS = 45_000;
+const DEEPSEEK_RETRY_BUDGET_MS = 90_000;
+
+export class DeepseekAPIError extends Error {
+  status: number;
+  /** From the Retry-After header on a 429, in seconds. */
+  retryAfterSec?: number;
+  constructor(status: number, message: string, retryAfterSec?: number) {
+    super(message);
+    this.name = "DeepseekAPIError";
+    this.status = status;
+    this.retryAfterSec = retryAfterSec;
+  }
+}
+
+interface DeepseekResponse {
+  choices?: { message?: { content?: string | null }; finish_reason?: string }[];
+  usage?: { prompt_tokens?: number; completion_tokens?: number; total_tokens?: number };
+  error?: { message?: string } | string;
+}
+
+async function deepseekFetch(apiKey: string, body: unknown): Promise<DeepseekResponse> {
+  let lastErr: unknown;
+  let sleptMs = 0;
+  for (let attempt = 0; attempt < DEEPSEEK_MAX_ATTEMPTS; attempt++) {
+    try {
+      const res = await fetch(DEEPSEEK_API_URL, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${apiKey}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(DEEPSEEK_TIMEOUT_MS),
+      });
+      if (res.ok) return (await res.json()) as DeepseekResponse;
+      const errBody = (await res.json().catch(() => ({}))) as DeepseekResponse;
+      const message =
+        (typeof errBody.error === "string" ? errBody.error : errBody.error?.message) ??
+        `DeepSeek API error (${res.status}).`;
+      const derr = new DeepseekAPIError(res.status, message, retryAfterSeconds(res));
+      if (!DEEPSEEK_RETRYABLE.has(res.status)) throw derr;
+      lastErr = derr;
+    } catch (err) {
+      if (err instanceof DeepseekAPIError && !DEEPSEEK_RETRYABLE.has(err.status)) throw err;
+      lastErr = err;
+    }
+    if (attempt >= DEEPSEEK_MAX_ATTEMPTS - 1) break;
+
+    const advised = lastErr instanceof DeepseekAPIError ? lastErr.retryAfterSec : undefined;
+    const backoffMs = 400 * 2 ** attempt;
+    const waitMs = advised !== undefined ? Math.max(advised * 1000, backoffMs) : backoffMs;
+    if (waitMs > DEEPSEEK_MAX_RETRY_WAIT_MS || sleptMs + waitMs > DEEPSEEK_RETRY_BUDGET_MS) break;
+    await sleep(waitMs);
+    sleptMs += waitMs;
+  }
+  throw lastErr ?? new Error("DeepSeek request failed.");
+}
+
+/** Utility-call helper, matching the other providers' chat helpers. */
+async function deepseekChat(
+  apiKey: string,
+  model: string,
+  system: string | undefined,
+  user: string,
+  maxTokens: number,
+  json = false,
+): Promise<ChatResult> {
+  const messages: { role: string; content: string }[] = [];
+  if (system) messages.push({ role: "system", content: system });
+  messages.push({ role: "user", content: user });
+
+  const data = await deepseekFetch(apiKey, {
+    model,
+    messages,
+    max_tokens: maxTokens,
+    // DeepSeek V4 has "thinking mode" ON by default, effort "high" per its own
+    // docs, and reasoning shares the SAME max_tokens as the visible answer --
+    // the identical failure shape as Gemini's thinking tokens (see
+    // GOOGLE_THINKING_HEADROOM), confirmed live 2026-08-14: the verifyKey ping
+    // (8 tokens) came back "empty answer (finish_reason: length)" — the entire
+    // budget was spent on hidden reasoning before a single visible token could
+    // be written. Disabled outright rather than padded with headroom the way
+    // Gemini's is: unlike Gemini, DeepSeek exposes a real off switch, and every
+    // call this adapter makes (a tiny ping, a structured classification, a
+    // company-listing answer) is a task that doesn't need chain-of-thought.
+    // Leaving it on would also make DeepSeek's cost and truncation risk
+    // unpredictable in a way no other engine here is, for no measured benefit.
+    thinking: { type: "disabled" },
+    ...(json ? { response_format: { type: "json_object" } } : {}),
+  });
+
+  const choice = data.choices?.[0];
+  const text = (choice?.message?.content ?? "").trim();
+  const usage = data.usage;
+  const tokens =
+    usage?.total_tokens ?? (usage?.prompt_tokens ?? 0) + (usage?.completion_tokens ?? 0);
+
+  // A 200 carrying no usable answer is an error, not an empty measurement: it
+  // would be stored, scanned for zero mentions, and charted as "the brand
+  // wasn't named". Same guard as googleGenerate and perplexityGenerate.
+  if (!choice) {
+    throw new Error("DeepSeek returned no answer (the response contained no choices).");
+  }
+  if (!text) {
+    throw new Error(
+      `DeepSeek returned an empty answer (finish_reason: ${choice.finish_reason ?? "unspecified"}).`,
+    );
+  }
+  return { text, tokens };
+}
+
+async function deepseekRunQuery(
+  apiKey: string,
+  model: string,
+  prompt: string,
+): Promise<QueryResult> {
+  // No webSearch parameter, and that is the point rather than an omission. A
+  // grounded project never reaches this function (providerCanMeasure refuses it
+  // at resolveRunKeyFor), and an ungrounded one has nothing to ask for. Sources
+  // are always empty because the model never looked anything up — recording a
+  // citation here would be inventing one.
+  const res = await deepseekChat(apiKey, model, undefined, prompt, ANSWER_MAX_TOKENS);
+  return { ...res, sources: [] };
 }
 
 // Prompt shape is the single biggest lever on whether a run measures anything.
@@ -2066,6 +2234,28 @@ export function humanError(err: unknown): string {
       );
     }
     if (err.status >= 500) return "The AI provider had a temporary error. Please try again.";
+    return err.message || `Provider error (${err.status}).`;
+  }
+  if (err instanceof DeepseekAPIError) {
+    if (err.status === 401 || err.status === 403) return "Invalid API key.";
+    // DeepSeek runs on a prepaid balance and calls this one out by name in its
+    // docs. A good key simply stops working when the balance hits zero, so
+    // "Provider error (402)" would send someone hunting for a bad key.
+    if (err.status === 402) {
+      return "This DeepSeek key is out of balance. Top it up in the DeepSeek platform console.";
+    }
+    if (err.status === 429) {
+      const wait =
+        err.retryAfterSec !== undefined && err.retryAfterSec > 0
+          ? ` DeepSeek asked us to wait ${Math.ceil(err.retryAfterSec)}s.`
+          : "";
+      return (
+        `DeepSeek rejected the request: this key is over its rate limit.${wait} ` +
+        `Check your rate limits and balance in the DeepSeek platform console, or wait and run again.`
+      );
+    }
+    if (err.status >= 500) return "The AI provider had a temporary error. Please try again.";
+    if (err.status === 404) return "The requested model isn't available for this key.";
     return err.message || `Provider error (${err.status}).`;
   }
   if (err instanceof XaiAPIError) {

--- a/lib/llm/index.ts
+++ b/lib/llm/index.ts
@@ -1516,23 +1516,35 @@ interface XaiResponsesReply {
  * final answer, so it is the weaker signal of the two.
  *
  * A note on the TEXT this function's sources sit alongside, not on the sources
- * themselves: xAI writes its inline citations directly into the answer text as
- * markdown, `[[1]](url)` — double-bracketed, unlike the single-bracket
+ * themselves: xAI CAN write its inline citations directly into the answer text
+ * as markdown, `[[1]](url)` — double-bracketed, unlike the single-bracket
  * `[label](url)` most tools emit. `response_text` stores that markdown as-is
- * (no other adapter here needs to strip anything, since Anthropic/OpenAI/Google
- * keep citation metadata separate from the visible text). Two consequences,
- * checked live 2026-08-14 against a real captured answer rather than assumed:
+ * when present (no other adapter here needs to strip anything, since
+ * Anthropic/OpenAI/Google keep citation metadata separate from the visible
+ * text).
+ *
+ * "Can", not "always does" — checked live twice, 2026-08-14: a forced grok-4.6
+ * probe answer embedded the bracket markdown inline (captured JSON, see the
+ * commit that added this note), but a real dashboard run against grok-4.3 with
+ * the same forcing shape came back with 18 real sources and ZERO inline
+ * brackets in the visible text — citations arrived purely as separate
+ * annotation metadata that `xaiSources` above reads regardless. So the display
+ * concern below is a "sometimes", not an "every Grok answer" — worth knowing
+ * before assuming a fix is needed, not before knowing the format could appear.
+ *
+ * Two consequences on the occasions the brackets ARE present:
  *   - Mention detection is NOT at risk: `lib/mentions.ts`'s `stripLinkSurfaces`
  *     blanks any bare `https://...` run independently of bracket nesting, so a
  *     citation URL whose domain happens to match a tracked brand does not leak
  *     into the scanned text, even though its markdown-link regex (written for
- *     single brackets) doesn't recognise xAI's link as a link.
+ *     single brackets) doesn't recognise xAI's link as a link. Verified against
+ *     an actual captured citation string, not assumed.
  *   - Display is cosmetically affected: the dashboard renders `response_text`
  *     as plain text (no markdown renderer in this app), so a user reading a raw
- *     Grok answer sees the literal `[[1]](https://...)` characters rather than
- *     a clean sentence or a rendered link. Not a correctness bug, not fixed
- *     here — worth a follow-up if raw Grok answers turn out to read poorly in
- *     the UI once real users see them.
+ *     Grok answer that DID get inline brackets sees the literal
+ *     `[[1]](https://...)` characters rather than a clean sentence or a
+ *     rendered link. Not a correctness bug, not fixed here — worth a follow-up
+ *     only if this turns out to be common enough that real users notice it.
  */
 export function xaiSources(reply: XaiResponsesReply): CitedSource[] {
   const cited: CitedSource[] = [];

--- a/lib/llm/index.ts
+++ b/lib/llm/index.ts
@@ -1365,13 +1365,18 @@ const XAI_RETRYABLE = new Set([429, 500, 502, 503, 504]);
 // never block one prompt long enough to starve the rest of the run.
 const XAI_MAX_RETRY_WAIT_MS = 45_000;
 const XAI_RETRY_BUDGET_MS = 90_000;
-// Floor for the verifyKey ping. NOT yet measured against a live key — set to
-// Perplexity's known floor as the conservative guess, because the failure it
-// guards against is silent and one-directional: too small and a VALID key is
-// reported invalid (exactly what an 8-token ping copied from the Google adapter
-// did to Perplexity), while too large costs a few tokens once. Clamped inside
-// xaiGenerate so no caller can reintroduce a smaller one.
-// TODO(probe): confirm xAI's real floor and lower this if it allows less.
+// Floor for the verifyKey ping. Set to Perplexity's known floor as a
+// conservative guess, because the failure it guards against is silent and
+// one-directional: too small and a VALID key is reported invalid (exactly what
+// an 8-token ping copied from the Google adapter did to Perplexity), while too
+// large costs a few tokens once.
+//
+// Probed 2026-08-14 against grok-4.6 with a funded key: 16 is ACCEPTED (no
+// "must be at least N" rejection). Not re-tested below 16 — the guess already
+// works, and the failure mode this guards against only bites if the floor
+// creeps UP, not down, so there was nothing to gain from finding the exact
+// minimum. Clamped inside xaiGenerate so no caller can reintroduce a smaller
+// value without re-confirming it.
 const XAI_MIN_MAX_TOKENS = 16;
 
 export class XaiAPIError extends Error {
@@ -1509,6 +1514,25 @@ interface XaiResponsesReply {
  * inline — the same preference the Anthropic path applies to its retrieved-but-
  * not-cited results. xAI's own docs say not every URL in it is referenced in the
  * final answer, so it is the weaker signal of the two.
+ *
+ * A note on the TEXT this function's sources sit alongside, not on the sources
+ * themselves: xAI writes its inline citations directly into the answer text as
+ * markdown, `[[1]](url)` — double-bracketed, unlike the single-bracket
+ * `[label](url)` most tools emit. `response_text` stores that markdown as-is
+ * (no other adapter here needs to strip anything, since Anthropic/OpenAI/Google
+ * keep citation metadata separate from the visible text). Two consequences,
+ * checked live 2026-08-14 against a real captured answer rather than assumed:
+ *   - Mention detection is NOT at risk: `lib/mentions.ts`'s `stripLinkSurfaces`
+ *     blanks any bare `https://...` run independently of bracket nesting, so a
+ *     citation URL whose domain happens to match a tracked brand does not leak
+ *     into the scanned text, even though its markdown-link regex (written for
+ *     single brackets) doesn't recognise xAI's link as a link.
+ *   - Display is cosmetically affected: the dashboard renders `response_text`
+ *     as plain text (no markdown renderer in this app), so a user reading a raw
+ *     Grok answer sees the literal `[[1]](https://...)` characters rather than
+ *     a clean sentence or a rendered link. Not a correctness bug, not fixed
+ *     here — worth a follow-up if raw Grok answers turn out to read poorly in
+ *     the UI once real users see them.
  */
 export function xaiSources(reply: XaiResponsesReply): CitedSource[] {
   const cited: CitedSource[] = [];
@@ -1570,11 +1594,30 @@ function xaiText(reply: XaiResponsesReply): string {
 // Anthropic path already uses. That matters the moment a second tool is offered
 // here — with "required", Grok could satisfy the constraint by calling anything.
 //
-// STILL UNVERIFIED: whether the model then actually browses. A legal parameter
-// that the model ignores is the dangerous case — it looks forced and isn't.
-// Confirm with forced-vs-unforced source counts on a question answerable from
-// memory (probe-xai-forcing) once the key's team has credit, and record the
-// counts here. Until then Grok's grounding is expressible, not proven.
+// Whether the model then actually browses, rather than accepting a legal
+// parameter and ignoring it, needed a funded key — checked 2026-08-14 against
+// grok-4.6 on /v1/responses, forced vs merely offered, source counts compared:
+//
+//   Round 1 — "What is the capital of France?" (answerable from memory)
+//     offered, no tool_choice   5 inline sources
+//     forced (this shape)       5 inline sources
+//
+//   Round 2 — "a headline from the last 48 hours" (NOT answerable from memory,
+//   so a real dated/sourced answer is unambiguous proof a search happened)
+//     offered, no tool_choice   1 inline source, real Aug-14-2026 headline
+//     forced (this shape)       1 inline source, a DIFFERENT real headline
+//
+// Both rounds: identical behaviour forced vs offered. grok-4.6 appears to
+// browse readily whenever the tool is merely available, at least when the
+// prompt itself asks it to search. That is NOT the same finding Anthropic and
+// Gemini gave (there, offering alone measured 0/2) — it may mean this model
+// needs less pushing, or it may mean two data points can't tell the difference
+// between "forcing works" and "this model always searches when it can". This
+// codebase's own standard for ranking behaviour needs more than a couple of
+// prompts (see the Perplexity PR's Wilson-interval discussion), so the honest
+// state is: forcing is accepted, never behaves worse, and its marginal effect
+// over merely offering is UNPROVEN at this sample size. Kept forced anyway —
+// it costs nothing to ask and matches the other providers' shape.
 const XAI_FORCE_SEARCH = { type: "tool", name: "web_search" } as const;
 
 async function xaiRunQuery(

--- a/lib/llm/index.ts
+++ b/lib/llm/index.ts
@@ -1521,6 +1521,12 @@ async function xaiChat(
 interface XaiResponsesReply {
   output?: {
     type?: string;
+    // Present (value "commentary") on the throwaway "I'll look that up for
+    // you" message a search turn emits before its web_search_call items —
+    // same shape as Meta's MetaResponsesReply, and the same failure mode:
+    // concatenating it onto the real answer glues commentary text onto the
+    // front of what gets scanned for brand mentions.
+    phase?: string;
     content?: {
       type?: string;
       text?: string;
@@ -1598,11 +1604,18 @@ export function xaiSources(reply: XaiResponsesReply): CitedSource[] {
   return dedupeSources(fallback);
 }
 
-/** Answer text from a Responses reply, concatenated across output items. */
+/**
+ * Answer text from a Responses reply: final message items only, never
+ * reasoning, tool items, or search-turn commentary. This had no item-type
+ * filter at all until now, so any of those could get concatenated into the
+ * stored answer — the exact bug metaText was already fixed for below.
+ */
 function xaiText(reply: XaiResponsesReply): string {
   let text = "";
   for (const item of reply.output ?? []) {
+    if (item.type !== "message" || item.phase === "commentary") continue;
     for (const c of item.content ?? []) {
+      if (c.type !== undefined && c.type !== "output_text") continue;
       if (typeof c.text === "string") text += (text ? "\n" : "") + c.text;
     }
   }
@@ -1663,6 +1676,14 @@ function xaiText(reply: XaiResponsesReply): string {
 // it costs nothing to ask and matches the other providers' shape.
 const XAI_FORCE_SEARCH = { type: "tool", name: "web_search" } as const;
 
+// A grounded call's tool-calling turns count against the SAME output budget as
+// the answer — the identical bug fixed for Meta below (META_GROUNDED_MAX_TOKENS),
+// and Grok is a reasoning model on the same Responses surface, so tool turns
+// plus reasoning can exhaust 1200 tokens before any answer text is written.
+// Ungrounded calls never hit this path (no tools means no tool-calling turns),
+// so they keep the shared answer budget.
+const XAI_GROUNDED_MAX_TOKENS = 4000;
+
 async function xaiRunQuery(
   apiKey: string,
   model: string,
@@ -1672,7 +1693,9 @@ async function xaiRunQuery(
   const reply = await xaiFetch<XaiResponsesReply>("/responses", apiKey, {
     model,
     input: prompt,
-    max_output_tokens: Math.max(ANSWER_MAX_TOKENS, XAI_MIN_MAX_TOKENS),
+    max_output_tokens: webSearch
+      ? XAI_GROUNDED_MAX_TOKENS
+      : Math.max(ANSWER_MAX_TOKENS, XAI_MIN_MAX_TOKENS),
     ...(webSearch
       ? { tools: [{ type: "web_search" }], tool_choice: XAI_FORCE_SEARCH }
       : {}),
@@ -2001,6 +2024,8 @@ interface MetaResponsesReply {
     // both (the original bug here) stored the commentary sentence glued
     // onto the front of the real answer.
     phase?: string;
+    // On a web_search_call item: "completed" for a search that actually ran.
+    status?: string;
     content?: {
       type?: string;
       text?: string;
@@ -2046,6 +2071,13 @@ function metaText(reply: MetaResponsesReply): string {
     }
   }
   return text.trim();
+}
+
+/** Did a completed web_search_call actually run? */
+function metaSearched(reply: MetaResponsesReply): boolean {
+  return (reply.output ?? []).some(
+    (item) => item.type === "web_search_call" && (item.status === undefined || item.status === "completed"),
+  );
 }
 
 // Probed live 2026-08-15, three real calls against Muse Spark: no tools, tools
@@ -2095,6 +2127,17 @@ async function metaRunQuery(
         }
       : {}),
   });
+
+  // Offered-only search: Meta can only offer web_search, never force it (see
+  // META_FORCE_SEARCH above), so the model may answer from memory instead of
+  // browsing. That answer is not a grounded measurement and must not be stored
+  // as one -- the same line providerCanMeasure draws for DeepSeek, drawn per
+  // reply here since forcing can't draw it up front.
+  if (webSearch && !metaSearched(reply)) {
+    throw new Error(
+      "Meta answered without searching the web, so the answer can't be recorded as search-grounded.",
+    );
+  }
 
   const text = metaText(reply);
   const usage = reply.usage;

--- a/lib/llm/index.ts
+++ b/lib/llm/index.ts
@@ -289,6 +289,10 @@ const DIRECT_SHAPE: Record<Provider, CallShape> = {
   openai: "openai-chat",
   google: "google",
   perplexity: "perplexity",
+  // xAI's utility surface really is chat-completions: same JSON-object
+  // response_format, so it wants OpenAI's phrasing rather than a shape of its
+  // own. Only the ANSWER path differs (the Responses API, below).
+  xai: "openai-chat",
 };
 
 function callShape(opts: BaseCall, model: string): CallShape {
@@ -319,6 +323,13 @@ async function utilityChat(
       ? anthropicChat(opts.apiKey, model, system, user, maxTokens, plan)
       : openaiChat(opts.apiKey, model, system, user, maxTokens, json, plan);
   }
+  // Exhaustive on purpose — no `default`. The default this replaces sent every
+  // unlisted provider to openaiChat, i.e. to api.openai.com, so a provider added
+  // to the catalog without a branch here would have posted the user's key for a
+  // DIFFERENT vendor to OpenAI: a leaked credential and a wrong answer, with
+  // nothing failing to say so. Listing every case makes the compiler refuse to
+  // build until the next engine is handled. (Same bug the pilot harness's
+  // `keyFor` had, where google was handed the OpenAI key.)
   switch (opts.provider) {
     case "anthropic":
       return anthropicChat(opts.apiKey, model, system, user, maxTokens);
@@ -326,7 +337,9 @@ async function utilityChat(
       return googleChat(opts.apiKey, model, system, user, maxTokens, json);
     case "perplexity":
       return perplexityChat(opts.apiKey, model, system, user, maxTokens);
-    default:
+    case "xai":
+      return xaiChat(opts.apiKey, model, system, user, maxTokens, json);
+    case "openai":
       return openaiChat(opts.apiKey, model, system, user, maxTokens, json);
   }
 }
@@ -345,6 +358,11 @@ export async function verifyKey(
       await googleChat(apiKey, "gemini-flash-lite-latest", undefined, "ping", 8);
     } else if (provider === "perplexity") {
       await perplexityChat(apiKey, "sonar", undefined, "ping", 8);
+    } else if (provider === "xai") {
+      // The cheap model, and a budget xaiChat will clamp up to the floor rather
+      // than send as-is — see XAI_MIN_MAX_TOKENS for why a too-small ping is how
+      // a valid key gets reported invalid.
+      await xaiChat(apiKey, "grok-4.3", undefined, "ping", 8);
     } else {
       await openaiChat(apiKey, "gpt-4o-mini", undefined, "ping", 4);
     }
@@ -527,6 +545,11 @@ export async function runQuery(
   // Perplexity always searches, so it ignores the project toggle entirely.
   if (opts.provider === "perplexity") {
     return perplexityRunQuery(opts.apiKey, opts.model, opts.prompt);
+  }
+  // xAI answers on the Responses API whether or not it is browsing, so it takes
+  // its own branch rather than splitting across the shared web-search one below.
+  if (opts.provider === "xai") {
+    return xaiRunQuery(opts.apiKey, opts.model, opts.prompt, webSearch);
   }
   if (!webSearch) {
     const res =
@@ -1311,6 +1334,277 @@ async function perplexityRunQuery(
   return { text, tokens, sources: perplexitySources(data) };
 }
 
+// ==================================================================
+// xAI (Grok)
+//
+// Two surfaces under one host, because xAI splits them the way OpenAI does:
+//
+//   /v1/chat/completions  utility work — JSON classification, suggestion. Plain
+//                         OpenAI-compatible, response_format included, which is
+//                         why DIRECT_SHAPE calls this provider 'openai-chat'.
+//   /v1/responses         monitored answers. The server-side `web_search` tool
+//                         lives only here, and it returns citations in the same
+//                         `annotations[] {type:"url_citation"}` shape the direct
+//                         OpenAI path and gatewaySources already read.
+//
+// Raw fetch for both, like the Google and Perplexity adapters: the OpenAI SDK
+// would carry us for chat-completions but not for the Responses body below, and
+// one transport per provider beats two.
+//
+// The legacy `search_parameters` / Live Search API xAI shipped first is gone —
+// retired 2026-01-12, answering 410 — so anything written against it is dead.
+// Server-side search is the Agent Tools route only.
+// ==================================================================
+
+const XAI_API_BASE = "https://api.x.ai/v1";
+const XAI_TIMEOUT_MS = 60_000;
+const XAI_MAX_ATTEMPTS = 4;
+const XAI_RETRYABLE = new Set([429, 500, 502, 503, 504]);
+// Same bounds and same reasoning as the Google and Perplexity adapters: a rate
+// limit's window does not care about our backoff, so honour Retry-After, but
+// never block one prompt long enough to starve the rest of the run.
+const XAI_MAX_RETRY_WAIT_MS = 45_000;
+const XAI_RETRY_BUDGET_MS = 90_000;
+// Floor for the verifyKey ping. NOT yet measured against a live key — set to
+// Perplexity's known floor as the conservative guess, because the failure it
+// guards against is silent and one-directional: too small and a VALID key is
+// reported invalid (exactly what an 8-token ping copied from the Google adapter
+// did to Perplexity), while too large costs a few tokens once. Clamped inside
+// xaiGenerate so no caller can reintroduce a smaller one.
+// TODO(probe): confirm xAI's real floor and lower this if it allows less.
+const XAI_MIN_MAX_TOKENS = 16;
+
+export class XaiAPIError extends Error {
+  status: number;
+  /** From the Retry-After header on a 429, in seconds. */
+  retryAfterSec?: number;
+  constructor(status: number, message: string, retryAfterSec?: number) {
+    super(message);
+    this.name = "XaiAPIError";
+    this.status = status;
+    this.retryAfterSec = retryAfterSec;
+  }
+}
+
+/** Seconds from a Retry-After header, which may be a delta or an HTTP date. */
+function xaiRetryAfterSec(res: Response): number | undefined {
+  const raw = res.headers.get("retry-after");
+  if (!raw) return undefined;
+  const secs = Number(raw);
+  if (Number.isFinite(secs) && secs >= 0) return secs;
+  const when = Date.parse(raw);
+  if (!Number.isNaN(when)) return Math.max(0, (when - Date.now()) / 1000);
+  return undefined;
+}
+
+/** POST to one of xAI's two surfaces, with the shared retry policy. */
+async function xaiFetch<T>(path: "/chat/completions" | "/responses", apiKey: string, body: unknown): Promise<T> {
+  let lastErr: unknown;
+  let sleptMs = 0;
+  for (let attempt = 0; attempt < XAI_MAX_ATTEMPTS; attempt++) {
+    try {
+      const res = await fetch(`${XAI_API_BASE}${path}`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${apiKey}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(XAI_TIMEOUT_MS),
+      });
+      if (res.ok) return (await res.json()) as T;
+      const errBody = (await res.json().catch(() => ({}))) as {
+        error?: { message?: string } | string;
+        detail?: unknown;
+      };
+      const message =
+        (typeof errBody.error === "string" ? errBody.error : errBody.error?.message) ??
+        (typeof errBody.detail === "string" ? errBody.detail : undefined) ??
+        `xAI API error (${res.status}).`;
+      const xerr = new XaiAPIError(res.status, message, xaiRetryAfterSec(res));
+      if (!XAI_RETRYABLE.has(res.status)) throw xerr;
+      lastErr = xerr;
+    } catch (err) {
+      if (err instanceof XaiAPIError && !XAI_RETRYABLE.has(err.status)) throw err;
+      lastErr = err;
+    }
+    if (attempt >= XAI_MAX_ATTEMPTS - 1) break;
+
+    const advised = lastErr instanceof XaiAPIError ? lastErr.retryAfterSec : undefined;
+    const backoffMs = 400 * 2 ** attempt;
+    const waitMs = advised !== undefined ? Math.max(advised * 1000, backoffMs) : backoffMs;
+    if (waitMs > XAI_MAX_RETRY_WAIT_MS || sleptMs + waitMs > XAI_RETRY_BUDGET_MS) break;
+    await sleep(waitMs);
+    sleptMs += waitMs;
+  }
+  throw lastErr ?? new Error("xAI request failed.");
+}
+
+interface XaiChatResponse {
+  choices?: { message?: { content?: string | null }; finish_reason?: string }[];
+  usage?: { prompt_tokens?: number; completion_tokens?: number; total_tokens?: number };
+}
+
+/** Utility-call helper, matching anthropicChat / openaiChat / perplexityChat. */
+async function xaiChat(
+  apiKey: string,
+  model: string,
+  system: string | undefined,
+  user: string,
+  maxTokens: number,
+  json = false,
+): Promise<ChatResult> {
+  const messages: { role: string; content: string }[] = [];
+  if (system) messages.push({ role: "system", content: system });
+  messages.push({ role: "user", content: user });
+
+  const data = await xaiFetch<XaiChatResponse>("/chat/completions", apiKey, {
+    model,
+    messages,
+    max_tokens: Math.max(maxTokens, XAI_MIN_MAX_TOKENS),
+    ...(json ? { response_format: { type: "json_object" } } : {}),
+  });
+
+  const choice = data.choices?.[0];
+  const text = (choice?.message?.content ?? "").trim();
+  const usage = data.usage;
+  const tokens =
+    usage?.total_tokens ?? (usage?.prompt_tokens ?? 0) + (usage?.completion_tokens ?? 0);
+
+  // Same guards as everywhere else: a 200 carrying no usable answer is an error,
+  // not an empty measurement. See googleGenerate for why this matters.
+  if (!choice) throw new Error("xAI returned no answer (the response contained no choices).");
+  if (!text) {
+    throw new Error(
+      `xAI returned an empty answer (finish_reason: ${choice.finish_reason ?? "unspecified"}).`,
+    );
+  }
+  return { text, tokens };
+}
+
+interface XaiResponsesReply {
+  output?: {
+    type?: string;
+    content?: {
+      type?: string;
+      text?: string;
+      annotations?: { type?: string; url?: string; title?: string }[];
+    }[];
+  }[];
+  /** Every URL the agent touched, cited in the answer or not. */
+  citations?: string[];
+  usage?: { input_tokens?: number; output_tokens?: number; total_tokens?: number };
+}
+
+/**
+ * Sources from an xAI answer. Exported for tests.
+ *
+ * `annotations[].title` is NOT a page title — xAI puts the citation's LABEL
+ * there ("1", "2", …), so passing it through would store the string "1" as the
+ * title of every source and show that in the UI. Titles are dropped rather than
+ * faked; the URL is the part that carries meaning, and `domain` comes from
+ * parsing it.
+ *
+ * The top-level `citations` list is used only when the answer cited nothing
+ * inline — the same preference the Anthropic path applies to its retrieved-but-
+ * not-cited results. xAI's own docs say not every URL in it is referenced in the
+ * final answer, so it is the weaker signal of the two.
+ */
+export function xaiSources(reply: XaiResponsesReply): CitedSource[] {
+  const cited: CitedSource[] = [];
+  for (const item of reply.output ?? []) {
+    for (const c of item.content ?? []) {
+      for (const a of c.annotations ?? []) {
+        if (a.type && a.type !== "url_citation") continue;
+        const s = a.url ? safeSource(a.url, null, null) : null;
+        if (s) cited.push(s);
+      }
+    }
+  }
+  if (cited.length > 0) return dedupeSources(cited);
+
+  const fallback: CitedSource[] = [];
+  for (const url of reply.citations ?? []) {
+    const s = typeof url === "string" ? safeSource(url, null, null) : null;
+    if (s) fallback.push(s);
+  }
+  return dedupeSources(fallback);
+}
+
+/** Answer text from a Responses reply, concatenated across output items. */
+function xaiText(reply: XaiResponsesReply): string {
+  let text = "";
+  for (const item of reply.output ?? []) {
+    for (const c of item.content ?? []) {
+      if (typeof c.text === "string") text += (text ? "\n" : "") + c.text;
+    }
+  }
+  return text.trim();
+}
+
+// Ask for the browse rather than leaving it to the model, matching every other
+// grounded engine here (Anthropic's tool_choice, OpenAI's tool_choice, Gemini's
+// ALWAYS_SEARCH instruction). Left to choose, a model answers a question it
+// thinks it knows from memory and cites nothing, and its mention rate then
+// measures something different from the engines that were made to look.
+//
+// The SHAPE below is measured, not guessed. xAI documents the web_search tool
+// but not tool_choice for it, so the first draft of this used
+// `{type:"web_search"}` by analogy with OpenAI's Responses surface — which xAI
+// rejects outright with 422 "did not match any variant of untagged enum
+// ModelToolChoice". Every grounded run would have failed.
+//
+// Probed 2026-08-13 against grok-4.6 on /v1/responses. xAI validates the body
+// BEFORE it checks billing, so the status code separates a legal shape (403, on
+// a credit-less team) from an illegal one (422) without spending anything:
+//
+//   "required"                              403  legal
+//   {type:"tool", name:"web_search"}        403  legal   <- this one
+//   {function_name:"web_search"}            422  rejected
+//   {type:"web_search"}                     422  rejected
+//   {type:"function", function:{...}}       422  rejected
+//   search_parameters:{mode:"on"} (legacy)  410  "Live search is deprecated"
+//
+// Of the two legal forms, the named one is chosen deliberately: "required"
+// compels SOME tool, this compels THIS tool, and it is the exact shape the
+// Anthropic path already uses. That matters the moment a second tool is offered
+// here — with "required", Grok could satisfy the constraint by calling anything.
+//
+// STILL UNVERIFIED: whether the model then actually browses. A legal parameter
+// that the model ignores is the dangerous case — it looks forced and isn't.
+// Confirm with forced-vs-unforced source counts on a question answerable from
+// memory (probe-xai-forcing) once the key's team has credit, and record the
+// counts here. Until then Grok's grounding is expressible, not proven.
+const XAI_FORCE_SEARCH = { type: "tool", name: "web_search" } as const;
+
+async function xaiRunQuery(
+  apiKey: string,
+  model: string,
+  prompt: string,
+  webSearch: boolean,
+): Promise<QueryResult> {
+  const reply = await xaiFetch<XaiResponsesReply>("/responses", apiKey, {
+    model,
+    input: prompt,
+    max_output_tokens: Math.max(ANSWER_MAX_TOKENS, XAI_MIN_MAX_TOKENS),
+    ...(webSearch
+      ? { tools: [{ type: "web_search" }], tool_choice: XAI_FORCE_SEARCH }
+      : {}),
+  });
+
+  const text = xaiText(reply);
+  const usage = reply.usage;
+  const tokens =
+    usage?.total_tokens ?? (usage?.input_tokens ?? 0) + (usage?.output_tokens ?? 0);
+
+  if (!text) {
+    // A grounded ask that comes back empty is the dangerous case: stored, it
+    // scans for zero mentions and charts as "the brand wasn't named".
+    throw new Error("xAI returned an empty answer.");
+  }
+  return { text, tokens, sources: webSearch ? xaiSources(reply) : [] };
+}
+
 // Prompt shape is the single biggest lever on whether a run measures anything.
 // Measured against a stealth-stage brand (24 queries per shape, both providers):
 //
@@ -1717,6 +2011,28 @@ export function humanError(err: unknown): string {
       );
     }
     if (err.status >= 500) return "The AI provider had a temporary error. Please try again.";
+    return err.message || `Provider error (${err.status}).`;
+  }
+  if (err instanceof XaiAPIError) {
+    if (err.status === 401 || err.status === 403) return "Invalid API key.";
+    // xAI bills from a prepaid credit balance rather than an invoice, so a key
+    // that authenticates fine still stops working when the balance runs out.
+    // "Provider error (402)" would send someone looking for a bug in the key.
+    if (err.status === 402) return "This xAI key has no credit left. Top it up in the xAI console.";
+    if (err.status === 429) {
+      // Same reasoning as the Gemini and Perplexity 429s: "rate limited" reads
+      // as "we went too fast" and invites an immediate retry that cannot work.
+      const wait =
+        err.retryAfterSec !== undefined && err.retryAfterSec > 0
+          ? ` xAI asked us to wait ${Math.ceil(err.retryAfterSec)}s.`
+          : "";
+      return (
+        `xAI rejected the request: this key is over its rate limit.${wait} ` +
+        `Check the key's limits and credit balance in the xAI console, or wait and run again.`
+      );
+    }
+    if (err.status >= 500) return "The AI provider had a temporary error. Please try again.";
+    if (err.status === 404) return "The requested model isn't available for this key.";
     return err.message || `Provider error (${err.status}).`;
   }
   if (err instanceof Error) {

--- a/lib/llm/meta.test.ts
+++ b/lib/llm/meta.test.ts
@@ -22,11 +22,11 @@ import { PROVIDERS, PROVIDER_LIST, analysisModelFor, defaultModelFor } from "@/l
 //      the visible answer, the exact failure that turned an 8-token DeepSeek
 //      ping into an empty response. Pinning this here is what stops a future
 //      edit from removing the parameter and reintroducing that failure live.
-//   2. No tool_choice/forcing parameter is documented for web_search at all
-//      (unlike Grok, where xai-proto at least implied one existed before it
-//      was measured). Until the Tier-0 probe runs, the adapter must OFFER the
-//      tool and not claim to force it -- these tests pin that honest state,
-//      not a guess at what the probe will eventually find.
+//   2. Meta rejects tool_choice for web_search outright (HTTP 400, probed
+//      2026-08-15), so the adapter can only OFFER the tool -- it cannot force
+//      a browse the way the other engines do. A grounded reply that shows no
+//      completed web_search_call is therefore refused rather than stored as a
+//      grounded measurement; the tests below pin both halves of that.
 // ------------------------------------------------------------------
 
 const KEY = "LLM|test|key";
@@ -46,11 +46,14 @@ function respOk(
   extra: {
     annotations?: { type?: string; url?: string; title?: string }[];
     usage?: Record<string, number>;
+    /** Include a completed web_search_call item, as a live grounded reply carries. */
+    searched?: boolean;
   } = {},
 ) {
   return {
     id: "r",
     output: [
+      ...(extra.searched ? [{ type: "web_search_call", status: "completed" }] : []),
       {
         type: "message",
         content: [
@@ -129,7 +132,7 @@ describe("meta runQuery", () => {
   });
 
   it("offers web_search when the project asks for grounding", async () => {
-    mockFetch(jsonResponse(respOk("grounded")));
+    mockFetch(jsonResponse(respOk("grounded", { searched: true })));
     await runQuery(answer({ webSearch: true }));
     expect(sentBody().tools).toEqual([{ type: "web_search" }]);
   });
@@ -144,7 +147,7 @@ describe("meta runQuery", () => {
   // above. search_context_size:"low" did not reduce the page-open count
   // (tested, no effect); a bigger ceiling was the only lever that worked.
   it("gives a grounded call a bigger token ceiling than the shared answer budget", async () => {
-    mockFetch(jsonResponse(respOk("grounded")));
+    mockFetch(jsonResponse(respOk("grounded", { searched: true })));
     await runQuery(answer({ webSearch: true }));
     expect(sentBody().max_output_tokens).toBe(4000);
   });
@@ -155,14 +158,28 @@ describe("meta runQuery", () => {
     expect(sentBody().max_output_tokens).toBe(1200);
   });
 
-  // The honest pre-probe state: no documented forcing parameter exists, so
-  // none is sent. This must FAIL once a real forcing shape is wired in after
-  // the Tier-0 probe -- that failure is the reminder to update this test
-  // alongside the code, not a regression.
-  it("does not claim to force search — no forcing shape is confirmed yet", async () => {
-    mockFetch(jsonResponse(respOk("grounded")));
+  // Meta rejects every tool_choice shape for web_search (400, probed
+  // 2026-08-15), so nothing is sent; the tool is offered and the model decides.
+  it("sends no tool_choice — Meta rejects forcing", async () => {
+    mockFetch(jsonResponse(respOk("grounded", { searched: true })));
     await runQuery(answer({ webSearch: true }));
     expect(sentBody().tool_choice).toBeUndefined();
+  });
+
+  // Offered-only search means the model may answer from memory. That answer
+  // is not a grounded measurement and must not be stored as one -- the same
+  // line providerCanMeasure draws for DeepSeek, drawn per reply here since
+  // forcing can't draw it up front.
+  it("refuses a grounded answer in which the model never searched", async () => {
+    mockFetch(jsonResponse(respOk("Akamai is the biggest CDN.")));
+    await expect(runQuery(answer({ webSearch: true }))).rejects.toThrow(/without searching/i);
+  });
+
+  it("does not require a search when the project isn't grounded", async () => {
+    mockFetch(jsonResponse(respOk("Akamai is the biggest CDN.")));
+    await expect(runQuery(answer({ webSearch: false }))).resolves.toMatchObject({
+      text: "Akamai is the biggest CDN.",
+    });
   });
 
   // Live-measured 2026-08-15: a real 2-search grounded call returned output

--- a/lib/llm/meta.test.ts
+++ b/lib/llm/meta.test.ts
@@ -1,0 +1,609 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  runQuery,
+  verifyKey,
+  generateVariations,
+  analyzeResponse,
+  humanError,
+  metaSources,
+  MetaAPIError,
+} from "./index";
+import { PROVIDERS, PROVIDER_LIST, analysisModelFor, defaultModelFor } from "@/lib/models";
+
+// ------------------------------------------------------------------
+// Meta (Muse Spark, via the Meta Model API) adapter. Mocked fetch throughout.
+//
+// Not the retired Llama API -- a different, currently-active product Meta
+// launched after that one's 2026-07-06 sunset. Two things drive most of what's
+// asserted here:
+//   1. reasoning_effort is set on EVERY call, never left to Meta's own default
+//      ("still being finalized" per Meta's own docs). This is the DeepSeek
+//      lesson applied proactively: reasoning tokens share the same budget as
+//      the visible answer, the exact failure that turned an 8-token DeepSeek
+//      ping into an empty response. Pinning this here is what stops a future
+//      edit from removing the parameter and reintroducing that failure live.
+//   2. No tool_choice/forcing parameter is documented for web_search at all
+//      (unlike Grok, where xai-proto at least implied one existed before it
+//      was measured). Until the Tier-0 probe runs, the adapter must OFFER the
+//      tool and not claim to force it -- these tests pin that honest state,
+//      not a guess at what the probe will eventually find.
+// ------------------------------------------------------------------
+
+const KEY = "LLM|test|key";
+const CHAT_URL = "https://api.meta.ai/v1/chat/completions";
+const RESPONSES_URL = "https://api.meta.ai/v1/responses";
+
+function chatOk(content: string, usage?: Record<string, number>) {
+  return {
+    id: "x",
+    choices: [{ message: { role: "assistant", content }, finish_reason: "stop" }],
+    usage: usage ?? { total_tokens: 42 },
+  };
+}
+
+function respOk(
+  text: string,
+  extra: {
+    annotations?: { type?: string; url?: string; title?: string }[];
+    usage?: Record<string, number>;
+  } = {},
+) {
+  return {
+    id: "r",
+    output: [
+      {
+        type: "message",
+        content: [
+          {
+            type: "output_text",
+            text,
+            ...(extra.annotations ? { annotations: extra.annotations } : {}),
+          },
+        ],
+      },
+    ],
+    usage: extra.usage ?? { total_tokens: 99 },
+  };
+}
+
+function jsonResponse(body: unknown, status = 200, headers: Record<string, string> = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    headers: { get: (k: string) => headers[k.toLowerCase()] ?? null },
+  } as unknown as Response;
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+/** Queue of responses; the last one repeats once exhausted. */
+function mockFetch(...responses: Response[]) {
+  let i = 0;
+  fetchMock = vi.fn(async () => responses[Math.min(i++, responses.length - 1)]);
+  vi.stubGlobal("fetch", fetchMock);
+}
+
+function sentUrl(call = 0): string {
+  return fetchMock.mock.calls[call][0] as string;
+}
+function sentBody(call = 0): Record<string, any> {
+  return JSON.parse(fetchMock.mock.calls[call][1].body as string);
+}
+
+const answer = (over: Record<string, unknown> = {}) =>
+  ({ provider: "meta" as const, model: "muse-spark-1.2", apiKey: KEY, prompt: "q", ...over });
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+// --- the monitored answer path -------------------------------------------
+
+describe("meta runQuery", () => {
+  it("answers on the Responses API with a bearer key", async () => {
+    mockFetch(jsonResponse(respOk("hello")));
+    const res = await runQuery(answer());
+    expect(sentUrl()).toBe(RESPONSES_URL);
+    const headers = fetchMock.mock.calls[0][1].headers as Record<string, string>;
+    expect(headers.authorization).toBe(`Bearer ${KEY}`);
+    expect(res.text).toBe("hello");
+  });
+
+  it("sets reasoning.effort on every answer call, never leaves it unset", async () => {
+    // Meta's own docs say the default "is still being finalized" -- an
+    // admitted unknown. This is the exact class of bug already hit live in
+    // DeepSeek (default reasoning ate an 8-token budget); this test exists so
+    // removing the parameter here fails CI before it fails live a second time.
+    //
+    // Nested, not the flat `reasoning_effort` chat-completions uses -- the
+    // Responses API rejects the flat field outright with HTTP 400 (measured
+    // live 2026-08-15). Getting this shape wrong doesn't degrade an answer,
+    // it 400s every single monitored Meta run.
+    mockFetch(jsonResponse(respOk("hi")));
+    await runQuery(answer());
+    expect(sentBody().reasoning).toEqual({ effort: "low" });
+    expect(sentBody().reasoning_effort).toBeUndefined();
+  });
+
+  it("offers web_search when the project asks for grounding", async () => {
+    mockFetch(jsonResponse(respOk("grounded")));
+    await runQuery(answer({ webSearch: true }));
+    expect(sentBody().tools).toEqual([{ type: "web_search" }]);
+  });
+
+  // Live-measured 2026-08-15 via the pilot harness against a real open-ended
+  // question ("What is the best CDN for speeding up a global website?"):
+  // Muse Spark ran a search plus THREE full open_page fetches before writing
+  // any answer text, spending the entire 1200-token shared budget on tool
+  // orchestration and returning incomplete_details:{reason:"max_output_tokens"}
+  // with no message at all -- every such prompt refused rather than
+  // measuring anything, a much bigger version of the reasoning-token bug
+  // above. search_context_size:"low" did not reduce the page-open count
+  // (tested, no effect); a bigger ceiling was the only lever that worked.
+  it("gives a grounded call a bigger token ceiling than the shared answer budget", async () => {
+    mockFetch(jsonResponse(respOk("grounded")));
+    await runQuery(answer({ webSearch: true }));
+    expect(sentBody().max_output_tokens).toBe(4000);
+  });
+
+  it("keeps the shared answer budget for an ungrounded call", async () => {
+    mockFetch(jsonResponse(respOk("from memory")));
+    await runQuery(answer({ webSearch: false }));
+    expect(sentBody().max_output_tokens).toBe(1200);
+  });
+
+  // The honest pre-probe state: no documented forcing parameter exists, so
+  // none is sent. This must FAIL once a real forcing shape is wired in after
+  // the Tier-0 probe -- that failure is the reminder to update this test
+  // alongside the code, not a regression.
+  it("does not claim to force search — no forcing shape is confirmed yet", async () => {
+    mockFetch(jsonResponse(respOk("grounded")));
+    await runQuery(answer({ webSearch: true }));
+    expect(sentBody().tool_choice).toBeUndefined();
+  });
+
+  // Live-measured 2026-08-15: a real 2-search grounded call returned output
+  // = [reasoning, message(phase:"commentary", "I'll locate the top global
+  // CDN providers for you."), web_search_call, reasoning, web_search_call,
+  // reasoning, message(the real answer)]. The original metaText concatenated
+  // every message's text regardless of phase, so a stored answer read
+  // "I'll locate the top global CDN providers for you.\nTop 5 global CDN
+  // providers are Akamai, Cloudflare..." -- the commentary sentence would
+  // have skewed mention-detection's first-occurrence prominence and printed
+  // as part of the measured answer on every grounded run.
+  it("drops the search-turn commentary message, keeps only the real answer", async () => {
+    mockFetch(
+      jsonResponse({
+        output: [
+          { type: "reasoning" },
+          {
+            type: "message",
+            phase: "commentary",
+            content: [{ type: "output_text", text: "I'll locate the top global CDN providers for you." }],
+          },
+          { type: "web_search_call" },
+          { type: "reasoning" },
+          {
+            type: "message",
+            content: [{ type: "output_text", text: "Akamai, Cloudflare, AWS, Fastly, Google" }],
+          },
+        ],
+        usage: { total_tokens: 500 },
+      }),
+    );
+    const res = await runQuery(answer({ webSearch: true }));
+    expect(res.text).toBe("Akamai, Cloudflare, AWS, Fastly, Google");
+    expect(res.text).not.toContain("I'll locate");
+  });
+
+  it("asks for no tools at all when web search is off", async () => {
+    mockFetch(jsonResponse(respOk("from memory")));
+    const res = await runQuery(answer({ webSearch: false }));
+    expect(sentBody().tools).toBeUndefined();
+    expect(res.sources).toEqual([]);
+  });
+
+  it("does not attribute sources to an ungrounded answer", async () => {
+    mockFetch(
+      jsonResponse(
+        respOk("x", { annotations: [{ type: "url_citation", url: "https://example.com/a" }] }),
+      ),
+    );
+    const res = await runQuery(answer({ webSearch: false }));
+    expect(res.sources).toEqual([]);
+  });
+});
+
+// --- sources --------------------------------------------------------------
+
+describe("metaSources", () => {
+  // Unlike xAI, Meta's docs describe annotations[].title as a real page
+  // title, not a citation-number label -- so unlike xaiSources, the title is
+  // KEPT here rather than dropped. Confirm this holds against a live citation
+  // before trusting it fully; xAI's equivalent field looked just as ordinary
+  // in its own docs and turned out not to be.
+  it("keeps the title, unlike xAI's citation-label quirk", () => {
+    const got = metaSources({
+      output: [
+        {
+          content: [
+            {
+              annotations: [
+                { type: "url_citation", url: "https://fastly.com/cdn", title: "Fastly CDN" },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    expect(got).toEqual([
+      { url: "https://fastly.com/cdn", domain: "fastly.com", title: "Fastly CDN", snippet: null },
+    ]);
+  });
+
+  it("ignores annotation kinds that are not web sources", () => {
+    const got = metaSources({
+      output: [
+        {
+          content: [
+            {
+              annotations: [
+                { type: "file_citation", url: "https://not-a-web-source.com/x" },
+                { type: "url_citation", url: "https://real.com/y" },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    expect(got.map((s) => s.domain)).toEqual(["real.com"]);
+  });
+
+  it("drops unsafe URL schemes", () => {
+    const got = metaSources({
+      output: [
+        {
+          content: [
+            {
+              annotations: [
+                { type: "url_citation", url: "javascript:alert(1)" },
+                { type: "url_citation", url: "https://ok.com/a" },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    expect(got.map((s) => s.domain)).toEqual(["ok.com"]);
+  });
+
+  it("dedupes repeated URLs", () => {
+    const got = metaSources({
+      output: [
+        {
+          content: [
+            {
+              annotations: [
+                { type: "url_citation", url: "https://same.com/a" },
+                { type: "url_citation", url: "https://same.com/a" },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    expect(got).toHaveLength(1);
+  });
+
+  it("returns nothing rather than throwing on an empty reply", () => {
+    expect(metaSources({})).toEqual([]);
+  });
+});
+
+// --- token accounting -----------------------------------------------------
+
+describe("meta token accounting", () => {
+  it("uses total_tokens when present", async () => {
+    mockFetch(jsonResponse(respOk("hi", { usage: { total_tokens: 1234 } })));
+    expect((await runQuery(answer())).tokens).toBe(1234);
+  });
+
+  it("sums input and output when there is no total", async () => {
+    mockFetch(jsonResponse(respOk("hi", { usage: { input_tokens: 100, output_tokens: 25 } })));
+    expect((await runQuery(answer())).tokens).toBe(125);
+  });
+
+  it("reports zero rather than NaN when usage is absent", async () => {
+    mockFetch(jsonResponse({ output: [{ type: "message", content: [{ text: "hi" }] }] }));
+    expect((await runQuery(answer())).tokens).toBe(0);
+  });
+});
+
+// --- 200-but-unusable -------------------------------------------------------
+
+describe("meta unusable 200s", () => {
+  it("fails an answer with no text", async () => {
+    mockFetch(jsonResponse({ output: [], usage: { total_tokens: 3 } }));
+    await expect(runQuery(answer())).rejects.toThrow(/empty answer/i);
+  });
+
+  it("fails a utility call with no choices", async () => {
+    mockFetch(jsonResponse({ usage: { total_tokens: 3 } }));
+    await expect(
+      generateVariations({
+        provider: "meta",
+        model: "muse-spark-1.2",
+        apiKey: KEY,
+        topicName: "cdn",
+        count: 3,
+      }),
+    ).rejects.toThrow(/no choices/i);
+  });
+
+  it("fails a utility call whose content is empty", async () => {
+    mockFetch(jsonResponse(chatOk("")));
+    await expect(
+      generateVariations({
+        provider: "meta",
+        model: "muse-spark-1.2",
+        apiKey: KEY,
+        topicName: "cdn",
+        count: 3,
+      }),
+    ).rejects.toThrow(/empty answer/i);
+  });
+
+  it("does not retry an unusable 200 — the tokens are already spent", async () => {
+    mockFetch(jsonResponse({ output: [] }));
+    await expect(runQuery(answer())).rejects.toThrow();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+// --- utility calls ----------------------------------------------------------
+
+describe("meta utility calls", () => {
+  it("sends utility work to Meta's chat-completions host, never OpenAI's", async () => {
+    mockFetch(jsonResponse(chatOk('{"questions":["a","b"]}')));
+    await generateVariations({
+      provider: "meta",
+      model: "muse-spark-1.2",
+      apiKey: KEY,
+      topicName: "cdn",
+      count: 2,
+    });
+    expect(sentUrl()).toBe(CHAT_URL);
+    expect(sentUrl()).not.toContain("openai.com");
+  });
+
+  it("sets reasoning_effort:\"minimal\" on every utility call", async () => {
+    mockFetch(jsonResponse(chatOk('{"questions":["a"]}')));
+    await generateVariations({
+      provider: "meta",
+      model: "muse-spark-1.2",
+      apiKey: KEY,
+      topicName: "cdn",
+      count: 1,
+    });
+    expect(sentBody().reasoning_effort).toBe("minimal");
+  });
+
+  it("asks for a JSON object, the way the OpenAI-shaped surfaces do", async () => {
+    mockFetch(jsonResponse(chatOk('{"questions":["a"]}')));
+    await generateVariations({
+      provider: "meta",
+      model: "muse-spark-1.2",
+      apiKey: KEY,
+      topicName: "cdn",
+      count: 1,
+    });
+    expect(sentBody().response_format).toEqual({ type: "json_object" });
+  });
+
+  it("classifies on analysisModelFor's model", async () => {
+    mockFetch(
+      jsonResponse(chatOk('{"results":[{"key":"brand","sentiment":"positive","recommended":true}]}')),
+    );
+    await analyzeResponse({
+      provider: "meta",
+      model: "muse-spark-1.2",
+      apiKey: KEY,
+      question: "q",
+      responseText: "Acme is great",
+      entities: [{ key: "brand", name: "Acme" }],
+    });
+    expect(sentBody().model).toBe(analysisModelFor("meta"));
+  });
+
+  it("never asks a utility call to search", async () => {
+    mockFetch(jsonResponse(chatOk('{"questions":["a"]}')));
+    await generateVariations({
+      provider: "meta",
+      model: "muse-spark-1.2",
+      apiKey: KEY,
+      topicName: "cdn",
+      count: 1,
+    });
+    expect(sentBody().tools).toBeUndefined();
+    expect(sentUrl()).not.toContain("/responses");
+  });
+});
+
+// --- HTTP errors and retries ------------------------------------------------
+
+describe("meta HTTP errors", () => {
+  it("surfaces a bad key immediately, without retrying", async () => {
+    mockFetch(jsonResponse({ error: { message: "Unauthorized" } }, 401));
+    await expect(runQuery(answer())).rejects.toThrow();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry a 400", async () => {
+    mockFetch(jsonResponse({ error: { message: "bad model" } }, 400));
+    await expect(runQuery(answer())).rejects.toThrow();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a 503 and succeeds", async () => {
+    vi.useFakeTimers();
+    mockFetch(jsonResponse({ error: { message: "upstream" } }, 503), jsonResponse(respOk("ok")));
+    const p = runQuery(answer());
+    await vi.runAllTimersAsync();
+    await expect(p).resolves.toMatchObject({ text: "ok" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries a dropped connection", async () => {
+    vi.useFakeTimers();
+    let calls = 0;
+    fetchMock = vi.fn(async () => {
+      if (++calls === 1) throw new TypeError("fetch failed");
+      return jsonResponse(respOk("ok"));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const p = runQuery(answer());
+    await vi.runAllTimersAsync();
+    await expect(p).resolves.toMatchObject({ text: "ok" });
+    expect(calls).toBe(2);
+  });
+
+  it("waits as long as Retry-After asks, not the exponential backoff", async () => {
+    vi.useFakeTimers();
+    mockFetch(
+      jsonResponse({ error: { message: "slow down" } }, 429, { "retry-after": "12" }),
+      jsonResponse(respOk("ok")),
+    );
+    const p = runQuery(answer());
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(11_000);
+    await expect(p).resolves.toMatchObject({ text: "ok" });
+  });
+
+  it("accepts an HTTP-date Retry-After", async () => {
+    vi.useFakeTimers();
+    const when = new Date(Date.now() + 10_000).toUTCString();
+    mockFetch(
+      jsonResponse({ error: { message: "wait" } }, 429, { "retry-after": when }),
+      jsonResponse(respOk("ok")),
+    );
+    const p = runQuery(answer());
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(9_000);
+    await expect(p).resolves.toMatchObject({ text: "ok" });
+  });
+
+  it("gives up rather than sleeping past the single-wait ceiling", async () => {
+    vi.useFakeTimers();
+    mockFetch(jsonResponse({ error: { message: "daily cap" } }, 429, { "retry-after": "3600" }));
+    const p = runQuery(answer());
+    const rejected = expect(p).rejects.toThrow(/daily cap/);
+    await vi.runAllTimersAsync();
+    await rejected;
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops retrying once the per-call sleep budget is spent", async () => {
+    vi.useFakeTimers();
+    mockFetch(jsonResponse({ error: { message: "busy" } }, 429, { "retry-after": "40" }));
+    const p = runQuery(answer());
+    const rejected = expect(p).rejects.toThrow(/busy/);
+    await vi.runAllTimersAsync();
+    await rejected;
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("reads the error message Meta sent", async () => {
+    mockFetch(jsonResponse({ error: { message: "model muse-spark-9 does not exist" } }, 404));
+    await expect(runQuery(answer())).rejects.toThrow(/muse-spark-9/);
+  });
+});
+
+// --- verifyKey ---------------------------------------------------------------
+
+describe("meta verifyKey", () => {
+  it("accepts a working key", async () => {
+    mockFetch(jsonResponse(chatOk("pong")));
+    await expect(verifyKey("meta", KEY)).resolves.toEqual({ ok: true });
+  });
+
+  it("probes with reasoning_effort minimal — the same guard that protects every utility call", async () => {
+    mockFetch(jsonResponse(chatOk("pong")));
+    await verifyKey("meta", KEY);
+    expect(sentBody().reasoning_effort).toBe("minimal");
+  });
+
+  it("reports a bad key as invalid rather than as an outage", async () => {
+    mockFetch(jsonResponse({ error: { message: "Unauthorized" } }, 401));
+    await expect(verifyKey("meta", KEY)).resolves.toMatchObject({
+      ok: false,
+      error: "Invalid API key.",
+    });
+  });
+});
+
+// --- humanError ---------------------------------------------------------------
+
+describe("meta humanError", () => {
+  it("maps auth failures", () => {
+    expect(humanError(new MetaAPIError(401, "nope"))).toBe("Invalid API key.");
+    expect(humanError(new MetaAPIError(403, "nope"))).toBe("Invalid API key.");
+  });
+
+  it("explains a 429 instead of saying 'rate limited'", () => {
+    const msg = humanError(new MetaAPIError(429, "slow down", 30));
+    expect(msg).toMatch(/rate limit/i);
+    expect(msg).toContain("30s");
+  });
+
+  it("maps server errors to a retryable message", () => {
+    expect(humanError(new MetaAPIError(503, "boom"))).toMatch(/temporary/i);
+  });
+
+  it("maps an unknown model to something actionable", () => {
+    expect(humanError(new MetaAPIError(404, "no such model"))).toMatch(/isn't available/i);
+  });
+});
+
+// --- catalog guards -----------------------------------------------------------
+
+describe("meta catalog", () => {
+  it("offers Meta under the vendor id, labelled by product", () => {
+    expect(PROVIDERS.meta.label).toContain("Meta");
+    expect(PROVIDERS.meta.keyPrefix).toBe("LLM|");
+  });
+
+  it("defaults to the current flagship", () => {
+    expect(defaultModelFor("meta")).toBe("muse-spark-1.2");
+  });
+
+  // The one deliberate exception in the catalog: Meta ships no separate cheap
+  // tier, so analysisModelFor returns the SAME id as the default. Every other
+  // provider's classification model differs from its default; this asserts
+  // the exception is intentional, not a gap that crept in unnoticed.
+  it("uses the same model for classification, unlike every other provider — documented exception", () => {
+    expect(analysisModelFor("meta")).toBe(defaultModelFor("meta"));
+    for (const info of PROVIDER_LIST) {
+      if (info.id === "meta") continue;
+      expect(analysisModelFor(info.id)).not.toBe(defaultModelFor(info.id));
+    }
+  });
+
+  it("honours the analysis-model env override", () => {
+    vi.stubEnv("ANALYSIS_META_MODEL", " muse-spark-1.1 ");
+    expect(analysisModelFor("meta")).toBe("muse-spark-1.1"); // trimmed
+  });
+
+  // Neither is offered: 1.1 is the prior generation at identical pricing (no
+  // reason to default anyone onto it), and -contributor opts your traffic
+  // into improving Meta's own products, which nobody asked for.
+  it("keeps the prior generation and the contributor variant out of the catalog", () => {
+    const ids = PROVIDERS.meta.models.map((m) => m.id);
+    expect(ids).not.toContain("muse-spark-1.1");
+    expect(ids.some((id) => id.includes("contributor"))).toBe(false);
+  });
+});

--- a/lib/llm/xai.test.ts
+++ b/lib/llm/xai.test.ts
@@ -175,6 +175,44 @@ describe("xai runQuery", () => {
     const res = await runQuery(answer());
     expect(res.text).toBe("one\ntwo");
   });
+
+  // Same guard the Meta path needed after a live commentary message was glued
+  // onto a real answer: only final message text is the answer. xaiText had no
+  // item-type filter at all until now, so any of these could have leaked in.
+  it("keeps only message text — never reasoning, tool items, or search-turn commentary", async () => {
+    mockFetch(
+      jsonResponse({
+        output: [
+          { type: "reasoning", content: [{ type: "reasoning_text", text: "thinking aloud" }] },
+          {
+            type: "message",
+            phase: "commentary",
+            content: [{ type: "output_text", text: "Let me look that up." }],
+          },
+          { type: "web_search_call", content: [{ type: "output_text", text: "query: cdn" }] },
+          { type: "message", content: [{ type: "output_text", text: "Akamai and Fastly." }] },
+        ],
+        usage: { total_tokens: 5 },
+      }),
+    );
+    const res = await runQuery(answer({ webSearch: true }));
+    expect(res.text).toBe("Akamai and Fastly.");
+  });
+
+  // Tool turns spend the same output budget as the answer; 1200 was exhausted
+  // before any answer text on the Meta path (measured), and Grok is a
+  // reasoning model on the same Responses surface.
+  it("gives a grounded call a bigger token ceiling than the shared answer budget", async () => {
+    mockFetch(jsonResponse(respOk("grounded")));
+    await runQuery(answer({ webSearch: true }));
+    expect(sentBody().max_output_tokens).toBe(4000);
+  });
+
+  it("keeps the shared answer budget for an ungrounded call", async () => {
+    mockFetch(jsonResponse(respOk("from memory")));
+    await runQuery(answer({ webSearch: false }));
+    expect(sentBody().max_output_tokens).toBe(1200);
+  });
 });
 
 // --- sources --------------------------------------------------------------
@@ -297,7 +335,7 @@ describe("xai token accounting", () => {
   });
 
   it("reports zero rather than NaN when usage is absent", async () => {
-    mockFetch(jsonResponse({ output: [{ content: [{ text: "hi" }] }] }));
+    mockFetch(jsonResponse({ output: [{ type: "message", content: [{ text: "hi" }] }] }));
     expect((await runQuery(answer())).tokens).toBe(0);
   });
 });

--- a/lib/llm/xai.test.ts
+++ b/lib/llm/xai.test.ts
@@ -1,0 +1,601 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  runQuery,
+  verifyKey,
+  generateVariations,
+  analyzeResponse,
+  humanError,
+  xaiSources,
+  XaiAPIError,
+} from "./index";
+import { PROVIDERS, analysisModelFor } from "@/lib/models";
+
+// ------------------------------------------------------------------
+// xAI (Grok) adapter. Mocked fetch throughout — the subject is the request we
+// build and the responses we survive, not xAI's behaviour.
+//
+// Three things drive most of what's asserted here:
+//   1. Two surfaces under one host. Utility work goes to /chat/completions,
+//      monitored answers to /responses, and sending either to the other's
+//      endpoint would fail in a way no type catches.
+//   2. `annotations[].title` is the citation LABEL ("1", "2"), not a page
+//      title. Passed through, every source would be titled "1".
+//   3. The utility dispatch used to have a `default:` branch that sent anything
+//      unrecognised to api.openai.com — so an xAI key would have been posted to
+//      OpenAI. There is a test below that pins the host for exactly that reason.
+// ------------------------------------------------------------------
+
+const KEY = "xai-test-key";
+const CHAT_URL = "https://api.x.ai/v1/chat/completions";
+const RESPONSES_URL = "https://api.x.ai/v1/responses";
+
+/** A /chat/completions 200. */
+function chatOk(content: string, usage?: Record<string, number>) {
+  return {
+    id: "x",
+    choices: [{ message: { role: "assistant", content }, finish_reason: "stop" }],
+    usage: usage ?? { total_tokens: 42 },
+  };
+}
+
+/** A /responses 200. */
+function respOk(
+  text: string,
+  extra: {
+    annotations?: { type?: string; url?: string; title?: string }[];
+    citations?: string[];
+    usage?: Record<string, number>;
+  } = {},
+) {
+  return {
+    id: "r",
+    output: [
+      {
+        type: "message",
+        content: [
+          {
+            type: "output_text",
+            text,
+            ...(extra.annotations ? { annotations: extra.annotations } : {}),
+          },
+        ],
+      },
+    ],
+    ...(extra.citations ? { citations: extra.citations } : {}),
+    usage: extra.usage ?? { total_tokens: 99 },
+  };
+}
+
+function jsonResponse(body: unknown, status = 200, headers: Record<string, string> = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    headers: { get: (k: string) => headers[k.toLowerCase()] ?? null },
+  } as unknown as Response;
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+/** Queue of responses; the last one repeats once exhausted. */
+function mockFetch(...responses: Response[]) {
+  let i = 0;
+  fetchMock = vi.fn(async () => responses[Math.min(i++, responses.length - 1)]);
+  vi.stubGlobal("fetch", fetchMock);
+}
+
+function sentUrl(call = 0): string {
+  return fetchMock.mock.calls[call][0] as string;
+}
+function sentBody(call = 0): Record<string, any> {
+  return JSON.parse(fetchMock.mock.calls[call][1].body as string);
+}
+function sentHeaders(call = 0): Record<string, string> {
+  return fetchMock.mock.calls[call][1].headers as Record<string, string>;
+}
+
+const answer = (over: Record<string, unknown> = {}) =>
+  ({ provider: "xai" as const, model: "grok-4.6", apiKey: KEY, prompt: "q", ...over });
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+// --- the monitored answer path -------------------------------------------
+
+describe("xai runQuery", () => {
+  it("answers on the Responses API with a bearer key", async () => {
+    mockFetch(jsonResponse(respOk("hello")));
+    const res = await runQuery(answer());
+    expect(sentUrl()).toBe(RESPONSES_URL);
+    expect(sentHeaders().authorization).toBe(`Bearer ${KEY}`);
+    expect(res.text).toBe("hello");
+  });
+
+  it("forces the browse when the project asks for web search", async () => {
+    mockFetch(jsonResponse(respOk("grounded")));
+    await runQuery(answer({ webSearch: true }));
+    const body = sentBody();
+    expect(body.tools).toEqual([{ type: "web_search" }]);
+    // Offered is not forced — the whole reason the other engines carry a
+    // tool_choice. Left to choose, a model answers from memory and cites
+    // nothing, and its mention rate stops being comparable with theirs.
+    //
+    // The exact shape is load-bearing and was measured, not assumed: xAI
+    // answers 422 "did not match any variant of untagged enum ModelToolChoice"
+    // to {type:"web_search"}, {function_name:...} and the OpenAI function form.
+    // Only "required" and the named-tool form below are accepted. See the
+    // comment on XAI_FORCE_SEARCH for the probe that established that.
+    expect(body.tool_choice).toEqual({ type: "tool", name: "web_search" });
+  });
+
+  // A regression guard with a specific failure in mind: reverting to any of the
+  // three shapes xAI rejects would 422 every grounded run, and a mocked suite
+  // would not notice because the mock answers 200 regardless.
+  it("never sends a tool_choice shape xAI rejects", async () => {
+    mockFetch(jsonResponse(respOk("grounded")));
+    await runQuery(answer({ webSearch: true }));
+    const tc = sentBody().tool_choice;
+    expect(tc).not.toEqual({ type: "web_search" });
+    expect(tc).not.toHaveProperty("function_name");
+    expect(tc).not.toHaveProperty("function");
+  });
+
+  it("asks for no tools at all when web search is off", async () => {
+    mockFetch(jsonResponse(respOk("from memory")));
+    const res = await runQuery(answer({ webSearch: false }));
+    expect(sentBody().tools).toBeUndefined();
+    expect(sentBody().tool_choice).toBeUndefined();
+    // and reports no sources even if the reply somehow carried some
+    expect(res.sources).toEqual([]);
+  });
+
+  it("does not attribute sources to an ungrounded answer", async () => {
+    // A reply carrying citations on a run that never asked to browse must not
+    // have them recorded: they would read as evidence the answer was grounded.
+    mockFetch(
+      jsonResponse(respOk("x", { citations: ["https://example.com/a"] })),
+    );
+    const res = await runQuery(answer({ webSearch: false }));
+    expect(res.sources).toEqual([]);
+  });
+
+  it("concatenates text across output items", async () => {
+    mockFetch(
+      jsonResponse({
+        output: [
+          { type: "message", content: [{ type: "output_text", text: "one" }] },
+          { type: "message", content: [{ type: "output_text", text: "two" }] },
+        ],
+        usage: { total_tokens: 5 },
+      }),
+    );
+    const res = await runQuery(answer());
+    expect(res.text).toBe("one\ntwo");
+  });
+});
+
+// --- sources --------------------------------------------------------------
+
+describe("xaiSources", () => {
+  // xAI puts the citation's LABEL in `title` — "1", "2" — not the page title.
+  // Storing that would show every source titled "1" in the UI, so titles are
+  // dropped rather than faked. The URL is what carries meaning.
+  it("never stores the citation label as a title", () => {
+    const got = xaiSources({
+      output: [
+        {
+          content: [
+            {
+              annotations: [
+                { type: "url_citation", url: "https://fastly.com/cdn", title: "1" },
+                { type: "url_citation", url: "https://akamai.com/x", title: "2" },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    expect(got.map((s) => s.title)).toEqual([null, null]);
+    expect(got.map((s) => s.domain)).toEqual(["fastly.com", "akamai.com"]);
+  });
+
+  it("prefers inline citations over the all-sources list", () => {
+    // xAI's own docs say not every URL in `citations` is referenced in the
+    // answer, so it is the weaker signal and only a fallback.
+    const got = xaiSources({
+      output: [
+        { content: [{ annotations: [{ type: "url_citation", url: "https://cited.com/a" }] }] },
+      ],
+      citations: ["https://touched-but-not-cited.com/b"],
+    });
+    expect(got.map((s) => s.domain)).toEqual(["cited.com"]);
+  });
+
+  it("falls back to the all-sources list when nothing was cited inline", () => {
+    const got = xaiSources({
+      output: [{ content: [{ type: "output_text", text: "no annotations here" }] }],
+      citations: ["https://only.com/a", "https://only.com/b"],
+    });
+    expect(got).toHaveLength(2);
+  });
+
+  it("ignores annotation kinds that are not web sources", () => {
+    const got = xaiSources({
+      output: [
+        {
+          content: [
+            {
+              annotations: [
+                { type: "file_citation", url: "https://not-a-web-source.com/x" },
+                { type: "url_citation", url: "https://real.com/y" },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    expect(got.map((s) => s.domain)).toEqual(["real.com"]);
+  });
+
+  it("drops unsafe URL schemes", () => {
+    const got = xaiSources({
+      output: [
+        {
+          content: [
+            {
+              annotations: [
+                { type: "url_citation", url: "javascript:alert(1)" },
+                { type: "url_citation", url: "https://ok.com/a" },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    expect(got.map((s) => s.domain)).toEqual(["ok.com"]);
+  });
+
+  it("dedupes repeated URLs", () => {
+    const got = xaiSources({
+      output: [
+        {
+          content: [
+            {
+              annotations: [
+                { type: "url_citation", url: "https://same.com/a" },
+                { type: "url_citation", url: "https://same.com/a" },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    expect(got).toHaveLength(1);
+  });
+
+  it("returns nothing rather than throwing on an empty reply", () => {
+    expect(xaiSources({})).toEqual([]);
+  });
+});
+
+// --- token accounting -----------------------------------------------------
+
+describe("xai token accounting", () => {
+  it("uses total_tokens when present", async () => {
+    mockFetch(jsonResponse(respOk("hi", { usage: { total_tokens: 1234 } })));
+    expect((await runQuery(answer())).tokens).toBe(1234);
+  });
+
+  it("sums input and output when there is no total", async () => {
+    mockFetch(
+      jsonResponse(respOk("hi", { usage: { input_tokens: 100, output_tokens: 25 } })),
+    );
+    expect((await runQuery(answer())).tokens).toBe(125);
+  });
+
+  it("reports zero rather than NaN when usage is absent", async () => {
+    mockFetch(jsonResponse({ output: [{ content: [{ text: "hi" }] }] }));
+    expect((await runQuery(answer())).tokens).toBe(0);
+  });
+});
+
+// --- 200-but-unusable -----------------------------------------------------
+//
+// The dangerous class: the call succeeds, the stored answer is empty, and the
+// run reports "brand not mentioned" for a question that was never answered.
+
+describe("xai unusable 200s", () => {
+  it("fails an answer with no text", async () => {
+    mockFetch(jsonResponse({ output: [], usage: { total_tokens: 3 } }));
+    await expect(runQuery(answer())).rejects.toThrow(/empty answer/i);
+  });
+
+  it("fails a utility call with no choices", async () => {
+    mockFetch(jsonResponse({ usage: { total_tokens: 3 } }));
+    await expect(
+      generateVariations({
+        provider: "xai",
+        model: "grok-4.6",
+        apiKey: KEY,
+        topicName: "cdn",
+        count: 3,
+      }),
+    ).rejects.toThrow(/no choices/i);
+  });
+
+  it("fails a utility call whose content is empty", async () => {
+    mockFetch(jsonResponse(chatOk("")));
+    await expect(
+      generateVariations({
+        provider: "xai",
+        model: "grok-4.6",
+        apiKey: KEY,
+        topicName: "cdn",
+        count: 3,
+      }),
+    ).rejects.toThrow(/empty answer/i);
+  });
+
+  it("does not retry an unusable 200 — the tokens are already spent", async () => {
+    mockFetch(jsonResponse({ output: [] }));
+    await expect(runQuery(answer())).rejects.toThrow();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+// --- utility calls --------------------------------------------------------
+
+describe("xai utility calls", () => {
+  // The regression this pins: utilityChat's dispatch had a `default:` branch
+  // that sent every unlisted provider to openaiChat — so an xAI key would have
+  // been posted to api.openai.com. A leaked credential and a wrong answer, with
+  // nothing failing to say so.
+  it("sends utility work to xAI, never to OpenAI", async () => {
+    mockFetch(jsonResponse(chatOk('{"questions":["a","b"]}')));
+    await generateVariations({
+      provider: "xai",
+      model: "grok-4.6",
+      apiKey: KEY,
+      topicName: "cdn",
+      count: 2,
+    });
+    expect(sentUrl()).toBe(CHAT_URL);
+    expect(sentUrl()).not.toContain("openai.com");
+  });
+
+  it("asks for a JSON object, the way the OpenAI-shaped surfaces do", async () => {
+    mockFetch(jsonResponse(chatOk('{"questions":["a"]}')));
+    await generateVariations({
+      provider: "xai",
+      model: "grok-4.6",
+      apiKey: KEY,
+      topicName: "cdn",
+      count: 1,
+    });
+    expect(sentBody().response_format).toEqual({ type: "json_object" });
+    expect(sentBody().messages[0].role).toBe("system");
+  });
+
+  it("classifies on the cheap model, not the answer model", async () => {
+    mockFetch(
+      jsonResponse(chatOk('{"results":[{"key":"brand","sentiment":"positive","recommended":true}]}')),
+    );
+    await analyzeResponse({
+      provider: "xai",
+      model: "grok-4.6",
+      apiKey: KEY,
+      question: "q",
+      responseText: "Acme is great",
+      entities: [{ key: "brand", name: "Acme" }],
+    });
+    expect(sentBody().model).toBe(analysisModelFor("xai"));
+    expect(sentBody().model).not.toBe("grok-4.6");
+  });
+
+  it("never asks a utility call to search", async () => {
+    // Utility calls reason over text WE supply. Searching there is pure cost,
+    // and a search result could contaminate a judgment about that text.
+    mockFetch(jsonResponse(chatOk('{"questions":["a"]}')));
+    await generateVariations({
+      provider: "xai",
+      model: "grok-4.6",
+      apiKey: KEY,
+      topicName: "cdn",
+      count: 1,
+    });
+    expect(sentBody().tools).toBeUndefined();
+    expect(sentUrl()).not.toContain("/responses");
+  });
+});
+
+// --- HTTP errors and retries ---------------------------------------------
+
+describe("xai HTTP errors", () => {
+  it("surfaces a bad key immediately, without retrying", async () => {
+    mockFetch(jsonResponse({ error: { message: "Unauthorized" } }, 401));
+    await expect(runQuery(answer())).rejects.toThrow();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry a 400", async () => {
+    mockFetch(jsonResponse({ error: { message: "bad model" } }, 400));
+    await expect(runQuery(answer())).rejects.toThrow();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a 503 and succeeds", async () => {
+    vi.useFakeTimers();
+    mockFetch(jsonResponse({ error: { message: "upstream" } }, 503), jsonResponse(respOk("ok")));
+    const p = runQuery(answer());
+    await vi.runAllTimersAsync();
+    await expect(p).resolves.toMatchObject({ text: "ok" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries a dropped connection", async () => {
+    vi.useFakeTimers();
+    let calls = 0;
+    fetchMock = vi.fn(async () => {
+      if (++calls === 1) throw new TypeError("fetch failed");
+      return jsonResponse(respOk("ok"));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const p = runQuery(answer());
+    await vi.runAllTimersAsync();
+    await expect(p).resolves.toMatchObject({ text: "ok" });
+    expect(calls).toBe(2);
+  });
+
+  // A rate limit's window does not care about our exponential backoff.
+  // Retrying inside it burns every attempt in a couple of seconds and then
+  // reports "rate limited" as if nothing could be done.
+  it("waits as long as Retry-After asks, not the exponential backoff", async () => {
+    vi.useFakeTimers();
+    mockFetch(
+      jsonResponse({ error: { message: "slow down" } }, 429, { "retry-after": "12" }),
+      jsonResponse(respOk("ok")),
+    );
+    const p = runQuery(answer());
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(fetchMock).toHaveBeenCalledTimes(1); // still waiting, not backed off
+    await vi.advanceTimersByTimeAsync(11_000);
+    await expect(p).resolves.toMatchObject({ text: "ok" });
+  });
+
+  it("accepts an HTTP-date Retry-After", async () => {
+    vi.useFakeTimers();
+    const when = new Date(Date.now() + 10_000).toUTCString();
+    mockFetch(
+      jsonResponse({ error: { message: "wait" } }, 429, { "retry-after": when }),
+      jsonResponse(respOk("ok")),
+    );
+    const p = runQuery(answer());
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(9_000);
+    await expect(p).resolves.toMatchObject({ text: "ok" });
+  });
+
+  it("gives up rather than sleeping past the single-wait ceiling", async () => {
+    // A wait this long means the quota window has hours left; blocking the
+    // request for it is worse than failing with a message that says so.
+    vi.useFakeTimers();
+    mockFetch(jsonResponse({ error: { message: "daily cap" } }, 429, { "retry-after": "3600" }));
+    const p = runQuery(answer());
+    const rejected = expect(p).rejects.toThrow(/daily cap/);
+    await vi.runAllTimersAsync();
+    await rejected;
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops retrying once the per-call sleep budget is spent", async () => {
+    vi.useFakeTimers();
+    mockFetch(jsonResponse({ error: { message: "busy" } }, 429, { "retry-after": "40" }));
+    const p = runQuery(answer());
+    const rejected = expect(p).rejects.toThrow(/busy/);
+    await vi.runAllTimersAsync();
+    await rejected;
+    // 40s + 40s fits the 90s budget; a third would exceed it.
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("reads the error message xAI sent", async () => {
+    mockFetch(jsonResponse({ error: { message: "model grok-9 does not exist" } }, 404));
+    await expect(runQuery(answer())).rejects.toThrow(/grok-9/);
+  });
+});
+
+// --- verifyKey ------------------------------------------------------------
+
+describe("xai verifyKey", () => {
+  it("accepts a working key", async () => {
+    mockFetch(jsonResponse(chatOk("pong")));
+    await expect(verifyKey("xai", KEY)).resolves.toEqual({ ok: true });
+  });
+
+  it("probes on the cheap model, not the flagship", async () => {
+    mockFetch(jsonResponse(chatOk("pong")));
+    await verifyKey("xai", KEY);
+    expect(sentBody().model).toBe("grok-4.3");
+  });
+
+  // The bug this pins, from the Perplexity adapter: an 8-token probe budget
+  // copied from another provider hit a vendor floor of 16, so a VALID key was
+  // reported invalid. Every real call worked — only verification failed.
+  // Clamped inside the adapter so no caller can reintroduce a smaller one.
+  it("never sends a probe budget below the vendor floor", async () => {
+    mockFetch(jsonResponse(chatOk("pong")));
+    await verifyKey("xai", KEY);
+    expect(sentBody().max_tokens).toBeGreaterThanOrEqual(16);
+  });
+
+  it("reports a bad key as invalid rather than as an outage", async () => {
+    mockFetch(jsonResponse({ error: { message: "Unauthorized" } }, 401));
+    await expect(verifyKey("xai", KEY)).resolves.toMatchObject({
+      ok: false,
+      error: "Invalid API key.",
+    });
+  });
+});
+
+// --- humanError -----------------------------------------------------------
+
+describe("xai humanError", () => {
+  it("maps auth failures", () => {
+    expect(humanError(new XaiAPIError(401, "nope"))).toBe("Invalid API key.");
+    expect(humanError(new XaiAPIError(403, "nope"))).toBe("Invalid API key.");
+  });
+
+  // xAI bills from a prepaid balance, so a perfectly good key stops working
+  // when the credit runs out. "Provider error (402)" would send someone
+  // looking for a bug in the key itself.
+  it("says a spent balance is a spent balance", () => {
+    expect(humanError(new XaiAPIError(402, "insufficient"))).toMatch(/credit/i);
+  });
+
+  it("explains a 429 instead of saying 'rate limited'", () => {
+    const msg = humanError(new XaiAPIError(429, "slow down", 30));
+    expect(msg).toMatch(/rate limit/i);
+    expect(msg).toContain("30s");
+    expect(msg).toMatch(/console/i); // names where to look
+  });
+
+  it("maps server errors to a retryable message", () => {
+    expect(humanError(new XaiAPIError(503, "boom"))).toMatch(/temporary/i);
+  });
+
+  it("maps an unknown model to something actionable", () => {
+    expect(humanError(new XaiAPIError(404, "no such model"))).toMatch(/isn't available/i);
+  });
+});
+
+// --- catalog guards -------------------------------------------------------
+
+describe("xai catalog", () => {
+  it("offers Grok under the vendor id, not the model line", () => {
+    expect(PROVIDERS.xai.label).toContain("Grok");
+    expect(PROVIDERS.xai.keyPrefix).toBe("xai-");
+  });
+
+  it("classifies on a model that is not the answer model", () => {
+    expect(analysisModelFor("xai")).toBe("grok-4.3");
+    expect(analysisModelFor("xai")).not.toBe(PROVIDERS.xai.models[0].id);
+  });
+
+  it("honours the analysis-model env override", () => {
+    vi.stubEnv("ANALYSIS_XAI_MODEL", " grok-4.6 ");
+    expect(analysisModelFor("xai")).toBe("grok-4.6"); // trimmed
+  });
+
+  // Untested surfaces stay out of the picker. Whether the multi-agent variant
+  // can finish inside a run's budget has never been measured, and offering an
+  // unmeasured model is how sonar-deep-research would have shipped.
+  it("keeps the specialised grok variants out of the catalog", () => {
+    const ids = PROVIDERS.xai.models.map((m) => m.id);
+    expect(ids.some((id) => id.includes("multi-agent"))).toBe(false);
+    expect(ids.some((id) => id.includes("build"))).toBe(false);
+  });
+});

--- a/lib/models.test.ts
+++ b/lib/models.test.ts
@@ -21,8 +21,26 @@ describe("provider catalog", () => {
     expect(isProvider("openai")).toBe(true);
     expect(isProvider("google")).toBe(true);
     expect(isProvider("perplexity")).toBe(true);
+    expect(isProvider("xai")).toBe(true);
     expect(isProvider("gemini")).toBe(false); // "gemini" is a model line, not our provider id
+    expect(isProvider("grok")).toBe(false); // likewise: the provider id is the vendor, 'xai'
     expect(isProvider("mistral")).toBe(false);
+  });
+
+  // isProvider is derived from the catalog now, which means it answers whatever
+  // the object answers — including for keys every object inherits. `value in
+  // PROVIDERS` would narrow "toString" to Provider and hand it to code that
+  // indexes the catalog with it.
+  it("does not mistake inherited object properties for providers", () => {
+    expect(isProvider("toString")).toBe(false);
+    expect(isProvider("constructor")).toBe(false);
+    expect(isProvider("__proto__")).toBe(false);
+  });
+
+  it("recognizes every provider in the catalog", () => {
+    for (const info of PROVIDER_LIST) {
+      expect(isProvider(info.id)).toBe(true);
+    }
   });
 
   it("exposes google (Gemini) in the catalog", () => {

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -98,14 +98,39 @@ export const PROVIDERS: Record<Provider, ProviderInfo> = {
       { id: "sonar-reasoning-pro", label: "Sonar Reasoning Pro", note: "Chain-of-thought" },
     ],
   },
+  xai: {
+    id: "xai",
+    label: "xAI (Grok)",
+    keyUrl: "https://console.x.ai/team/default/api-keys",
+    keyPrefix: "xai-",
+    // Two entries, not seven. xAI publishes grok-4.5, three grok-4.20 variants
+    // and grok-build-0.1 alongside these, but a new provider has no trend line
+    // to preserve, so there is nothing for an older generation to be continuous
+    // with — it would just be picker clutter. The 4.20 variants (reasoning,
+    // non-reasoning, multi-agent) and grok-build are specialised surfaces no
+    // consumer Grok product serves; whether the multi-agent one can finish
+    // inside a run's budget is untested, and offering an untested model is how
+    // `sonar-deep-research` would have shipped.
+    models: [
+      { id: "grok-4.6", label: "Grok 4.6", note: "grok.com's default" },
+      { id: "grok-4.3", label: "Grok 4.3", note: "Fast & cheap" },
+    ],
+  },
 };
 
 export const PROVIDER_LIST: ProviderInfo[] = Object.values(PROVIDERS);
 
+// Derived from the catalog rather than a hand-written chain of comparisons, so a
+// provider added above can't be silently unrecognised here. The chain this
+// replaces was compiler-invisible: widening `Provider` did not fail the build,
+// it just left the new engine rejected by every write path that validates a
+// provider id — a saved key, a project's default, a v1 request body — with no
+// error pointing at this function.
+//
+// hasOwnProperty rather than `value in PROVIDERS`: `in` walks the prototype, so
+// "toString" and "constructor" would both answer true and narrow to Provider.
 export function isProvider(value: string): value is Provider {
-  return (
-    value === "anthropic" || value === "openai" || value === "google" || value === "perplexity"
-  );
+  return Object.prototype.hasOwnProperty.call(PROVIDERS, value);
 }
 
 export function defaultModelFor(provider: Provider): string {
@@ -157,6 +182,7 @@ const ANALYSIS_MODEL_ENV: Record<Provider, string> = {
   openai: "ANALYSIS_OPENAI_MODEL",
   google: "ANALYSIS_GOOGLE_MODEL",
   perplexity: "ANALYSIS_PERPLEXITY_MODEL",
+  xai: "ANALYSIS_XAI_MODEL",
 };
 
 const ANALYSIS_MODEL_DEFAULT: Record<Provider, string> = {
@@ -165,6 +191,9 @@ const ANALYSIS_MODEL_DEFAULT: Record<Provider, string> = {
   google: "gemini-flash-lite-latest",
   // Sonar is the cheap search model; classification never needs Pro.
   perplexity: "sonar",
+  // xAI's own model page calls 4.3 suitable for classification, and it is the
+  // cheapest per token of the entries offered above.
+  xai: "grok-4.3",
 };
 
 // Sentiment/recommendation enrichment is a simple structured-JSON judgment;

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -14,12 +14,39 @@ export interface ModelOption {
   note?: string;
 }
 
+/**
+ * How an engine grounds its answers — a property of the provider's API, not a
+ * preference.
+ *
+ * This documents behaviour the catalog already had rather than introducing any:
+ *   'optional' — grounded when the project asks for it. Anthropic, OpenAI and
+ *                Google all take the project's use_web_search flag.
+ *   'always'   — search IS the product and the flag is ignored. Perplexity
+ *                never runs ungrounded (see perplexityRunQuery), because an
+ *                ungrounded Sonar answer corresponds to nothing a real
+ *                Perplexity user ever sees.
+ *   'none'     — the API cannot browse at all. A grounded project is REFUSED
+ *                rather than quietly answered from memory.
+ *
+ * The 'none' case is what this type exists for. A provider whose API has no
+ * server-side browsing can still be a useful answer engine — plenty of people
+ * ask it questions — but its answers are recall, and recording them under a
+ * project that asked for live web grounding would put two different
+ * measurements on one trend line. Caller-executed function tools do NOT count
+ * as browsing: running the search ourselves and handing results back measures
+ * our search engine wearing the provider's label, which is the same thing
+ * lib/routers.ts refuses to do for Google.
+ */
+export type ProviderSearch = "always" | "optional" | "none";
+
 export interface ProviderInfo {
   id: Provider;
   label: string;
   /** Where a user gets a key. */
   keyUrl: string;
   keyPrefix: string;
+  /** How this engine grounds — see ProviderSearch. */
+  search: ProviderSearch;
   models: ModelOption[];
 }
 
@@ -31,6 +58,7 @@ export const PROVIDERS: Record<Provider, ProviderInfo> = {
     label: "Anthropic (Claude)",
     keyUrl: "https://console.anthropic.com/settings/keys",
     keyPrefix: "sk-ant-",
+    search: "optional",
     // Ordered by capability; the FIRST entry is the provider default
     // (defaultModelFor), so reordering is a behavior change for every project
     // that never picked a model — don't reorder to freshen the picker.
@@ -46,6 +74,7 @@ export const PROVIDERS: Record<Provider, ProviderInfo> = {
     label: "OpenAI (ChatGPT)",
     keyUrl: "https://platform.openai.com/api-keys",
     keyPrefix: "sk-",
+    search: "optional",
     // gpt-4o stays first (the default) for measurement continuity — a run's
     // rates are only comparable to the runs before it on the same surface, so
     // moving the default is a deliberate cut-over, not a freshen. The 5.6
@@ -65,6 +94,11 @@ export const PROVIDERS: Record<Provider, ProviderInfo> = {
     label: "Google (Gemini)",
     keyUrl: "https://aistudio.google.com/apikey",
     keyPrefix: "AIza",
+    // 'optional' describes the Gemini models, which ground when the project
+    // asks. The AI Overviews pseudo-model below always grounds regardless —
+    // that is a property of that one engine, forced in googleRunQuery, not of
+    // the Google key, so it doesn't change the provider's answer here.
+    search: "optional",
     // Google's rolling aliases rather than pinned versions. The pinned 2.5 ids
     // this shipped with were already rejected on a fresh project — "no longer
     // available to new users" — so a pin here rots silently and 404s every run
@@ -87,6 +121,9 @@ export const PROVIDERS: Record<Provider, ProviderInfo> = {
     label: "Perplexity (Sonar)",
     keyUrl: "https://www.perplexity.ai/account/api/keys",
     keyPrefix: "pplx-",
+    // Sonar searches on every call; perplexityRunQuery deliberately has no
+    // ungrounded branch, so the project's toggle never reaches it.
+    search: "always",
     // Named models rather than dated versions, so these don't rot the way the
     // pinned Gemini ids did. `sonar-deep-research` is deliberately absent: it
     // runs for minutes on a single question, which exceeds the 300s the run
@@ -103,6 +140,12 @@ export const PROVIDERS: Record<Provider, ProviderInfo> = {
     label: "xAI (Grok)",
     keyUrl: "https://console.x.ai/team/default/api-keys",
     keyPrefix: "xai-",
+    // The server-side web_search tool is real and the forcing shape is
+    // accepted (see XAI_FORCE_SEARCH). Whether the model then actually browses
+    // is still unverified against a funded key — if it turns out it cannot be
+    // compelled, this becomes 'none' rather than staying a weaker measurement
+    // that looks like the others.
+    search: "optional",
     // Two entries, not seven. xAI publishes grok-4.5, three grok-4.20 variants
     // and grok-build-0.1 alongside these, but a new provider has no trend line
     // to preserve, so there is nothing for an older generation to be continuous
@@ -114,6 +157,28 @@ export const PROVIDERS: Record<Provider, ProviderInfo> = {
     models: [
       { id: "grok-4.6", label: "Grok 4.6", note: "grok.com's default" },
       { id: "grok-4.3", label: "Grok 4.3", note: "Fast & cheap" },
+    ],
+  },
+  deepseek: {
+    id: "deepseek",
+    label: "DeepSeek",
+    keyUrl: "https://platform.deepseek.com/api_keys",
+    // DeepSeek issues OpenAI-style `sk-` keys, so the prefix cannot tell the
+    // two apart. Nothing depends on it doing so — the prefix is a placeholder
+    // hint in the key form, and every key is verified against its own provider
+    // before storage (setProviderKey -> verifyKey).
+    keyPrefix: "sk-",
+    // The one provider in the catalog that cannot browse. DeepSeek's API
+    // documents `function` tools only — caller-executed — so grounding would
+    // mean running the search ourselves and labelling the result DeepSeek.
+    // Web search exists in their consumer app, not on the API.
+    search: "none",
+    // V4 ids, not the `deepseek-chat` / `deepseek-reasoner` aliases: those were
+    // transitional pointers with an announced retirement date, which is exactly
+    // the rot that left every pinned Gemini id answering 404 on fresh keys.
+    models: [
+      { id: "deepseek-v4-pro", label: "DeepSeek V4 Pro", note: "Most capable" },
+      { id: "deepseek-v4-flash", label: "DeepSeek V4 Flash", note: "Fast & cheap" },
     ],
   },
 };
@@ -140,6 +205,48 @@ export function defaultModelFor(provider: Provider): string {
 /** Does this provider actually offer this model? */
 export function isModelFor(provider: Provider, modelId: string): boolean {
   return PROVIDERS[provider].models.some((m) => m.id === modelId);
+}
+
+/**
+ * Can this engine serve a run with this grounding setting?
+ *
+ * The provider-side twin of routerCanMeasure (lib/routers.ts), deliberately the
+ * same shape and asked at the same points, because it is the same question one
+ * layer down: a router that strips native search and a provider that never had
+ * any both end with a memory answer stored as a grounded measurement.
+ *
+ * Ungrounded runs are always fine — 'none' only ever blocks a project that
+ * asked for the live web.
+ */
+export function providerCanMeasure(
+  provider: Provider,
+  opts: { webSearch: boolean },
+): boolean {
+  if (!opts.webSearch) return true;
+  return PROVIDERS[provider].search !== "none";
+}
+
+/**
+ * Why this engine can't serve the run, phrased as the fix.
+ *
+ * Only called when providerCanMeasure said no, which today means exactly one
+ * thing: the project wants grounded answers and this provider's API cannot
+ * browse. Both fixes are named, because which one is right depends on what the
+ * user is actually trying to measure — and neither is "try again".
+ */
+export function providerRefusalMessage(provider: Provider): string {
+  const label = PROVIDERS[provider].label;
+  const grounded = PROVIDER_LIST.filter((p) => p.search !== "none").map((p) => p.label);
+  const alternatives =
+    grounded.length <= 1
+      ? (grounded[0] ?? "another engine")
+      : `${grounded.slice(0, -1).join(", ")} or ${grounded[grounded.length - 1]}`;
+  return (
+    `Your project asks for answers grounded in the live web, and ${label}'s API can't search — ` +
+    `only its consumer app can. Running it anyway would answer from the model's memory and record ` +
+    `that as a search-grounded measurement. Turn off web search for this project to measure ` +
+    `${label} on what it recalls, or switch your answer engine to ${alternatives}.`
+  );
 }
 
 export type EngineResolution =
@@ -183,6 +290,7 @@ const ANALYSIS_MODEL_ENV: Record<Provider, string> = {
   google: "ANALYSIS_GOOGLE_MODEL",
   perplexity: "ANALYSIS_PERPLEXITY_MODEL",
   xai: "ANALYSIS_XAI_MODEL",
+  deepseek: "ANALYSIS_DEEPSEEK_MODEL",
 };
 
 const ANALYSIS_MODEL_DEFAULT: Record<Provider, string> = {
@@ -194,6 +302,9 @@ const ANALYSIS_MODEL_DEFAULT: Record<Provider, string> = {
   // xAI's own model page calls 4.3 suitable for classification, and it is the
   // cheapest per token of the entries offered above.
   xai: "grok-4.3",
+  // Flash is a third the price of Pro on output and classification is a
+  // structured-JSON judgment, not a reasoning task.
+  deepseek: "deepseek-v4-flash",
 };
 
 // Sentiment/recommendation enrichment is a simple structured-JSON judgment;

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -181,6 +181,27 @@ export const PROVIDERS: Record<Provider, ProviderInfo> = {
       { id: "deepseek-v4-flash", label: "DeepSeek V4 Flash", note: "Fast & cheap" },
     ],
   },
+  meta: {
+    id: "meta",
+    label: "Meta (Muse Spark)",
+    keyUrl: "https://dev.meta.ai/",
+    // Meta issues LLM|<digits>|<token> keys — distinctive, not sk-prefixed.
+    // Same caveat as DeepSeek's: this is a form hint only, every key is
+    // verified against its own provider before storage regardless of shape.
+    keyPrefix: "LLM|",
+    // Optional pending a live probe (2026-08-15): Meta's own docs offer a
+    // web_search tool but document no tool_choice/forcing parameter at all --
+    // "the model decides autonomously whether to search." Whether it grounds
+    // reliably enough to be measured the way Claude/GPT/Gemini are is what the
+    // probe answers; this may need to drop to a more conservative stance if it
+    // doesn't, the same way Grok's forcing effect remains an open question.
+    search: "optional",
+    // Only the current flagship. `muse-spark-1.1` is the prior generation at
+    // identical pricing (no reason to offer it new), and the `-contributor`
+    // variant opts your traffic into improving Meta's own products, which is
+    // not something to default anyone into.
+    models: [{ id: "muse-spark-1.2", label: "Muse Spark 1.2", note: "Most capable" }],
+  },
 };
 
 export const PROVIDER_LIST: ProviderInfo[] = Object.values(PROVIDERS);
@@ -291,6 +312,7 @@ const ANALYSIS_MODEL_ENV: Record<Provider, string> = {
   perplexity: "ANALYSIS_PERPLEXITY_MODEL",
   xai: "ANALYSIS_XAI_MODEL",
   deepseek: "ANALYSIS_DEEPSEEK_MODEL",
+  meta: "ANALYSIS_META_MODEL",
 };
 
 const ANALYSIS_MODEL_DEFAULT: Record<Provider, string> = {
@@ -305,6 +327,15 @@ const ANALYSIS_MODEL_DEFAULT: Record<Provider, string> = {
   // Flash is a third the price of Pro on output and classification is a
   // structured-JSON judgment, not a reasoning task.
   deepseek: "deepseek-v4-flash",
+  // Deliberate exception: this is the ONLY provider where the analysis id
+  // equals defaultModelFor's — Meta ships a single model, no separate cheap
+  // tier the way every other provider's catalog does. The cost/quality lever
+  // here is reasoning_effort, not model choice: the adapter hardcodes
+  // "minimal" for every utility call (see metaChat in lib/llm/index.ts) and
+  // "low" for answers, so classification is still cheaper in practice even
+  // though the id can't say so. The usual "must differ from the default" test
+  // gets a documented skip for this one provider rather than a silent gap.
+  meta: "muse-spark-1.2",
 };
 
 // Sentiment/recommendation enrichment is a simple structured-JSON judgment;

--- a/lib/pricing.ts
+++ b/lib/pricing.ts
@@ -72,6 +72,18 @@ const RATES: Record<Provider, { models: Record<string, number>; fallback: number
     },
     fallback: 12,
   },
+  // Published output rates are $0.87 (Pro) and $0.28 (Flash) per Mtok — an
+  // order of magnitude under everything else here. Rounded UP to whole dollars,
+  // and the fallback sits well above both, because DeepSeek has announced a
+  // significant price rise with no figure attached: under-charging silently is
+  // the failure this table exists to prevent.
+  deepseek: {
+    models: {
+      "deepseek-v4-pro": 1,
+      "deepseek-v4-flash": 1,
+    },
+    fallback: 5,
+  },
 };
 
 /**

--- a/lib/pricing.ts
+++ b/lib/pricing.ts
@@ -61,6 +61,17 @@ const RATES: Record<Provider, { models: Record<string, number>; fallback: number
   },
   google: { models: {}, fallback: 30 },
   perplexity: { models: {}, fallback: 30 },
+  // xAI prices in tiers — a lower rate under 200k tokens in the request, a
+  // higher one at or above it. These are the HIGH tier, per the err-high rule
+  // at the top of this file: the cheaper tier would let a long-context run
+  // overshoot the cap it was supposed to stop.
+  xai: {
+    models: {
+      "grok-4.6": 12,
+      "grok-4.3": 5,
+    },
+    fallback: 12,
+  },
 };
 
 /**

--- a/lib/pricing.ts
+++ b/lib/pricing.ts
@@ -84,6 +84,15 @@ const RATES: Record<Provider, { models: Record<string, number>; fallback: number
     },
     fallback: 5,
   },
+  // Published output rate is $4.25/Mtok, rounded up. Fallback padded well above
+  // it since this is a brand-new product (public preview since April 2026) with
+  // no pricing track record yet to trust past its current published figure.
+  meta: {
+    models: {
+      "muse-spark-1.2": 5,
+    },
+    fallback: 8,
+  },
 };
 
 /**

--- a/lib/routers.test.ts
+++ b/lib/routers.test.ts
@@ -326,6 +326,39 @@ describe("coveredProviders", () => {
   });
 });
 
+// An engine whose API cannot browse is refused by resolveRunKeyFor for a
+// grounded project on ANY credential, so coverage must say so too — otherwise
+// onboarding pins a grounded project to it and the settings form shows no
+// warning until the first run fails.
+describe("coverage of an engine that can't ground", () => {
+  it("reports 'ungrounded' for a grounded project even with a direct key", () => {
+    const cov = engineCoverage("deepseek", { direct: ["deepseek"], routers: [], webSearch: true });
+    expect(cov.kind).toBe("ungrounded");
+    expect(cov.kind === "ungrounded" && cov.reason).toMatch(/turn off web search/i);
+  });
+
+  it("is plain direct coverage when the project isn't grounded", () => {
+    expect(
+      engineCoverage("deepseek", { direct: ["deepseek"], routers: [], webSearch: false }),
+    ).toEqual({ kind: "direct" });
+  });
+
+  it("outranks routers: no credential can make it grounded", () => {
+    const cov = engineCoverage("deepseek", {
+      direct: [],
+      routers: [{ router: "openrouter", searchVerified: [] }],
+      webSearch: true,
+    });
+    expect(cov.kind).toBe("ungrounded");
+  });
+
+  it("is left out of coveredProviders for a grounded project, kept for an ungrounded one", () => {
+    const creds = { direct: ["deepseek", "anthropic"] as Provider[], routers: [] };
+    expect(coveredProviders({ ...creds, webSearch: true })).toEqual(["anthropic"]);
+    expect(coveredProviders({ ...creds, webSearch: false })).toEqual(["deepseek", "anthropic"]);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Routed Gemini (LET-176).
 //

--- a/lib/routers.ts
+++ b/lib/routers.ts
@@ -328,6 +328,7 @@ const OPENROUTER_UPSTREAM: Record<Provider, string> = {
   google: "google-vertex",
   perplexity: "perplexity",
   xai: "xai",
+  deepseek: "deepseek",
 };
 
 /** Display order for the settings cards and CLI listing: Merge leads. */

--- a/lib/routers.ts
+++ b/lib/routers.ts
@@ -329,6 +329,7 @@ const OPENROUTER_UPSTREAM: Record<Provider, string> = {
   perplexity: "perplexity",
   xai: "xai",
   deepseek: "deepseek",
+  meta: "meta",
 };
 
 /** Display order for the settings cards and CLI listing: Merge leads. */

--- a/lib/routers.ts
+++ b/lib/routers.ts
@@ -314,12 +314,20 @@ export const ROUTERS: Record<RouterId, RouterInfo> = {
   },
 };
 
-/** OpenRouter's upstream-provider names, for the pinning above. */
+/**
+ * OpenRouter's upstream-provider names, for the pinning above.
+ *
+ * A name here is NOT a claim that any router serves the engine — `providers`
+ * on each RouterInfo is the only thing that decides that, and no router lists
+ * xai. This map is total over `Provider` because the pinning helper is, so an
+ * entry is required for every provider whether or not it is ever reached.
+ */
 const OPENROUTER_UPSTREAM: Record<Provider, string> = {
   anthropic: "anthropic",
   openai: "openai",
   google: "google-vertex",
   perplexity: "perplexity",
+  xai: "xai",
 };
 
 /** Display order for the settings cards and CLI listing: Merge leads. */

--- a/lib/routers.ts
+++ b/lib/routers.ts
@@ -1,5 +1,10 @@
 import type { Provider, RouterId } from "./types";
-import { GOOGLE_AI_OVERVIEWS_MODEL, PROVIDERS } from "./models";
+import {
+  GOOGLE_AI_OVERVIEWS_MODEL,
+  PROVIDERS,
+  providerCanMeasure,
+  providerRefusalMessage,
+} from "./models";
 
 // ==================================================================
 // LLM routers (gateways).
@@ -466,6 +471,8 @@ export type EngineCoverage =
   | { kind: "direct" }
   | { kind: "routed"; router: RouterId }
   | { kind: "unroutable"; router: RouterId; reason: string }
+  // The engine's API can't browse; a grounded project is refused on any credential.
+  | { kind: "ungrounded"; reason: string }
   | { kind: "none" };
 
 /**
@@ -481,6 +488,11 @@ export function engineCoverage(
   provider: Provider,
   opts: { direct: Provider[]; routers: RouterCoverage[]; webSearch: boolean },
 ): EngineCoverage {
+  if (!PROVIDERS[provider]) return { kind: "none" };
+  // Same gate, same position as resolveRunKeyFor: ahead of every credential.
+  if (!providerCanMeasure(provider, { webSearch: opts.webSearch })) {
+    return { kind: "ungrounded", reason: providerRefusalMessage(provider) };
+  }
   if (opts.direct.includes(provider)) return { kind: "direct" };
 
   const usable = opts.routers.find((rk) =>
@@ -520,8 +532,10 @@ export function coveredProviders(opts: {
   routers: RouterCoverage[];
   webSearch: boolean;
 }): Provider[] {
-  const routed = (Object.keys(PROVIDERS) as Provider[]).filter(
-    (p) => engineCoverage(p, opts).kind === "routed",
-  );
-  return Array.from(new Set([...opts.direct, ...routed]));
+  const covered = new Set<Provider>();
+  for (const p of [...opts.direct, ...(Object.keys(PROVIDERS) as Provider[])]) {
+    const kind = engineCoverage(p, opts).kind;
+    if (kind === "direct" || kind === "routed") covered.add(p);
+  }
+  return Array.from(covered);
 }

--- a/lib/trial.test.ts
+++ b/lib/trial.test.ts
@@ -5,11 +5,17 @@ import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 // stays clean; resolveKey's own use of it is mocked per-test below.
 vi.mock("@/lib/data", () => ({
   getDecryptedKey: vi.fn(),
+  getDecryptedKeys: vi.fn(),
   getConfiguredProviders: vi.fn(),
   getDecryptedRouterKeys: vi.fn(),
 }));
 
-import { getDecryptedKey, getConfiguredProviders, getDecryptedRouterKeys } from "@/lib/data";
+import {
+  getDecryptedKey,
+  getDecryptedKeys,
+  getConfiguredProviders,
+  getDecryptedRouterKeys,
+} from "@/lib/data";
 import { PROVIDER_LIST } from "@/lib/models";
 import type { Provider, RouterId } from "@/lib/types";
 import {
@@ -89,6 +95,17 @@ beforeEach(() => {
   }
   process.env.TRIAL_RUN_LIMIT = "5";
   vi.mocked(getDecryptedKey).mockReset().mockResolvedValue(null);
+  // The batch lookup mirrors the per-provider mock, so one getDecryptedKey setup drives both resolvers.
+  vi.mocked(getDecryptedKeys)
+    .mockReset()
+    .mockImplementation(async (sb, uid) => {
+      const keys: Partial<Record<Provider, string>> = {};
+      for (const { id } of PROVIDER_LIST) {
+        const k = await getDecryptedKey(sb, uid, id);
+        if (k) keys[id] = k;
+      }
+      return keys;
+    });
   vi.mocked(getConfiguredProviders).mockReset().mockResolvedValue([]);
   vi.mocked(getDecryptedRouterKeys).mockReset().mockResolvedValue([]);
 });
@@ -100,81 +117,49 @@ afterEach(() => {
   }
 });
 
-// providerOrder replaced a hand-written N x N table. The compiler could only
-// ever catch half of that table's hazard: growing `Provider` demanded a new ROW,
-// but nothing required the new provider to be ADDED to the existing rows — and a
-// provider missing from those is one no other provider ever falls back to, so a
-// key the user holds would sit unused with nothing failing to say so.
-//
-// These observe the order the resolver actually walks rather than re-asserting a
-// table, so they would catch a provider dropped from the sequence as well as one
-// misplaced in it. The first case is the exact order the old table encoded.
+// providerOrder replaced a hand-written N x N table that the compiler could
+// only half-check: a new provider got its own row but nothing forced it INTO
+// the existing rows, so a key the user held could sit unused with no error.
+// These assert which key wins, so they catch a provider dropped from the
+// sequence as well as one misplaced in it.
 describe("auxiliary fallback order", () => {
-  /** The providers resolveKey asks about, in the order it asks. */
-  async function askedOrder(preferred: Provider): Promise<Provider[]> {
-    const asked: Provider[] = [];
-    vi.mocked(getDecryptedKey).mockImplementation(async (...args: unknown[]) => {
-      asked.push(args[2] as Provider);
-      return null;
-    });
-    await resolveKey(db(0), "user-1", preferred);
-    return asked;
+  const CATALOG = PROVIDER_LIST.map((i) => i.id);
+
+  /** The provider resolveKey settles on when the user holds keys for exactly `holders`. */
+  async function winner(preferred: Provider, holders: Provider[]): Promise<Provider | null> {
+    ownsKeysFor(...holders);
+    const k = await resolveKey(db(0), "user-1", preferred);
+    return k.source === "own" ? k.provider : null;
   }
 
-  it("prefers the requested engine, then walks the catalog in order", async () => {
-    expect(await askedOrder("anthropic")).toEqual([
-      "anthropic",
-      "openai",
-      "google",
-      "perplexity",
-      "xai",
-      "deepseek",
-      "meta",
-    ]);
+  it("prefers the requested engine when its key exists", async () => {
+    for (const p of CATALOG) expect(await winner(p, CATALOG)).toBe(p);
   });
 
-  it("puts the requested engine first whichever one it is", async () => {
-    expect(await askedOrder("google")).toEqual([
-      "google",
-      "anthropic",
-      "openai",
-      "perplexity",
-      "xai",
-      "deepseek",
-      "meta",
-    ]);
-    expect(await askedOrder("deepseek")).toEqual([
-      "deepseek",
-      "anthropic",
-      "openai",
-      "google",
-      "perplexity",
-      "xai",
-      "meta",
-    ]);
-  });
-
-  // Derived from the catalog, so this stays honest as providers are added
-  // rather than pinning a length that has to be edited every time.
-  it("asks about every provider exactly once", async () => {
-    for (const p of PROVIDER_LIST.map((i) => i.id)) {
-      const order = await askedOrder(p);
-      expect(new Set(order).size).toBe(order.length);
-      expect(order).toHaveLength(PROVIDER_LIST.length);
+  it("otherwise walks the catalog in order, whichever engine was requested", async () => {
+    for (const preferred of CATALOG) {
+      const rest = CATALOG.filter((p) => p !== preferred);
+      // Peel the expected winner off the front each time; the next must be the next in catalog order.
+      for (let i = 0; i < rest.length; i++) {
+        expect(await winner(preferred, rest.slice(i))).toBe(rest[i]);
+      }
     }
+  });
+
+  it("looks the user's keys up once, not once per provider", async () => {
+    await resolveKey(db(0), "user-1", "anthropic");
+    expect(getDecryptedKeys).toHaveBeenCalledTimes(1);
   });
 
   it("actually falls back to a newly added provider", async () => {
     // The bug the old table would have had: xai present as its own row but
     // absent from the other four, so a user holding only an xAI key and asking
     // for Claude would have been told they had no key at all.
-    vi.mocked(getDecryptedKey).mockImplementation(async (...args: unknown[]) =>
-      args[2] === "xai" ? "xai-only-key" : null,
-    );
+    ownsKeysFor("xai");
     const k = await resolveKey(db(0), "user-1", "anthropic");
     expect(k.source).toBe("own");
     expect(k.provider).toBe("xai");
-    expect(k.apiKey).toBe("xai-only-key");
+    expect(k.apiKey).toBe("key-for-xai");
     // and it still reports what was ASKED for, not what answered
     expect(k.requested.provider).toBe("anthropic");
   });

--- a/lib/trial.test.ts
+++ b/lib/trial.test.ts
@@ -10,6 +10,7 @@ vi.mock("@/lib/data", () => ({
 }));
 
 import { getDecryptedKey, getConfiguredProviders, getDecryptedRouterKeys } from "@/lib/data";
+import { PROVIDER_LIST } from "@/lib/models";
 import type { Provider, RouterId } from "@/lib/types";
 import {
   resolveKey,
@@ -67,10 +68,12 @@ const TRIAL_VARS = [
   "TRIAL_GOOGLE_API_KEY",
   "TRIAL_PERPLEXITY_API_KEY",
   "TRIAL_XAI_API_KEY",
+  "TRIAL_DEEPSEEK_API_KEY",
   "TRIAL_ANTHROPIC_MODEL",
   "TRIAL_OPENAI_MODEL",
   "TRIAL_GOOGLE_MODEL",
   "TRIAL_XAI_MODEL",
+  "TRIAL_DEEPSEEK_MODEL",
   "TRIAL_RUN_LIMIT",
 ] as const;
 
@@ -123,6 +126,7 @@ describe("auxiliary fallback order", () => {
       "google",
       "perplexity",
       "xai",
+      "deepseek",
     ]);
   });
 
@@ -133,21 +137,25 @@ describe("auxiliary fallback order", () => {
       "openai",
       "perplexity",
       "xai",
+      "deepseek",
     ]);
-    expect(await askedOrder("xai")).toEqual([
-      "xai",
+    expect(await askedOrder("deepseek")).toEqual([
+      "deepseek",
       "anthropic",
       "openai",
       "google",
       "perplexity",
+      "xai",
     ]);
   });
 
+  // Derived from the catalog, so this stays honest as providers are added
+  // rather than pinning a length that has to be edited every time.
   it("asks about every provider exactly once", async () => {
-    for (const p of ["anthropic", "openai", "google", "perplexity", "xai"] as Provider[]) {
+    for (const p of PROVIDER_LIST.map((i) => i.id)) {
       const order = await askedOrder(p);
       expect(new Set(order).size).toBe(order.length);
-      expect(order).toHaveLength(5);
+      expect(order).toHaveLength(PROVIDER_LIST.length);
     }
   });
 
@@ -164,6 +172,38 @@ describe("auxiliary fallback order", () => {
     expect(k.apiKey).toBe("xai-only-key");
     // and it still reports what was ASKED for, not what answered
     expect(k.requested.provider).toBe("anthropic");
+  });
+});
+
+// An engine that cannot browse must be refused for a grounded project no
+// matter what credential the user holds. The gate lives ahead of every
+// credential branch precisely so a perfectly good key can't route around it.
+describe("an engine that can't ground", () => {
+  it("refuses a grounded project even when the user owns that provider's key", async () => {
+    vi.mocked(getDecryptedKey).mockResolvedValue("sk-deepseek-own");
+    const k = await runKeyFor(db(0), "user-1", "deepseek", undefined, { webSearch: true });
+    expect(k.source).toBe("ungrounded");
+    expect(k.apiKey).toBeUndefined(); // never hands back a key it won't let you use
+    expect(engineKeyMessage(k)).toMatch(/can't search/i);
+  });
+
+  it("refuses before spending a trial key on it", async () => {
+    process.env.TRIAL_DEEPSEEK_API_KEY = "sk-deepseek-trial";
+    const k = await runKeyFor(db(0), "user-1", "deepseek", undefined, { webSearch: true });
+    expect(k.source).toBe("ungrounded");
+  });
+
+  it("serves the same engine happily when the project isn't grounded", async () => {
+    vi.mocked(getDecryptedKey).mockResolvedValue("sk-deepseek-own");
+    const k = await runKeyFor(db(0), "user-1", "deepseek", undefined, { webSearch: false });
+    expect(k.source).toBe("own");
+    expect(k.apiKey).toBe("sk-deepseek-own");
+  });
+
+  it("does not block engines that can browse", async () => {
+    vi.mocked(getDecryptedKey).mockResolvedValue("sk-ant-own");
+    const k = await runKeyFor(db(0), "user-1", "anthropic", undefined, { webSearch: true });
+    expect(k.source).toBe("own");
   });
 });
 

--- a/lib/trial.test.ts
+++ b/lib/trial.test.ts
@@ -66,9 +66,11 @@ const TRIAL_VARS = [
   "TRIAL_OPENAI_API_KEY",
   "TRIAL_GOOGLE_API_KEY",
   "TRIAL_PERPLEXITY_API_KEY",
+  "TRIAL_XAI_API_KEY",
   "TRIAL_ANTHROPIC_MODEL",
   "TRIAL_OPENAI_MODEL",
   "TRIAL_GOOGLE_MODEL",
+  "TRIAL_XAI_MODEL",
   "TRIAL_RUN_LIMIT",
 ] as const;
 
@@ -91,6 +93,78 @@ afterEach(() => {
     if (saved[v] === undefined) delete process.env[v];
     else process.env[v] = saved[v];
   }
+});
+
+// providerOrder replaced a hand-written N x N table. The compiler could only
+// ever catch half of that table's hazard: growing `Provider` demanded a new ROW,
+// but nothing required the new provider to be ADDED to the existing rows — and a
+// provider missing from those is one no other provider ever falls back to, so a
+// key the user holds would sit unused with nothing failing to say so.
+//
+// These observe the order the resolver actually walks rather than re-asserting a
+// table, so they would catch a provider dropped from the sequence as well as one
+// misplaced in it. The first case is the exact order the old table encoded.
+describe("auxiliary fallback order", () => {
+  /** The providers resolveKey asks about, in the order it asks. */
+  async function askedOrder(preferred: Provider): Promise<Provider[]> {
+    const asked: Provider[] = [];
+    vi.mocked(getDecryptedKey).mockImplementation(async (...args: unknown[]) => {
+      asked.push(args[2] as Provider);
+      return null;
+    });
+    await resolveKey(db(0), "user-1", preferred);
+    return asked;
+  }
+
+  it("prefers the requested engine, then walks the catalog in order", async () => {
+    expect(await askedOrder("anthropic")).toEqual([
+      "anthropic",
+      "openai",
+      "google",
+      "perplexity",
+      "xai",
+    ]);
+  });
+
+  it("puts the requested engine first whichever one it is", async () => {
+    expect(await askedOrder("google")).toEqual([
+      "google",
+      "anthropic",
+      "openai",
+      "perplexity",
+      "xai",
+    ]);
+    expect(await askedOrder("xai")).toEqual([
+      "xai",
+      "anthropic",
+      "openai",
+      "google",
+      "perplexity",
+    ]);
+  });
+
+  it("asks about every provider exactly once", async () => {
+    for (const p of ["anthropic", "openai", "google", "perplexity", "xai"] as Provider[]) {
+      const order = await askedOrder(p);
+      expect(new Set(order).size).toBe(order.length);
+      expect(order).toHaveLength(5);
+    }
+  });
+
+  it("actually falls back to a newly added provider", async () => {
+    // The bug the old table would have had: xai present as its own row but
+    // absent from the other four, so a user holding only an xAI key and asking
+    // for Claude would have been told they had no key at all.
+    vi.mocked(getDecryptedKey).mockImplementation(async (...args: unknown[]) =>
+      args[2] === "xai" ? "xai-only-key" : null,
+    );
+    const k = await resolveKey(db(0), "user-1", "anthropic");
+    expect(k.source).toBe("own");
+    expect(k.provider).toBe("xai");
+    expect(k.apiKey).toBe("xai-only-key");
+    // and it still reports what was ASKED for, not what answered
+    expect(k.requested.provider).toBe("anthropic");
+  });
 });
 
 describe("resolveKey", () => {

--- a/lib/trial.test.ts
+++ b/lib/trial.test.ts
@@ -69,11 +69,13 @@ const TRIAL_VARS = [
   "TRIAL_PERPLEXITY_API_KEY",
   "TRIAL_XAI_API_KEY",
   "TRIAL_DEEPSEEK_API_KEY",
+  "TRIAL_META_API_KEY",
   "TRIAL_ANTHROPIC_MODEL",
   "TRIAL_OPENAI_MODEL",
   "TRIAL_GOOGLE_MODEL",
   "TRIAL_XAI_MODEL",
   "TRIAL_DEEPSEEK_MODEL",
+  "TRIAL_META_MODEL",
   "TRIAL_RUN_LIMIT",
 ] as const;
 
@@ -127,6 +129,7 @@ describe("auxiliary fallback order", () => {
       "perplexity",
       "xai",
       "deepseek",
+      "meta",
     ]);
   });
 
@@ -138,6 +141,7 @@ describe("auxiliary fallback order", () => {
       "perplexity",
       "xai",
       "deepseek",
+      "meta",
     ]);
     expect(await askedOrder("deepseek")).toEqual([
       "deepseek",
@@ -146,6 +150,7 @@ describe("auxiliary fallback order", () => {
       "google",
       "perplexity",
       "xai",
+      "meta",
     ]);
   });
 

--- a/lib/trial.ts
+++ b/lib/trial.ts
@@ -53,6 +53,7 @@ const TRIAL_KEY_ENV: Record<Provider, string> = {
   openai: "TRIAL_OPENAI_API_KEY",
   google: "TRIAL_GOOGLE_API_KEY",
   perplexity: "TRIAL_PERPLEXITY_API_KEY",
+  xai: "TRIAL_XAI_API_KEY",
 };
 
 const TRIAL_MODEL_ENV: Record<Provider, string> = {
@@ -60,6 +61,7 @@ const TRIAL_MODEL_ENV: Record<Provider, string> = {
   openai: "TRIAL_OPENAI_MODEL",
   google: "TRIAL_GOOGLE_MODEL",
   perplexity: "TRIAL_PERPLEXITY_MODEL",
+  xai: "TRIAL_XAI_MODEL",
 };
 
 // Derived from the env map above rather than written out again, so a provider
@@ -186,21 +188,31 @@ export interface ResolvedKey {
   available?: Provider[];
 }
 
-/** The provider new projects default to: one we can actually serve (has a trial key), else anthropic. */
+/** The provider new projects default to: one we can actually serve (has a trial
+ *  key), else anthropic. Walks PROVIDER_IDS rather than a chain of ifs, for the
+ *  same reason PROVIDER_IDS itself is derived — a provider missing from the
+ *  chain is invisible to the compiler and simply never gets picked. */
 export function pickDefaultProvider(): Provider {
-  if (trialKeyFor("anthropic")) return "anthropic";
-  if (trialKeyFor("openai")) return "openai";
-  if (trialKeyFor("google")) return "google";
-  if (trialKeyFor("perplexity")) return "perplexity";
-  return "anthropic";
+  return PROVIDER_IDS.find((p) => trialKeyFor(p)) ?? "anthropic";
 }
 
-const PROVIDER_ORDER: Record<Provider, Provider[]> = {
-  anthropic: ["anthropic", "openai", "google", "perplexity"],
-  openai: ["openai", "anthropic", "google", "perplexity"],
-  google: ["google", "anthropic", "openai", "perplexity"],
-  perplexity: ["perplexity", "anthropic", "openai", "google"],
-};
+/**
+ * Preference order for AUXILIARY work: the requested provider, then every other
+ * one in catalog order.
+ *
+ * Derived rather than kept as the N x N table this replaces. That table was a
+ * half-caught hazard: growing `Provider` made the compiler demand a new ROW, so
+ * the new engine got its own preference list — but nothing required it to be
+ * ADDED to the four existing rows, and a provider absent from those is one no
+ * other provider will ever fall back to. It would have been a key the user
+ * holds, silently never used, with no error anywhere.
+ *
+ * The four rows it replaces were each exactly "preferred, then catalog order
+ * minus self", so this reproduces them unchanged; a test pins that.
+ */
+function providerOrder(preferred: Provider): Provider[] {
+  return [preferred, ...PROVIDER_IDS.filter((p) => p !== preferred)];
+}
 
 /**
  * Resolve a key for AUXILIARY work — prompt/competitor/topic suggestion — by
@@ -223,7 +235,7 @@ export async function resolveKey(
   preferred: Provider,
   preferredModel?: string,
 ): Promise<ResolvedKey> {
-  const order = PROVIDER_ORDER[preferred];
+  const order = providerOrder(preferred);
   const modelFor = (p: Provider) =>
     p === preferred && preferredModel ? preferredModel : defaultModelFor(p);
   const requested = { provider: preferred, model: modelFor(preferred) };

--- a/lib/trial.ts
+++ b/lib/trial.ts
@@ -61,6 +61,7 @@ const TRIAL_KEY_ENV: Record<Provider, string> = {
   perplexity: "TRIAL_PERPLEXITY_API_KEY",
   xai: "TRIAL_XAI_API_KEY",
   deepseek: "TRIAL_DEEPSEEK_API_KEY",
+  meta: "TRIAL_META_API_KEY",
 };
 
 const TRIAL_MODEL_ENV: Record<Provider, string> = {
@@ -70,6 +71,7 @@ const TRIAL_MODEL_ENV: Record<Provider, string> = {
   perplexity: "TRIAL_PERPLEXITY_MODEL",
   xai: "TRIAL_XAI_MODEL",
   deepseek: "TRIAL_DEEPSEEK_MODEL",
+  meta: "TRIAL_META_MODEL",
 };
 
 // Derived from the env map above rather than written out again, so a provider

--- a/lib/trial.ts
+++ b/lib/trial.ts
@@ -6,7 +6,13 @@ import {
   getDecryptedRouterKeys,
   type DecryptedRouterKey,
 } from "@/lib/data";
-import { defaultModelFor, modelLabel, PROVIDERS } from "@/lib/models";
+import {
+  defaultModelFor,
+  modelLabel,
+  providerCanMeasure,
+  providerRefusalMessage,
+  PROVIDERS,
+} from "@/lib/models";
 import {
   ROUTERS,
   ROUTER_LIST,
@@ -54,6 +60,7 @@ const TRIAL_KEY_ENV: Record<Provider, string> = {
   google: "TRIAL_GOOGLE_API_KEY",
   perplexity: "TRIAL_PERPLEXITY_API_KEY",
   xai: "TRIAL_XAI_API_KEY",
+  deepseek: "TRIAL_DEEPSEEK_API_KEY",
 };
 
 const TRIAL_MODEL_ENV: Record<Provider, string> = {
@@ -62,6 +69,7 @@ const TRIAL_MODEL_ENV: Record<Provider, string> = {
   google: "TRIAL_GOOGLE_MODEL",
   perplexity: "TRIAL_PERPLEXITY_MODEL",
   xai: "TRIAL_XAI_MODEL",
+  deepseek: "TRIAL_DEEPSEEK_MODEL",
 };
 
 // Derived from the env map above rather than written out again, so a provider
@@ -154,7 +162,13 @@ export type KeySource =
   // measure it comparably — a distinct state from "no key", because the fix is
   // different (switch engine, turn off web search, or add a direct key) and
   // because running it anyway would produce data that looks fine and isn't.
-  | "unroutable";
+  | "unroutable"
+  // The engine itself can't ground: this project wants live-web answers and the
+  // provider's API has no search at all. Distinct from 'unroutable' because no
+  // credential can fix it — the fix is the project's grounding setting or a
+  // different engine, and saying "your router can't measure this" to someone
+  // holding a direct key would be nonsense. See providerCanMeasure.
+  | "ungrounded";
 
 export interface ResolvedKey {
   source: KeySource;
@@ -335,6 +349,16 @@ export async function resolveRunKeyFor(
   const requested = { provider, model: model || defaultModelFor(provider) };
   const base = { provider, model: requested.model, requested };
 
+  // Before any credential question: can this engine even produce the kind of
+  // answer the project asked for? A provider whose API cannot browse must not
+  // serve a grounded project on ANY credential, so this outranks every branch
+  // below — finding a perfectly good key first and refusing afterwards would
+  // just be a slower way to reach the same answer, and an easy one to forget in
+  // one of the paths. See providerCanMeasure.
+  if (!providerCanMeasure(provider, { webSearch: opts.webSearch })) {
+    return { ...base, source: "ungrounded", refusal: providerRefusalMessage(provider) };
+  }
+
   const own = await getDecryptedKey(supabase, userId, provider);
   if (own) return { ...base, source: "own", apiKey: own };
 
@@ -464,8 +488,12 @@ export function engineKeyMessage(key: ResolvedKey): string {
   const providerLabel = PROVIDERS[key.requested.provider].label;
 
   // Composed by the resolver, which is the only place that still knows which
-  // router refused and why.
-  if (key.source === "unroutable" && key.refusal) return key.refusal;
+  // router refused and why. 'ungrounded' carries its refusal the same way — the
+  // reason differs (the engine can't search at all, rather than the credential
+  // not carrying its search) but both arrive pre-written and naming the fix.
+  if ((key.source === "unroutable" || key.source === "ungrounded") && key.refusal) {
+    return key.refusal;
+  }
 
   if (key.source === "exhausted") {
     // The spend ceiling and the run ceiling are different refusals. Someone

--- a/lib/trial.ts
+++ b/lib/trial.ts
@@ -2,6 +2,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Project, Provider, RouteInfo } from "@/lib/types";
 import {
   getDecryptedKey,
+  getDecryptedKeys,
   getConfiguredProviders,
   getDecryptedRouterKeys,
   type DecryptedRouterKey,
@@ -11,6 +12,7 @@ import {
   modelLabel,
   providerCanMeasure,
   providerRefusalMessage,
+  PROVIDER_LIST,
   PROVIDERS,
 } from "@/lib/models";
 import {
@@ -74,10 +76,8 @@ const TRIAL_MODEL_ENV: Record<Provider, string> = {
   meta: "TRIAL_META_MODEL",
 };
 
-// Derived from the env map above rather than written out again, so a provider
-// added to the catalog can't be silently skipped here — omitting perplexity
-// from this list is what made a perplexity-only deployment report no trial.
-const PROVIDER_IDS = Object.keys(TRIAL_KEY_ENV) as Provider[];
+// Catalog order, from the catalog itself: this is also the fallback/default walk order.
+const PROVIDER_IDS: Provider[] = PROVIDER_LIST.map((p) => p.id);
 
 /** The operator's shared key for a provider, if configured. */
 export function trialKeyFor(provider: Provider): string | null {
@@ -204,28 +204,12 @@ export interface ResolvedKey {
   available?: Provider[];
 }
 
-/** The provider new projects default to: one we can actually serve (has a trial
- *  key), else anthropic. Walks PROVIDER_IDS rather than a chain of ifs, for the
- *  same reason PROVIDER_IDS itself is derived — a provider missing from the
- *  chain is invisible to the compiler and simply never gets picked. */
+/** The provider new projects default to: the first in catalog order with a trial key, else anthropic. */
 export function pickDefaultProvider(): Provider {
   return PROVIDER_IDS.find((p) => trialKeyFor(p)) ?? "anthropic";
 }
 
-/**
- * Preference order for AUXILIARY work: the requested provider, then every other
- * one in catalog order.
- *
- * Derived rather than kept as the N x N table this replaces. That table was a
- * half-caught hazard: growing `Provider` made the compiler demand a new ROW, so
- * the new engine got its own preference list — but nothing required it to be
- * ADDED to the four existing rows, and a provider absent from those is one no
- * other provider will ever fall back to. It would have been a key the user
- * holds, silently never used, with no error anywhere.
- *
- * The four rows it replaces were each exactly "preferred, then catalog order
- * minus self", so this reproduces them unchanged; a test pins that.
- */
+/** Preference order for AUXILIARY work: the requested provider, then the rest in catalog order. */
 function providerOrder(preferred: Provider): Provider[] {
   return [preferred, ...PROVIDER_IDS.filter((p) => p !== preferred)];
 }
@@ -264,9 +248,12 @@ export async function resolveKey(
   //    which credential settles the bill, and a user holding a direct Claude key
   //    should get Claude rather than Claude-via-a-gateway. Web search never
   //    applies to utility work, so any router that reaches the engine will do.
-  const routerKeys = await getDecryptedRouterKeys(supabase, userId);
+  const [ownKeys, routerKeys] = await Promise.all([
+    getDecryptedKeys(supabase, userId),
+    getDecryptedRouterKeys(supabase, userId),
+  ]);
   for (const p of order) {
-    const own = await getDecryptedKey(supabase, userId, p);
+    const own = ownKeys[p];
     if (own) return { source: "own", apiKey: own, provider: p, model: modelFor(p), requested };
 
     const viaRouter = routerKeys.find((rk) => routerSupport(rk.router, p) !== null);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -10,7 +10,8 @@ export type Provider =
   | "google"
   | "perplexity"
   | "xai"
-  | "deepseek";
+  | "deepseek"
+  | "meta";
 
 // LLM routers are credentials, not providers, so they get their own union and
 // stay out of `Provider` — which is what keeps `runs.provider` meaning "whose

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -4,7 +4,13 @@
 // 'xai' names the vendor, not the model line, for the same reason the Gemini
 // engine is 'google': the id has to outlive the model it currently serves.
 // `isProvider` rejects "grok" explicitly so the two can't drift.
-export type Provider = "anthropic" | "openai" | "google" | "perplexity" | "xai";
+export type Provider =
+  | "anthropic"
+  | "openai"
+  | "google"
+  | "perplexity"
+  | "xai"
+  | "deepseek";
 
 // LLM routers are credentials, not providers, so they get their own union and
 // stay out of `Provider` — which is what keeps `runs.provider` meaning "whose

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,7 +1,10 @@
 // Shared domain + database row types for LetterTrace.
 // Column names mirror supabase/schema.sql exactly.
 
-export type Provider = "anthropic" | "openai" | "google" | "perplexity";
+// 'xai' names the vendor, not the model line, for the same reason the Gemini
+// engine is 'google': the id has to outlive the model it currently serves.
+// `isProvider` rejects "grok" explicitly so the two can't drift.
+export type Provider = "anthropic" | "openai" | "google" | "perplexity" | "xai";
 
 // LLM routers are credentials, not providers, so they get their own union and
 // stay out of `Provider` — which is what keeps `runs.provider` meaning "whose

--- a/scripts/pilot-client.ts
+++ b/scripts/pilot-client.ts
@@ -116,6 +116,7 @@ const ANSWER_MODEL: Record<Provider, string> = {
   google: "gemini-pro-latest",
   perplexity: "sonar-pro",
   xai: "grok-4.6",
+  deepseek: "deepseek-v4-pro",
 };
 
 // Rough blended $/1M tokens, only for an order-of-magnitude spend estimate.
@@ -129,6 +130,8 @@ const BLENDED_COST_PER_MTOK: Record<Provider, number> = {
   // Grok 4.6's own tiered rate, blended: the pilot's requests sit well under
   // the 200k-token threshold where xAI's higher tier starts.
   xai: 5,
+  // An order of magnitude cheaper than everything else here; see lib/pricing.
+  deepseek: 1,
 };
 
 // --- concurrency ----------------------------------------------------------
@@ -196,6 +199,7 @@ function keyFor(provider: Provider): string {
     google: "TRIAL_GOOGLE_API_KEY",
     perplexity: "TRIAL_PERPLEXITY_API_KEY",
     xai: "TRIAL_XAI_API_KEY",
+    deepseek: "TRIAL_DEEPSEEK_API_KEY",
   };
   const k = process.env[env[provider]];
   if (!k) throw new Error(`Missing ${env[provider]} in .env.local`);

--- a/scripts/pilot-client.ts
+++ b/scripts/pilot-client.ts
@@ -33,6 +33,7 @@ import {
 } from "../lib/llm";
 import { detectMention, brandTerms } from "../lib/mentions";
 import { hostOf, isOwnedDomain } from "../lib/engine";
+import { isProvider } from "../lib/models";
 import type { Provider } from "../lib/types";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -95,10 +96,11 @@ const maxPrompts = Number(flag("max-prompts", "10"));
 const providers = flag("providers", "anthropic,openai")
   .split(",")
   .map((p) => p.trim())
-  .filter(
-    (p): p is Provider =>
-      p === "anthropic" || p === "openai" || p === "google" || p === "perplexity",
-  );
+  // isProvider, not a chain of comparisons: the chain was compiler-invisible, so
+  // a provider added to the catalog stayed silently unrunnable here — `--providers
+  // xai` would be dropped without a word and the pilot would report on whatever
+  // was left, which is the wrong answer rather than an error.
+  .filter(isProvider);
 const webSearch = flag("web-search", "on") !== "off";
 
 // Answer models: the flagship of each provider, i.e. what a real user asking
@@ -109,6 +111,7 @@ const ANSWER_MODEL: Record<Provider, string> = {
   openai: "gpt-4o",
   google: "gemini-pro-latest",
   perplexity: "sonar-pro",
+  xai: "grok-4.6",
 };
 
 // Rough blended $/1M tokens, only for an order-of-magnitude spend estimate.
@@ -119,6 +122,9 @@ const BLENDED_COST_PER_MTOK: Record<Provider, number> = {
   // Perplexity bills per request and per search on top of tokens; this is only
   // an order-of-magnitude figure for the pilot's spend estimate.
   perplexity: 6,
+  // Grok 4.6's own tiered rate, blended: the pilot's requests sit well under
+  // the 200k-token threshold where xAI's higher tier starts.
+  xai: 5,
 };
 
 // --- concurrency ----------------------------------------------------------
@@ -185,6 +191,7 @@ function keyFor(provider: Provider): string {
     openai: "TRIAL_OPENAI_API_KEY",
     google: "TRIAL_GOOGLE_API_KEY",
     perplexity: "TRIAL_PERPLEXITY_API_KEY",
+    xai: "TRIAL_XAI_API_KEY",
   };
   const k = process.env[env[provider]];
   if (!k) throw new Error(`Missing ${env[provider]} in .env.local`);

--- a/scripts/pilot-client.ts
+++ b/scripts/pilot-client.ts
@@ -117,6 +117,7 @@ const ANSWER_MODEL: Record<Provider, string> = {
   perplexity: "sonar-pro",
   xai: "grok-4.6",
   deepseek: "deepseek-v4-pro",
+  meta: "muse-spark-1.2",
 };
 
 // Rough blended $/1M tokens, only for an order-of-magnitude spend estimate.
@@ -130,8 +131,10 @@ const BLENDED_COST_PER_MTOK: Record<Provider, number> = {
   // Grok 4.6's own tiered rate, blended: the pilot's requests sit well under
   // the 200k-token threshold where xAI's higher tier starts.
   xai: 5,
-  // An order of magnitude cheaper than everything else here; see lib/pricing.
+  // An order of magnitude cheaper than everything here; see lib/pricing.
   deepseek: 1,
+  // Published output rate is $4.25/Mtok; see lib/pricing.
+  meta: 5,
 };
 
 // --- concurrency ----------------------------------------------------------
@@ -200,6 +203,7 @@ function keyFor(provider: Provider): string {
     perplexity: "TRIAL_PERPLEXITY_API_KEY",
     xai: "TRIAL_XAI_API_KEY",
     deepseek: "TRIAL_DEEPSEEK_API_KEY",
+    meta: "TRIAL_META_API_KEY",
   };
   const k = process.env[env[provider]];
   if (!k) throw new Error(`Missing ${env[provider]} in .env.local`);

--- a/scripts/pilot-client.ts
+++ b/scripts/pilot-client.ts
@@ -43,7 +43,11 @@ const repoRoot = resolve(here, "..");
 
 function loadEnvLocal(): void {
   const raw = readFileSync(resolve(repoRoot, ".env.local"), "utf8");
-  for (const line of raw.split("\n")) {
+  // Split on /\r?\n/, not "\n": on a CRLF file every line keeps a trailing \r,
+  // and `.` in a JS regex can never consume \r (it's a line terminator), so
+  // (.*)$ never reaches end-of-string and the whole line fails to match --
+  // silently, for every variable, not just one. Reproduced live 2026-08-14.
+  for (const line of raw.split(/\r?\n/)) {
     const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*)$/);
     if (!m) continue;
     const value = m[2].trim().replace(/^["']|["']$/g, "");

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -121,7 +121,7 @@ $$;
 create table if not exists public.provider_keys (
   id uuid primary key default gen_random_uuid(),
   user_id uuid not null references auth.users (id) on delete cascade,
-  provider text not null check (provider in ('anthropic', 'openai', 'google', 'perplexity', 'xai')),
+  provider text not null check (provider in ('anthropic', 'openai', 'google', 'perplexity', 'xai', 'deepseek')),
   label text,
   encrypted_key text not null,
   key_hint text not null,
@@ -134,7 +134,7 @@ create table if not exists public.provider_keys (
 -- Safe to re-run.
 alter table public.provider_keys drop constraint if exists provider_keys_provider_check;
 alter table public.provider_keys
-  add constraint provider_keys_provider_check check (provider in ('anthropic', 'openai', 'google', 'perplexity', 'xai'));
+  add constraint provider_keys_provider_check check (provider in ('anthropic', 'openai', 'google', 'perplexity', 'xai', 'deepseek'));
 
 -- ---------- router_keys (LLM gateway credential, encrypted) ----------
 -- One key that reaches many providers (OpenRouter, Concentrate). Deliberately a
@@ -176,7 +176,7 @@ create table if not exists public.projects (
   brand_aliases text[] not null default '{}',
   brand_domains text[] not null default '{}',
   description text,
-  default_provider text not null default 'anthropic' check (default_provider in ('anthropic', 'openai', 'google', 'perplexity', 'xai')),
+  default_provider text not null default 'anthropic' check (default_provider in ('anthropic', 'openai', 'google', 'perplexity', 'xai', 'deepseek')),
   default_model text not null default 'claude-sonnet-4-6',
   schedule text not null default 'off' check (schedule in ('off', 'daily', 'weekly')),
   last_run_at timestamptz,
@@ -187,7 +187,7 @@ create table if not exists public.projects (
 -- Widen the default-provider allow-list on existing deployments. Safe to re-run.
 alter table public.projects drop constraint if exists projects_default_provider_check;
 alter table public.projects
-  add constraint projects_default_provider_check check (default_provider in ('anthropic', 'openai', 'google', 'perplexity', 'xai'));
+  add constraint projects_default_provider_check check (default_provider in ('anthropic', 'openai', 'google', 'perplexity', 'xai', 'deepseek'));
 
 -- Query the models with their native web search on, so we can capture the
 -- sources they cite. Default on. Safe to re-run.
@@ -339,7 +339,7 @@ alter table public.runs
 -- add and safe to re-run.
 alter table public.runs drop constraint if exists runs_provider_check;
 alter table public.runs
-  add constraint runs_provider_check check (provider in ('anthropic', 'openai', 'google', 'perplexity', 'xai'));
+  add constraint runs_provider_check check (provider in ('anthropic', 'openai', 'google', 'perplexity', 'xai', 'deepseek'));
 
 -- Which credential carried this run: null for a direct provider key (every
 -- historical row), else the router that served it. `provider` above stays the
@@ -370,7 +370,7 @@ create table if not exists public.responses (
 -- Same provider allow-list as runs (see note above). Safe to add and re-run.
 alter table public.responses drop constraint if exists responses_provider_check;
 alter table public.responses
-  add constraint responses_provider_check check (provider in ('anthropic', 'openai', 'google', 'perplexity', 'xai'));
+  add constraint responses_provider_check check (provider in ('anthropic', 'openai', 'google', 'perplexity', 'xai', 'deepseek'));
 
 -- ---------- mentions -------------------------------------------------
 create table if not exists public.mentions (

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -121,7 +121,7 @@ $$;
 create table if not exists public.provider_keys (
   id uuid primary key default gen_random_uuid(),
   user_id uuid not null references auth.users (id) on delete cascade,
-  provider text not null check (provider in ('anthropic', 'openai', 'google', 'perplexity')),
+  provider text not null check (provider in ('anthropic', 'openai', 'google', 'perplexity', 'xai')),
   label text,
   encrypted_key text not null,
   key_hint text not null,
@@ -134,7 +134,7 @@ create table if not exists public.provider_keys (
 -- Safe to re-run.
 alter table public.provider_keys drop constraint if exists provider_keys_provider_check;
 alter table public.provider_keys
-  add constraint provider_keys_provider_check check (provider in ('anthropic', 'openai', 'google', 'perplexity'));
+  add constraint provider_keys_provider_check check (provider in ('anthropic', 'openai', 'google', 'perplexity', 'xai'));
 
 -- ---------- router_keys (LLM gateway credential, encrypted) ----------
 -- One key that reaches many providers (OpenRouter, Concentrate). Deliberately a
@@ -176,7 +176,7 @@ create table if not exists public.projects (
   brand_aliases text[] not null default '{}',
   brand_domains text[] not null default '{}',
   description text,
-  default_provider text not null default 'anthropic' check (default_provider in ('anthropic', 'openai', 'google', 'perplexity')),
+  default_provider text not null default 'anthropic' check (default_provider in ('anthropic', 'openai', 'google', 'perplexity', 'xai')),
   default_model text not null default 'claude-sonnet-4-6',
   schedule text not null default 'off' check (schedule in ('off', 'daily', 'weekly')),
   last_run_at timestamptz,
@@ -187,7 +187,7 @@ create table if not exists public.projects (
 -- Widen the default-provider allow-list on existing deployments. Safe to re-run.
 alter table public.projects drop constraint if exists projects_default_provider_check;
 alter table public.projects
-  add constraint projects_default_provider_check check (default_provider in ('anthropic', 'openai', 'google', 'perplexity'));
+  add constraint projects_default_provider_check check (default_provider in ('anthropic', 'openai', 'google', 'perplexity', 'xai'));
 
 -- Query the models with their native web search on, so we can capture the
 -- sources they cite. Default on. Safe to re-run.
@@ -339,7 +339,7 @@ alter table public.runs
 -- add and safe to re-run.
 alter table public.runs drop constraint if exists runs_provider_check;
 alter table public.runs
-  add constraint runs_provider_check check (provider in ('anthropic', 'openai', 'google', 'perplexity'));
+  add constraint runs_provider_check check (provider in ('anthropic', 'openai', 'google', 'perplexity', 'xai'));
 
 -- Which credential carried this run: null for a direct provider key (every
 -- historical row), else the router that served it. `provider` above stays the
@@ -370,7 +370,7 @@ create table if not exists public.responses (
 -- Same provider allow-list as runs (see note above). Safe to add and re-run.
 alter table public.responses drop constraint if exists responses_provider_check;
 alter table public.responses
-  add constraint responses_provider_check check (provider in ('anthropic', 'openai', 'google', 'perplexity'));
+  add constraint responses_provider_check check (provider in ('anthropic', 'openai', 'google', 'perplexity', 'xai'));
 
 -- ---------- mentions -------------------------------------------------
 create table if not exists public.mentions (

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -121,7 +121,7 @@ $$;
 create table if not exists public.provider_keys (
   id uuid primary key default gen_random_uuid(),
   user_id uuid not null references auth.users (id) on delete cascade,
-  provider text not null check (provider in ('anthropic', 'openai', 'google', 'perplexity', 'xai', 'deepseek')),
+  provider text not null check (provider in ('anthropic', 'openai', 'google', 'perplexity', 'xai', 'deepseek', 'meta')),
   label text,
   encrypted_key text not null,
   key_hint text not null,
@@ -134,7 +134,7 @@ create table if not exists public.provider_keys (
 -- Safe to re-run.
 alter table public.provider_keys drop constraint if exists provider_keys_provider_check;
 alter table public.provider_keys
-  add constraint provider_keys_provider_check check (provider in ('anthropic', 'openai', 'google', 'perplexity', 'xai', 'deepseek'));
+  add constraint provider_keys_provider_check check (provider in ('anthropic', 'openai', 'google', 'perplexity', 'xai', 'deepseek', 'meta'));
 
 -- ---------- router_keys (LLM gateway credential, encrypted) ----------
 -- One key that reaches many providers (OpenRouter, Concentrate). Deliberately a
@@ -176,7 +176,7 @@ create table if not exists public.projects (
   brand_aliases text[] not null default '{}',
   brand_domains text[] not null default '{}',
   description text,
-  default_provider text not null default 'anthropic' check (default_provider in ('anthropic', 'openai', 'google', 'perplexity', 'xai', 'deepseek')),
+  default_provider text not null default 'anthropic' check (default_provider in ('anthropic', 'openai', 'google', 'perplexity', 'xai', 'deepseek', 'meta')),
   default_model text not null default 'claude-sonnet-4-6',
   schedule text not null default 'off' check (schedule in ('off', 'daily', 'weekly')),
   last_run_at timestamptz,
@@ -187,7 +187,7 @@ create table if not exists public.projects (
 -- Widen the default-provider allow-list on existing deployments. Safe to re-run.
 alter table public.projects drop constraint if exists projects_default_provider_check;
 alter table public.projects
-  add constraint projects_default_provider_check check (default_provider in ('anthropic', 'openai', 'google', 'perplexity', 'xai', 'deepseek'));
+  add constraint projects_default_provider_check check (default_provider in ('anthropic', 'openai', 'google', 'perplexity', 'xai', 'deepseek', 'meta'));
 
 -- Query the models with their native web search on, so we can capture the
 -- sources they cite. Default on. Safe to re-run.
@@ -339,7 +339,7 @@ alter table public.runs
 -- add and safe to re-run.
 alter table public.runs drop constraint if exists runs_provider_check;
 alter table public.runs
-  add constraint runs_provider_check check (provider in ('anthropic', 'openai', 'google', 'perplexity', 'xai', 'deepseek'));
+  add constraint runs_provider_check check (provider in ('anthropic', 'openai', 'google', 'perplexity', 'xai', 'deepseek', 'meta'));
 
 -- Which credential carried this run: null for a direct provider key (every
 -- historical row), else the router that served it. `provider` above stays the
@@ -370,7 +370,7 @@ create table if not exists public.responses (
 -- Same provider allow-list as runs (see note above). Safe to add and re-run.
 alter table public.responses drop constraint if exists responses_provider_check;
 alter table public.responses
-  add constraint responses_provider_check check (provider in ('anthropic', 'openai', 'google', 'perplexity', 'xai', 'deepseek'));
+  add constraint responses_provider_check check (provider in ('anthropic', 'openai', 'google', 'perplexity', 'xai', 'deepseek', 'meta'));
 
 -- ---------- mentions -------------------------------------------------
 create table if not exists public.mentions (


### PR DESCRIPTION
## Why

New engines requested: xAI (Grok), DeepSeek, and Meta (Muse Spark) needed to be measurable the same way Claude/GPT/Gemini/Perplexity already are. Each has a genuinely different web-search story — xAI and Meta can browse only when asked, DeepSeek's API cannot browse at all — and bolting on three more `if (provider === ...)` branches would have let a DeepSeek key silently take a grounded project (every run then refusing with no explanation) and let engine-specific transport quirks (reasoning text, tool-turn token budgets) leak into what gets stored as "the answer."

## What

- `lib/llm/index.ts`, `lib/models.ts` — xAI, DeepSeek, and Meta added as answer engines: direct API adapters, native web search for xAI/Meta via the Responses API, DeepSeek ungrounded-only by construction.
- `lib/routers.ts` — `engineCoverage`/`coveredProviders` check `providerCanMeasure` before credentials, so an engine that can't browse is never reported as covering a grounded project.
- `app/api/onboarding/complete/route.ts`, `app/dashboard/settings/project-form.tsx` — onboarding prefers a grounded-runnable engine, falling back to an ungrounded-runnable one before the env default; Settings shows the refusal reason and qualifies the save message instead of silently accepting a broken configuration.
- `lib/api-service.ts`, `app/api/v1/projects/[id]/runs/route.ts` — `triggerRunForProject` reports "ungrounded" as its own outcome; the v1 route maps it to 400 (a config problem), keeping 402 reserved for an actual missing key.
- `lib/trial.ts`, `lib/data.ts` — `resolveKey`'s auxiliary-work fallback batches the user's stored keys into one query instead of one query per provider — matters once the catalog is 7 engines deep.
- `lib/llm/index.ts` — xAI's answer-text extraction had no item-type filter at all, so reasoning/tool/commentary output could be concatenated into what gets scanned for brand mentions — the same bug already fixed for Meta. xAI grounded calls get the same 4000-token ceiling Meta needed, since tool turns spend the answer budget before any visible text. Meta now refuses to store a grounded reply as grounded if no completed `web_search_call` shows up in it.

## Design decisions worth reviewing

**DeepSeek is refused on any grounded project, on any credential.** DeepSeek's API only documents caller-executed function tools — no server-side browsing to hand a key. Answering from memory and recording it as "grounded" would corrupt the exact number this product exists to report. `providerCanMeasure` draws this line once; onboarding, Settings, and the v1 route all read it rather than re-deriving it.

**xAI and Meta get a bigger token ceiling only when grounded (4000 vs. the shared 1200).** Both run tool-calling turns on the same output budget as the visible answer. An ungrounded call never touches this path and keeps the cheaper budget; a grounded call that stayed at 1200 measurably came back empty or truncated mid-tool-orchestration.

**Meta's grounding is verified per-reply, not gated up front.** Unlike xAI (accepts a forcing parameter) and DeepSeek (gated before any call), Meta's API rejects every `tool_choice` shape for `web_search` — probed live, every shape came back 400. The tool can only be offered, so whether a reply actually searched can't be known until after the call; a grounded reply with no completed search is refused rather than stored.


## Scope

Touches the provider catalog, the three answer/utility-call adapters, the coverage/routing logic deciding which engine a project can run on, and the three places that logic needs to stay honest (onboarding default, Settings warning, v1 API status code). Does not touch billing, the router/gateway path for Anthropic/OpenAI, or any UI outside Settings' engine-coverage messaging.

## Tests

`lib/llm/xai.test.ts`, `lib/llm/meta.test.ts`, `lib/llm/deepseek.test.ts` — mocked fetch, no network. `lib/routers.test.ts`, `lib/trial.test.ts`, `lib/api-service.test.ts`, `onboarding-route.test.ts`, `v1-routes.test.ts` cover the coverage/routing/status-code logic. **834 tests passing** (39 files, after syncing with the latest master). Typecheck and lint clean; production build succeeds.

## Verification

Live-tested against real xAI, DeepSeek, and Meta keys (30/31 calls passing — the one failure is the pre-existing, out-of-scope xAI error-mapping gap noted above):
- xAI grounded call returned a complete, unfiltered answer with 3 real sources under the new 4000-token ceiling.
- Meta grounded call completed a real web search, clean answer, no commentary leakage.
- DeepSeek's grounding refusal fired with the exact user-facing message; its ungrounded path continued working normally.

Manual browser walkthrough (local Supabase) confirmed the Settings page renders the exact refusal reason and "Saved, but…" message for a DeepSeek-plus-web-search project, clearing correctly when web search is turned off.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789588045&installation_model_id=431526&pr_number=124&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F124&signature=cb3164ffb59903b9a233e70e917993a0e30523bcde9d0af88aaba8e2bd58f71b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->