### PR TITLE
feat(letterprove): report signups and logins, not just sessions

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -6,6 +6,7 @@ import { SignOutButton } from "@/components/dashboard/signout";
 import { WhyFree } from "@/components/dashboard/why-free";
 import { TrialBanner } from "@/components/dashboard/trial-banner";
 import { LetterproveAttest } from "@/components/letterprove-attest";
+import { isFirstSignIn } from "@/lib/letterprove";
 import { RunReadyBanner } from "@/components/dashboard/run-ready-banner";
 import { ThemeToggle } from "@/components/theme";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
@@ -78,7 +79,7 @@ export default async function DashboardLayout({
           it reports on authenticated product usage, which only exists behind
           this boundary — and because `user` is already resolved above, so it
           costs no extra query. Only the domain of the address is ever sent. */}
-      <LetterproveAttest email={user.email} />
+      <LetterproveAttest email={user.email} firstSignIn={isFirstSignIn(user)} />
 
       <aside className="flex flex-col border-b border-ink/10 bg-paper md:h-screen md:w-[260px] md:shrink-0 md:border-b-0 md:border-r">
         <div className="flex flex-col gap-6 px-5 py-6 md:h-full">

--- a/components/letterprove-attest.tsx
+++ b/components/letterprove-attest.tsx
@@ -54,12 +54,48 @@ declare global {
   }
 }
 
-export function LetterproveAttest({ email }: { email?: string | null }) {
+/** Marks that this browser session has already reported its sign-in. */
+const SESSION_FLAG = "letterprove:reported";
+
+/**
+ * Which of the three calls this page load should make.
+ *
+ * `signup` and `login` are once-per-browser-session facts; `session` is a
+ * per-page-load one, and attest.js already counts that itself. So the first
+ * load of a session reports the sign-in and every load after it just
+ * re-identifies — otherwise a refresh would read as a second login, and the
+ * first-sign-in window would report a signup on every page of that session.
+ *
+ * Falls back to `identify` when storage is unavailable (private mode, blocked
+ * cookies). Under-reporting a login is a missing row; over-reporting one is a
+ * false claim, and this product is the wrong place to guess upward.
+ */
+function callForThisLoad(firstSignIn: boolean): "identify" | "login" | "signup" {
+  try {
+    if (window.sessionStorage.getItem(SESSION_FLAG)) return "identify";
+    window.sessionStorage.setItem(SESSION_FLAG, "1");
+    return firstSignIn ? "signup" : "login";
+  } catch {
+    return "identify";
+  }
+}
+
+export function LetterproveAttest({
+  email,
+  firstSignIn = false,
+}: {
+  email?: string | null;
+  firstSignIn?: boolean;
+}) {
   const key = process.env.NEXT_PUBLIC_LETTERPROVE_KEY;
   const origin = process.env.NEXT_PUBLIC_LETTERPROVE_ORIGIN ?? DEFAULT_ORIGIN;
 
   useEffect(() => {
     if (!key || !email) return;
+
+    // signup() and login() both call identify() internally, so the domain is
+    // established whichever branch runs.
+    const call = callForThisLoad(firstSignIn);
 
     // Already injected by an earlier mount this page load. `identify` is
     // idempotent per page load on Letterprove's side — it fires at most one
@@ -67,7 +103,7 @@ export function LetterproveAttest({ email }: { email?: string | null }) {
     // and keeps the domain established if this remounts.
     const existing = document.getElementById(SCRIPT_ID);
     if (existing) {
-      window.Letterprove?.identify(email);
+      window.Letterprove?.[call](email);
       return;
     }
 
@@ -81,7 +117,7 @@ export function LetterproveAttest({ email }: { email?: string | null }) {
     // offline client — and that has to be a no-op, not an error boundary.
     script.onload = () => {
       try {
-        window.Letterprove?.identify(email);
+        window.Letterprove?.[call](email);
       } catch {
         /* ignore */
       }
@@ -90,7 +126,7 @@ export function LetterproveAttest({ email }: { email?: string | null }) {
       /* ignore — no attestation this page load */
     };
     document.head.appendChild(script);
-  }, [key, email, origin]);
+  }, [key, email, origin, firstSignIn]);
 
   return null;
 }

--- a/lib/letterprove.test.ts
+++ b/lib/letterprove.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { isFirstSignIn } from "./letterprove";
+
+describe("isFirstSignIn", () => {
+  // Supabase stamps both fields in the same request at signup, so they
+  // coincide exactly once in an account's life.
+  it("is true when the account was created by this very sign-in", () => {
+    expect(
+      isFirstSignIn({
+        created_at: "2026-08-17T17:28:32.058221Z",
+        last_sign_in_at: "2026-08-17T17:28:32.228147Z",
+      }),
+    ).toBe(true);
+  });
+
+  it("is false on every sign-in after the first", () => {
+    expect(
+      isFirstSignIn({
+        created_at: "2026-08-17T17:28:32.058221Z",
+        last_sign_in_at: "2026-08-18T09:04:11.000000Z",
+      }),
+    ).toBe(false);
+  });
+
+  // A signup counts as one signup forever. Reporting it again a minute later
+  // would be a fabricated event, which is the one thing this pipeline must not
+  // produce.
+  it("is false once even a minute has passed", () => {
+    expect(
+      isFirstSignIn({
+        created_at: "2026-08-17T17:28:32.000Z",
+        last_sign_in_at: "2026-08-17T17:29:32.000Z",
+      }),
+    ).toBe(false);
+  });
+
+  it("tolerates the two writes not landing in the same instant", () => {
+    expect(
+      isFirstSignIn({
+        created_at: "2026-08-17T17:28:32.000Z",
+        last_sign_in_at: "2026-08-17T17:28:36.000Z",
+      }),
+    ).toBe(true);
+  });
+
+  // Missing or unparseable timestamps must read as "not a signup". Guessing
+  // upward invents an event; guessing downward loses one, and only the first
+  // is a false claim.
+  it("refuses to guess when the record is incomplete", () => {
+    expect(isFirstSignIn({})).toBe(false);
+    expect(isFirstSignIn({ created_at: "2026-08-17T17:28:32Z" })).toBe(false);
+    expect(isFirstSignIn({ created_at: "2026-08-17T17:28:32Z", last_sign_in_at: null })).toBe(false);
+    expect(isFirstSignIn({ created_at: "not-a-date", last_sign_in_at: "also-not" })).toBe(false);
+  });
+});

--- a/lib/letterprove.ts
+++ b/lib/letterprove.ts
@@ -1,0 +1,35 @@
+/**
+ * Letterprove integration helpers that are not React.
+ *
+ * Lives here rather than beside the client component because the dashboard
+ * layout is a SERVER component: it needs this to decide which event the page
+ * load should report, and a server file importing a "use client" module for a
+ * pure function is a needless boundary crossing.
+ */
+
+/**
+ * Whether this is the account's first-ever sign-in.
+ *
+ * Supabase stamps `created_at` and `last_sign_in_at` together at signup and
+ * only advances the latter on subsequent sign-ins, so they coincide exactly
+ * once in an account's life. Computed on the server because it needs the auth
+ * record, and derived rather than stored because the alternative — a column —
+ * duplicates state the auth server already holds correctly.
+ *
+ * This covers OAuth and password identically, which matters: the login form
+ * knows whether the person pressed "sign up", but for OAuth that intent is
+ * meaningless — Supabase creates the account either way, so a first-time
+ * Google user pressing "sign in" is still a signup.
+ */
+export function isFirstSignIn(user: {
+  created_at?: string;
+  last_sign_in_at?: string | null;
+}): boolean {
+  if (!user.created_at || !user.last_sign_in_at) return false;
+  const created = Date.parse(user.created_at);
+  const signedIn = Date.parse(user.last_sign_in_at);
+  if (Number.isNaN(created) || Number.isNaN(signedIn)) return false;
+  // Seconds, not milliseconds: the two writes happen in one request but not in
+  // one instant.
+  return Math.abs(signedIn - created) < 10_000;
+}


### PR DESCRIPTION
Only `session` was ever fired — the integration called `identify()` and nothing else. So two of Letterprove's four phase-1 signals have never produced a single row, and every published tier is capped at what a session alone can earn.

My omission from #118; this closes it.

## Which call fires

| when | call |
|---|---|
| first load of a browser session, first-ever sign-in | `signup()` |
| first load of a browser session, otherwise | `login()` |
| every load after that | `identify()` |

`signup()` and `login()` both call `identify()` internally, so the domain is established whichever branch runs, and `attest.js` still counts exactly one session per page load on its own.

## Why the server decides "is this a signup"

`isFirstSignIn` derives from the auth record instead of storing a flag: Supabase stamps `created_at` and `last_sign_in_at` together at signup and only advances the latter afterwards, so they coincide exactly once in an account's life.

That covers **OAuth and password identically**, which is the part worth checking. The login form knows whether someone pressed "sign up" — but for OAuth that intent is meaningless, since Supabase creates the account either way. A first-time Google user pressing "sign in" is still a signup, and an intent-based hook would have mislabelled every one of them.

## Why the session guard matters

Without it the counts inflate two different ways: a refresh reads as a second login, and the first-sign-in condition stays true for the whole of that first session — so it would report a signup on *every page* of it.

## Both fallbacks under-report on purpose

Storage unavailable (private mode, blocked cookies) and an incomplete auth record both resolve to `identify()` / `false`. A missing row is a gap; an invented one is a false claim, and this is the wrong product to guess upward in.

## Verification

696 tests pass (was 691), `tsc` and `next build` clean. Five new tests on `isFirstSignIn` covering the same-request stamp, every later sign-in, the one-minute-later case, clock slop between the two writes, and incomplete records.

`isFirstSignIn` sits in `lib/` rather than beside the component because the dashboard layout is a server component, and a server file importing a `"use client"` module for a pure function is a needless boundary crossing.

## After deploy

`hot_events` should start showing `login` alongside `session`, and `signup` the next time someone new joins. Right now it's 29 rows, all `session`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/126"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789590203&installation_model_id=431526&pr_number=126&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F126&signature=ab9559f0fa206340c19f46387fdc7487f66aa484a19100bbfdc39476f7d90e76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->