### PR TITLE
feat(letterprove): alert when we stop reporting usage

### DIFF
--- a/app/api/cron/letterprove-health/route.test.ts
+++ b/app/api/cron/letterprove-health/route.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GET } from "./route";
+
+vi.mock("@/lib/notify", () => ({ sendAdminAlert: vi.fn() }));
+
+const SECRET = "cron-secret";
+
+function req(auth = `Bearer ${SECRET}`) {
+  return new Request("https://lettertrace.com/api/cron/letterprove-health", {
+    headers: { authorization: auth },
+  });
+}
+
+/** 200 for the script, and whatever is given for the config probe. */
+function respondWith(statuses: Record<string, number>) {
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = String(input);
+    const match = Object.keys(statuses).find((k) => url.includes(k));
+    return new Response("", { status: match ? statuses[match] : 200 });
+  });
+}
+
+describe("GET /api/cron/letterprove-health", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = SECRET;
+    process.env.NEXT_PUBLIC_LETTERPROVE_KEY = "lp_live_test";
+    delete process.env.NEXT_PUBLIC_LETTERPROVE_ORIGIN;
+  });
+  afterEach(() => {
+    delete process.env.NEXT_PUBLIC_LETTERPROVE_KEY;
+    vi.restoreAllMocks();
+  });
+
+  it("refuses an unauthenticated caller", async () => {
+    const res = await GET(req("Bearer wrong"));
+    expect(res.status).toBe(401);
+  });
+
+  // A deployment that doesn't report — a self-hoster, a preview — has nothing
+  // to check and nobody to bother.
+  it("does nothing when no key is configured", async () => {
+    delete process.env.NEXT_PUBLIC_LETTERPROVE_KEY;
+    const { sendAdminAlert } = await import("@/lib/notify");
+    const body = await (await GET(req())).json();
+    expect(body.status).toBe("not-configured");
+    expect(sendAdminAlert).not.toHaveBeenCalled();
+  });
+
+  it("stays quiet while both endpoints are reachable", async () => {
+    respondWith({});
+    const { sendAdminAlert } = await import("@/lib/notify");
+    const body = await (await GET(req())).json();
+    expect(body.status).toBe("healthy");
+    expect(sendAdminAlert).not.toHaveBeenCalled();
+  });
+
+  // The actual 2026-08-14 failure: the script URL started 404ing after
+  // Letterprove moved domains.
+  it("alerts when the script 404s, naming the URL that failed", async () => {
+    respondWith({ "attest.js": 404 });
+    const { sendAdminAlert } = await import("@/lib/notify");
+
+    const body = await (await GET(req())).json();
+    expect(body.status).toBe("unhealthy");
+    expect(sendAdminAlert).toHaveBeenCalledTimes(1);
+
+    const alert = vi.mocked(sendAdminAlert).mock.calls[0][0];
+    expect(alert.body).toContain("attest.js");
+    expect(alert.body).toContain("404");
+    expect(alert.body).toContain("app.letterprove.com");
+  });
+
+  it("alerts when the collector rejects our key", async () => {
+    respondWith({ "/api/v1/config": 404 });
+    const { sendAdminAlert } = await import("@/lib/notify");
+    const body = await (await GET(req())).json();
+    expect(body.status).toBe("unhealthy");
+    expect(vi.mocked(sendAdminAlert).mock.calls[0][0].body).toContain("config");
+  });
+
+  // A redirect is not a pass. attest.js derives its collector origin from its
+  // own src, so a script served from somewhere else reports somewhere else.
+  it("treats a redirect as a failure rather than following it", async () => {
+    respondWith({ "attest.js": 307 });
+    const body = await (await GET(req())).json();
+    expect(body.status).toBe("unhealthy");
+  });
+
+  it("alerts when the host is unreachable entirely", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("ENOTFOUND"));
+    const { sendAdminAlert } = await import("@/lib/notify");
+    const body = await (await GET(req())).json();
+    expect(body.status).toBe("unhealthy");
+    expect(vi.mocked(sendAdminAlert).mock.calls[0][0].body).toContain("ENOTFOUND");
+  });
+
+  // 200 even when unhealthy: the cron ran and reported correctly. Conflating
+  // "the integration is down" with "the check itself broke" is how a monitor
+  // starts getting ignored.
+  it("returns 200 for a successful check that found a problem", async () => {
+    respondWith({ "attest.js": 500 });
+    expect((await GET(req())).status).toBe(200);
+  });
+});

--- a/app/api/cron/letterprove-health/route.ts
+++ b/app/api/cron/letterprove-health/route.ts
@@ -1,0 +1,119 @@
+import crypto from "node:crypto";
+import { NextResponse } from "next/server";
+import { sendAdminAlert } from "@/lib/notify";
+import { letterproveOrigin } from "@/lib/letterprove";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Is our Letterprove integration still actually reporting?
+ *
+ * On 2026-08-14 it stopped for 65 hours and nothing said so. Letterprove had
+ * moved to its own domain and the `*.vercel.app` alias we pointed at began
+ * returning 404, so attest.js never loaded. Telemetry fails silently by design
+ * — correctly, since it must never break a page — and the `x-letterprove`
+ * diagnostic header only exists once a request is made, which a 404 on the
+ * script prevents. The only symptom was a table that stopped growing, which is
+ * indistinguishable from nobody signing in.
+ *
+ * So this checks the thing that actually broke: it fetches the exact URLs the
+ * browser will use and reports when they are not reachable.
+ *
+ * WHY THIS LIVES HERE AND NOT IN LETTERPROVE. Letterprove's own /attest.js was
+ * healthy for every one of those 65 hours — at its new address. What was
+ * broken was *our reference to the old one*. A canary inside Letterprove
+ * checking itself would have stayed green throughout. Only the consumer can
+ * detect a consumer-side misconfiguration, which is the whole lesson of that
+ * outage.
+ *
+ * Deliberately NOT an alert on event volume. The outage began on a Friday
+ * night and the weekend legitimately looks quiet: any freshness threshold
+ * short enough to catch it would cry wolf on every slow evening, and any
+ * threshold long enough to stay silent over a weekend would not have fired
+ * until Sunday. Volume infers breakage from absence of users; this observes
+ * breakage directly.
+ */
+function authorized(header: string | null, secret: string | undefined): boolean {
+  if (!header || !secret) return false;
+  const a = Buffer.from(header);
+  const b = Buffer.from(`Bearer ${secret}`);
+  return a.length === b.length && crypto.timingSafeEqual(a, b);
+}
+
+interface Probe {
+  what: string;
+  url: string;
+  ok: boolean;
+  status: number | null;
+  detail?: string;
+}
+
+const TIMEOUT_MS = 10_000;
+
+async function probe(what: string, url: string): Promise<Probe> {
+  try {
+    const res = await fetch(url, {
+      redirect: "manual",
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+      cache: "no-store",
+    });
+    // A redirect is a failure, not a pass: attest.js derives its collector
+    // origin from its own `src`, so a script served from somewhere else
+    // reports somewhere else.
+    return { what, url, ok: res.status === 200, status: res.status };
+  } catch (e) {
+    return {
+      what,
+      url,
+      ok: false,
+      status: null,
+      detail: e instanceof Error ? e.message : String(e),
+    };
+  }
+}
+
+async function handle(request: Request) {
+  if (!authorized(request.headers.get("authorization"), process.env.CRON_SECRET)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const key = process.env.NEXT_PUBLIC_LETTERPROVE_KEY;
+  // No key means this deployment does not report at all — a self-hoster, or a
+  // preview. Nothing to check, and nothing to alert anyone about.
+  if (!key) return NextResponse.json({ status: "not-configured" });
+
+  const origin = letterproveOrigin();
+  const probes = await Promise.all([
+    probe("script", `${origin}/attest.js`),
+    probe("config", `${origin}/api/v1/config?k=${encodeURIComponent(key)}`),
+  ]);
+
+  const failed = probes.filter((p) => !p.ok);
+  if (failed.length > 0) {
+    const lines = failed.map((p) => `  ${p.what}: ${p.url} -> ${p.detail ?? `HTTP ${p.status}`}`);
+    await sendAdminAlert({
+      subject: "Lettertrace is not reporting usage to Letterprove",
+      body: [
+        "The Letterprove integration is unreachable, so no usage is being recorded.",
+        "",
+        ...lines,
+        "",
+        `Configured origin: ${origin}`,
+        "Set NEXT_PUBLIC_LETTERPROVE_ORIGIN if Letterprove has moved, then redeploy —",
+        "the origin is read at build time.",
+      ].join("\n"),
+    });
+  }
+
+  // 200 even when a probe fails: the cron ran and reported correctly. A 500
+  // here would mean "the check itself broke", and conflating the two is how a
+  // monitor starts getting ignored.
+  return NextResponse.json({
+    status: failed.length ? "unhealthy" : "healthy",
+    origin,
+    probes,
+  });
+}
+
+export const GET = handle;
+export const POST = handle;

--- a/components/letterprove-attest.tsx
+++ b/components/letterprove-attest.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
+import { letterproveOrigin } from "@/lib/letterprove";
 
 /**
  * Letterprove usage attestation.
@@ -31,18 +32,6 @@ import { useEffect } from "react";
 
 const SCRIPT_ID = "letterprove-attest";
 
-/**
- * Letterprove's own custom domain — deliberately NOT a `*.vercel.app` alias.
- *
- * This defaulted to `letterprove.vercel.app`, which broke collection silently:
- * that alias has moved between Letterprove projects more than once and now
- * 404s entirely, so the script simply never loaded. Because telemetry fails
- * quietly by design, nothing surfaced it — the only symptom was `hot_events`
- * staying flat for two and a half days.
- *
- * A generated alias is not a stable contract. Point at a domain someone owns.
- */
-const DEFAULT_ORIGIN = "https://app.letterprove.com";
 
 declare global {
   interface Window {
@@ -88,7 +77,7 @@ export function LetterproveAttest({
   firstSignIn?: boolean;
 }) {
   const key = process.env.NEXT_PUBLIC_LETTERPROVE_KEY;
-  const origin = process.env.NEXT_PUBLIC_LETTERPROVE_ORIGIN ?? DEFAULT_ORIGIN;
+  const origin = letterproveOrigin();
 
   useEffect(() => {
     if (!key || !email) return;

--- a/lib/letterprove.test.ts
+++ b/lib/letterprove.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { isFirstSignIn } from "./letterprove";
+import { afterEach, describe, expect, it } from "vitest";
+import { isFirstSignIn, letterproveOrigin } from "./letterprove";
 
 describe("isFirstSignIn", () => {
   // Supabase stamps both fields in the same request at signup, so they
@@ -51,5 +51,25 @@ describe("isFirstSignIn", () => {
     expect(isFirstSignIn({ created_at: "2026-08-17T17:28:32Z" })).toBe(false);
     expect(isFirstSignIn({ created_at: "2026-08-17T17:28:32Z", last_sign_in_at: null })).toBe(false);
     expect(isFirstSignIn({ created_at: "not-a-date", last_sign_in_at: "also-not" })).toBe(false);
+  });
+});
+
+describe("letterproveOrigin", () => {
+  const saved = process.env.NEXT_PUBLIC_LETTERPROVE_ORIGIN;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.NEXT_PUBLIC_LETTERPROVE_ORIGIN;
+    else process.env.NEXT_PUBLIC_LETTERPROVE_ORIGIN = saved;
+  });
+
+  // Not a *.vercel.app alias. One of those moved between projects and started
+  // 404ing, which is how collection died silently for 65 hours.
+  it("defaults to Letterprove's own domain", () => {
+    delete process.env.NEXT_PUBLIC_LETTERPROVE_ORIGIN;
+    expect(letterproveOrigin()).toBe("https://app.letterprove.com");
+  });
+
+  it("can be pointed elsewhere", () => {
+    process.env.NEXT_PUBLIC_LETTERPROVE_ORIGIN = "https://staging.example";
+    expect(letterproveOrigin()).toBe("https://staging.example");
   });
 });

--- a/lib/letterprove.ts
+++ b/lib/letterprove.ts
@@ -33,3 +33,20 @@ export function isFirstSignIn(user: {
   // one instant.
   return Math.abs(signedIn - created) < 10_000;
 }
+
+/**
+ * Letterprove's own custom domain — deliberately NOT a `*.vercel.app` alias.
+ *
+ * The default was `letterprove.vercel.app`, which broke collection silently:
+ * that alias has moved between Letterprove projects more than once and now
+ * 404s entirely, so the script never loaded and nothing said so.
+ *
+ * Shared by the browser component and the health canary ON PURPOSE. If the two
+ * ever read different values, the canary would be checking a URL nobody uses
+ * and would stay green through exactly the outage it exists to catch.
+ */
+const DEFAULT_ORIGIN = "https://app.letterprove.com";
+
+export function letterproveOrigin(): string {
+  return process.env.NEXT_PUBLIC_LETTERPROVE_ORIGIN ?? DEFAULT_ORIGIN;
+}

--- a/vercel.json
+++ b/vercel.json
@@ -4,6 +4,10 @@
     {
       "path": "/api/cron/run",
       "schedule": "0 8 * * *"
+    },
+    {
+      "path": "/api/cron/letterprove-health",
+      "schedule": "0 */6 * * *"
     }
   ]
 }


### PR DESCRIPTION
Collection stopped for 65 hours on 2026-08-14 and nothing told us. This is the check that would have caught it.

## Why nothing caught it

Letterprove moved to its own domain; the `*.vercel.app` alias we pointed at began 404ing, so `attest.js` never loaded. Telemetry fails silently by design — correctly, it must never break a page — and the `x-letterprove` diagnostic header only exists **once a request is made**, which a 404 on the script prevents. The only symptom was a table that stopped growing, which is indistinguishable from nobody signing in.

## Why it lives here, not in Letterprove

This is the part worth checking. **Letterprove's own `/attest.js` was healthy for every one of those 65 hours** — at its new address. What was broken was *our reference to the old one*. A canary inside Letterprove checking itself would have stayed green throughout.

Only the consumer can detect a consumer-side misconfiguration.

## Why not an alert on event volume

That was my first instinct and it's wrong. The outage began on a Friday night, and a weekend legitimately looks quiet: any freshness threshold short enough to catch it would cry wolf on every slow evening, and any threshold long enough to survive a weekend wouldn't have fired until Sunday. Volume *infers* breakage from absence of users. This observes it directly.

## Verified against the real deployment, both ways

Healthy today:

```json
{"status":"healthy","origin":"https://app.letterprove.com",
 "probes":[{"what":"script","status":200},{"what":"config","status":200}]}
```

And pointed at the alias that actually caused the outage:

```json
{"status":"unhealthy","origin":"https://letterprove.vercel.app",
 "probes":[{"what":"script","status":404},{"what":"config","status":404}]}
```

## Three details worth a look

**`letterproveOrigin()` is now shared** by the browser component and the canary. If those ever read different values, the canary would check a URL nobody uses and stay green through exactly the outage it exists to catch.

**A redirect is a failure, not a pass.** `attest.js` derives its collector origin from its own `src`, so a script served from somewhere else reports somewhere else.

**A failed probe still returns 200.** The cron ran and reported correctly; conflating "the integration is down" with "the check itself broke" is how a monitor starts getting ignored.

Runs every 6 hours — no dedup state needed, and a broken integration becomes four nudges a day rather than twenty-four. Inert when no key is configured, so self-hosters and previews never alert.

706 tests pass (was 696), `tsc` and `next build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789592824&installation_model_id=431526&pr_number=127&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F127&signature=fc776b932ad3672291a836dc57b8ba59dadd629364594125a52716c4d78d6a01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->