### PR TITLE
feat(notify): allow several operator alert recipients

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -135,7 +135,9 @@ ANALYSIS_PERPLEXITY_MODEL=
 # ------------------------------------------------------------------
 # Operator alerts (optional)
 # ------------------------------------------------------------------
-# One address told when someone signs up. Leave ADMIN_ALERT_EMAIL unset and
+# Who gets told when someone signs up. Comma-separate for several people
+# (ops@example.com,founder@example.com) — they arrive as one email with
+# multiple recipients, not one send each. Leave ADMIN_ALERT_EMAIL unset and
 # nothing is sent, nothing is written, and no request pays for the feature.
 ADMIN_ALERT_EMAIL=
 # Sent FROM this address; it must be on a domain verified with the mail

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -9,7 +9,7 @@ import { LetterproveAttest } from "@/components/letterprove-attest";
 import { RunReadyBanner } from "@/components/dashboard/run-ready-banner";
 import { ThemeToggle } from "@/components/theme";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
-import { adminAlertEmail, fireAndForget } from "@/lib/notify";
+import { adminAlertEmails, fireAndForget } from "@/lib/notify";
 import { alertNewSignup } from "@/lib/notify-signup";
 import { getProject, getProjects, getConfiguredProviders } from "@/lib/data";
 import { getUnseenRun } from "@/lib/results-seen";
@@ -44,7 +44,7 @@ export default async function DashboardLayout({
   // Costs nothing when alerting is switched off — the check short-circuits
   // before any query — and one indexed read when it is on. The claim itself is
   // guarded in the database, so a second tab cannot produce a second email.
-  if (adminAlertEmail()) {
+  if (adminAlertEmails().length > 0) {
     const { data: alertState } = await supabase
       .from("profiles")
       .select("admin_alerted_at")

--- a/lib/notify-signup.ts
+++ b/lib/notify-signup.ts
@@ -1,5 +1,5 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { sendAdminAlert, signupAlert, adminAlertEmail } from "@/lib/notify";
+import { sendAdminAlert, signupAlert, adminAlertEmails } from "@/lib/notify";
 
 /**
  * Tell the operator about a new account, exactly once.
@@ -26,7 +26,7 @@ export async function alertNewSignup(
   // Claim the alert before doing anything slow. Cheap when unconfigured: skip
   // the write entirely so a deployment with no alerting doesn't take a round
   // trip on every sign-in.
-  if (!adminAlertEmail()) return "not-configured";
+  if (adminAlertEmails().length === 0) return "not-configured";
 
   const { data, error } = await admin
     .from("profiles")

--- a/lib/notify.test.ts
+++ b/lib/notify.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
-import { sendAdminAlert, signupAlert, adminAlertEmail } from "@/lib/notify";
+import { sendAdminAlert, signupAlert, adminAlertEmails } from "@/lib/notify";
 import { alertNewSignup } from "@/lib/notify-signup";
 
 const ENV = ["ADMIN_ALERT_EMAIL", "ADMIN_ALERT_FROM", "RESEND_API_KEY"] as const;
@@ -77,10 +77,30 @@ describe("sendAdminAlert", () => {
     expect(await sendAdminAlert({ subject: "s", body: "b" })).toBe("failed");
   });
 
-  it("reads the address from the environment", () => {
-    expect(adminAlertEmail()).toBeNull();
+  // Several people can want the same alert. One request with N recipients
+  // rather than N requests: a partial failure across separate sends is a worse
+  // thing to reason about than a single all-or-nothing result.
+  it("delivers one email to every configured recipient", async () => {
+    process.env.ADMIN_ALERT_EMAIL = "ops@example.com, second@example.com";
+    process.env.RESEND_API_KEY = "re_x";
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("{}", { status: 200 }));
+
+    expect(await sendAdminAlert({ subject: "s", body: "b" })).toBe("sent");
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const sent = JSON.parse(String((fetchSpy.mock.calls[0][1] as RequestInit).body));
+    expect(sent.to).toEqual(["ops@example.com", "second@example.com"]);
+  });
+
+  it("reads the recipients from the environment", () => {
+    expect(adminAlertEmails()).toEqual([]);
     process.env.ADMIN_ALERT_EMAIL = "  ops@example.com  ";
-    expect(adminAlertEmail()).toBe("ops@example.com");
+    expect(adminAlertEmails()).toEqual(["ops@example.com"]);
+    // Trailing separators and stray whitespace are the shape a human actually
+    // types into a Vercel env field.
+    process.env.ADMIN_ALERT_EMAIL = "a@x.com, b@y.com ,";
+    expect(adminAlertEmails()).toEqual(["a@x.com", "b@y.com"]);
   });
 });
 

--- a/lib/notify.ts
+++ b/lib/notify.ts
@@ -24,10 +24,21 @@ export interface AdminAlert {
   body: string;
 }
 
-/** Who gets operator alerts, if anyone. */
-export function adminAlertEmail(): string | null {
-  const v = process.env.ADMIN_ALERT_EMAIL;
-  return v && v.trim() ? v.trim() : null;
+/**
+ * Who gets operator alerts, if anyone.
+ *
+ * Comma-separated, parsed the same way as the admin allowlists in lib/admin.ts.
+ * A single address is still the common case and still works unchanged — the
+ * variable keeps its singular name so existing deployments need no edit.
+ *
+ * Empty means nobody, which is the normal state for a self-hoster who doesn't
+ * want alerts.
+ */
+export function adminAlertEmails(): string[] {
+  return (process.env.ADMIN_ALERT_EMAIL ?? "")
+    .split(",")
+    .map((e) => e.trim())
+    .filter(Boolean);
 }
 
 /** The address alerts are sent FROM. Must be on a domain verified with the mail
@@ -47,12 +58,12 @@ export type AlertOutcome = "sent" | "not-configured" | "failed";
  * result is also correct.
  */
 export async function sendAdminAlert(alert: AdminAlert): Promise<AlertOutcome> {
-  const to = adminAlertEmail();
+  const to = adminAlertEmails();
   const apiKey = process.env.RESEND_API_KEY?.trim();
 
   // Unconfigured is the normal state for a self-hosted deployment that doesn't
   // want alerts, so it is not an error and not worth logging on every signup.
-  if (!to || !apiKey) return "not-configured";
+  if (to.length === 0 || !apiKey) return "not-configured";
 
   try {
     const res = await fetch(RESEND_ENDPOINT, {
@@ -63,7 +74,10 @@ export async function sendAdminAlert(alert: AdminAlert): Promise<AlertOutcome> {
       },
       body: JSON.stringify({
         from: alertFrom(),
-        to: [to],
+        // One request with several recipients rather than one request each:
+        // Resend takes an array, and a partial failure across N sends is a
+        // worse thing to reason about than a single all-or-nothing result.
+        to,
         subject: alert.subject,
         text: alert.body,
       }),


### PR DESCRIPTION
Signup alerts went to exactly one address. Adding a second person meant a mailing list or a code change — and setting a comma-separated value in the env var would have **failed silently-ish**, because Resend would have received one malformed address instead of two valid ones.

## Change

`ADMIN_ALERT_EMAIL` now parses as a comma-separated list, the same way the admin allowlists in `lib/admin.ts` already do.

- **The variable keeps its singular name**, so existing deployments need no edit and a single address behaves exactly as before.
- **One request with several recipients**, not one request each. A partial failure across N sends is a worse thing to reason about than a single all-or-nothing result — and this is deliberately the kind of code that never throws into the thing it reports on.
- `adminAlertEmail()` → `adminAlertEmails(): string[]`. Both guard call sites (dashboard layout, `notify-signup`) check length rather than truthiness.

## Verification

686 tests pass, `tsc` and `next build` clean. New coverage for multi-recipient delivery and for the trailing-separator/whitespace shape a human actually types into a Vercel env field:

```
"a@x.com, b@y.com ,"  →  ["a@x.com", "b@y.com"]
```

## To actually add Saiyak

After merge, set on lettertrace Production:

```
ADMIN_ALERT_EMAIL = <existing>,saiyak@letterstory.com
```

Then redeploy — env changes only take effect on a new build.

One thing to check when you do: `ADMIN_ALERT_FROM` must be on a domain verified with Resend. It already is for the current recipient, and adding a recipient doesn't change that — but if alerts stop arriving for everyone, that's the first thing to look at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789588996&installation_model_id=431526&pr_number=125&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F125&signature=552c9458d62f76ff8f911b21851b9a2c1618fd151b0e7561684d1d362a5d82ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->