### PR TITLE
feat(trial): fund the free tier through one Concentrate key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,6 +93,12 @@ TRIAL_ANTHROPIC_API_KEY=
 TRIAL_OPENAI_API_KEY=
 TRIAL_GOOGLE_API_KEY=
 TRIAL_PERPLEXITY_API_KEY=
+# Or fund the free tier with ONE Concentrate (router) key: it routes the engines
+# Concentrate serves — Claude, GPT, Gemini — through the gateway (one capped key,
+# discount, clean attribution) instead of a direct key per provider. Engines it
+# can't serve still need their own trial key above: Google AI Overviews
+# (TRIAL_GOOGLE_API_KEY) and Perplexity (TRIAL_PERPLEXITY_API_KEY).
+TRIAL_CONCENTRATE_API_KEY=
 # Free monitoring runs per user before they must add their own key (default 5).
 # THIS is the configurable trial threshold. Consumed atomically at run start.
 TRIAL_RUN_LIMIT=5

--- a/lib/trial.test.ts
+++ b/lib/trial.test.ts
@@ -71,6 +71,7 @@ const TRIAL_VARS = [
   "TRIAL_OPENAI_MODEL",
   "TRIAL_GOOGLE_MODEL",
   "TRIAL_RUN_LIMIT",
+  "TRIAL_CONCENTRATE_API_KEY",
 ] as const;
 
 let saved: Record<string, string | undefined>;
@@ -644,5 +645,51 @@ describe("the free-tier spend ceiling", () => {
     } as never;
     const key = await resolveKey(legacy, "u1", "anthropic");
     expect(key.source).toBe("trial");
+  });
+});
+
+// The free tier can be funded by one shared Concentrate key instead of four
+// direct provider keys: it routes the engines Concentrate serves through the
+// gateway (one capped key, discount) and falls back to per-provider trial keys
+// for the engines it can't (AI Overviews, Perplexity).
+describe("free tier through a shared Concentrate key", () => {
+  it("routes a served engine through Concentrate", async () => {
+    process.env.TRIAL_CONCENTRATE_API_KEY = "sk-cn-trial";
+    const k = await runKeyFor(db(0), "user-1", "anthropic", "claude-opus-4-8", { webSearch: true });
+    expect(k.source).toBe("trial");
+    expect(k.apiKey).toBe("sk-cn-trial");
+    expect(k.route?.router).toBe("concentrate");
+  });
+
+  it("routes real Gemini through Concentrate", async () => {
+    process.env.TRIAL_CONCENTRATE_API_KEY = "sk-cn-trial";
+    const k = await runKeyFor(db(0), "user-1", "google", "gemini-flash-latest", { webSearch: true });
+    expect(k.source).toBe("trial");
+    expect(k.apiKey).toBe("sk-cn-trial");
+    expect(k.route?.router).toBe("concentrate");
+  });
+
+  it("falls back to a direct trial key for AI Overviews (Concentrate can't route it)", async () => {
+    process.env.TRIAL_CONCENTRATE_API_KEY = "sk-cn-trial";
+    process.env.TRIAL_GOOGLE_API_KEY = "trial-google";
+    const k = await runKeyFor(db(0), "user-1", "google", GOOGLE_AI_OVERVIEWS_MODEL, { webSearch: true });
+    expect(k.source).toBe("trial");
+    expect(k.apiKey).toBe("trial-google");
+    expect(k.route).toBeUndefined();
+  });
+
+  it("falls back to a direct trial key for Perplexity (not in Concentrate's catalog)", async () => {
+    process.env.TRIAL_CONCENTRATE_API_KEY = "sk-cn-trial";
+    process.env.TRIAL_PERPLEXITY_API_KEY = "trial-pplx";
+    const k = await runKeyFor(db(0), "user-1", "perplexity", undefined, { webSearch: true });
+    expect(k.source).toBe("trial");
+    expect(k.apiKey).toBe("trial-pplx");
+    expect(k.route).toBeUndefined();
+  });
+
+  it("enables the trial with only a Concentrate key set", () => {
+    expect(trialEnabled()).toBe(false);
+    process.env.TRIAL_CONCENTRATE_API_KEY = "sk-cn-trial";
+    expect(trialEnabled()).toBe(true);
   });
 });

--- a/lib/trial.ts
+++ b/lib/trial.ts
@@ -81,9 +81,47 @@ export function trialModelFor(provider: Provider, fallback: string): string {
   return v && v.trim() ? v.trim() : fallback;
 }
 
-/** True if a trial is offered for at least one provider. */
+/** The operator's shared Concentrate (router) key for free-tier runs (env:
+ *  TRIAL_CONCENTRATE_API_KEY). One capped gateway key can fund the whole free
+ *  tier for every engine Concentrate serves — Claude, GPT, Gemini — instead of a
+ *  direct key per provider. Engines it can't serve (AI Overviews, Perplexity)
+ *  still use their per-provider TRIAL_*_API_KEY. */
+export function trialConcentrateKey(): string | null {
+  const v = process.env.TRIAL_CONCENTRATE_API_KEY;
+  return v && v.trim() ? v.trim() : null;
+}
+
+/** Can the shared Concentrate trial key faithfully serve this (provider, model)?
+ *  Gated on the STATIC router capability, not a stored per-key verification (env
+ *  trial keys carry none — the operator is trusted to have confirmed the key on
+ *  the paid side). A grounded run needs passthrough search + a routable slug; an
+ *  ungrounded utility call just needs the router to reach the provider. */
+function concentrateTrialServes(provider: Provider, model: string, webSearch: boolean): boolean {
+  const support = routerSupport("concentrate", provider);
+  if (!support) return false;
+  if (routerSlug("concentrate", provider, model) === null) return false;
+  return webSearch ? support.search === "passthrough" : true;
+}
+
+/** The trial credential for a (provider, model): the shared Concentrate key +
+ *  route when it can serve the engine, else the per-provider direct trial key. */
+function trialCredFor(
+  provider: Provider,
+  model: string,
+  webSearch: boolean,
+): { apiKey: string; route?: RouteInfo } | null {
+  const cc = trialConcentrateKey();
+  if (cc && concentrateTrialServes(provider, model, webSearch)) {
+    return { apiKey: cc, route: { router: "concentrate", baseUrl: null } };
+  }
+  const direct = trialKeyFor(provider);
+  return direct ? { apiKey: direct } : null;
+}
+
+/** True if a trial is offered — either the shared Concentrate key or at least
+ *  one per-provider direct key. */
 export function trialEnabled(): boolean {
-  return PROVIDER_IDS.some((p) => trialKeyFor(p));
+  return !!trialConcentrateKey() || PROVIDER_IDS.some((p) => trialKeyFor(p));
 }
 
 /** How many free trial runs this user has already consumed. */
@@ -190,6 +228,8 @@ export interface ResolvedKey {
 
 /** The provider new projects default to: one we can actually serve (has a trial key), else anthropic. */
 export function pickDefaultProvider(): Provider {
+  // A Concentrate trial key serves Claude/GPT/Gemini, so it can fund the default.
+  if (trialConcentrateKey() && routerSupport("concentrate", "anthropic")) return "anthropic";
   if (trialKeyFor("anthropic")) return "anthropic";
   if (trialKeyFor("openai")) return "openai";
   if (trialKeyFor("google")) return "google";
@@ -262,13 +302,16 @@ export async function resolveKey(
   const usage = await getTrialUsage(supabase, userId);
   let trialConfigured = false;
   for (const p of order) {
-    const tk = trialKeyFor(p);
-    if (!tk) continue;
+    // Utility calls never search, so webSearch=false — Concentrate serves the
+    // engine whenever it has a slug for it; else the per-provider direct key.
+    const cred = trialCredFor(p, modelFor(p), false);
+    if (!cred) continue;
     trialConfigured = true;
     if (withinTrial(usage, limit, cap)) {
       return {
         source: "trial",
-        apiKey: tk,
+        apiKey: cred.apiKey,
+        ...(cred.route ? { route: cred.route } : {}),
         provider: p,
         model: trialModelFor(p, modelFor(p)),
         requested,
@@ -357,18 +400,22 @@ export async function resolveRunKeyFor(
     return { ...base, source: "own", apiKey: usable.apiKey, route: routeOf(usable) };
   }
 
-  // The operator's shared key, but only for the engine actually chosen.
+  // The operator's shared key, but only for the engine actually chosen. Prefer
+  // the Concentrate trial key (routes through the gateway — one capped key,
+  // discount) for engines it can serve; AI Overviews / Perplexity fall to their
+  // per-provider direct trial key.
   const limit = trialRunLimit();
   const cap = trialSpendLimitMicros();
-  const trialKey = trialKeyFor(provider);
+  const trialCred = trialCredFor(provider, requested.model, opts.webSearch);
   let trialUsage: TrialUsage | null = null;
-  if (trialKey) {
+  if (trialCred) {
     trialUsage = await getTrialUsage(supabase, userId);
     if (withinTrial(trialUsage, limit, cap)) {
       return {
         ...base,
         source: "trial",
-        apiKey: trialKey,
+        apiKey: trialCred.apiKey,
+        ...(trialCred.route ? { route: trialCred.route } : {}),
         // Still a substitution, but within the chosen provider: the answers
         // remain that assistant's, and `requested` carries the difference.
         model: trialModelFor(provider, requested.model),
@@ -410,7 +457,7 @@ export async function resolveRunKeyFor(
   const others = Array.from(new Set([...direct, ...viaRouters])).filter((p) => p !== provider);
   if (others.length > 0) return { ...base, source: "mismatch", available: others };
 
-  if (trialKey) {
+  if (trialCred) {
     const usage = trialUsage ?? (await getTrialUsage(supabase, userId));
     return {
       ...base,


### PR DESCRIPTION
## Why
The free tier (first N runs per new signup) is funded by operator keys — one **direct provider key per engine** (`TRIAL_*_API_KEY`), executed BYOK-style. This lets **one shared Concentrate key** fund it instead: the discount, a single hard spend cap, and clean cost attribution ("Lettertrace Free Tier" on the Concentrate dashboard).

## What
New `TRIAL_CONCENTRATE_API_KEY`. When set, free-tier runs route the engines Concentrate serves — **Claude, GPT, real Gemini** — through the gateway; engines it can't serve fall back to their per-provider trial key (**Google AI Overviews** — `routerSlug` null; **Perplexity** — not in the catalog).

- `trialConcentrateKey()` + `concentrateTrialServes()` + `trialCredFor()` pick, per `(provider, model, webSearch)`, whether the shared Concentrate key routes the run or a direct trial key does. Gated on the **static** router capability (env trial keys carry no stored `search_verified`; the operator confirms the key on the paid side).
- `resolveRunKeyFor` (probes) + `resolveKey` (utility) trial branches set `route: {concentrate}` when applicable — the dashboard run path (`app/api/runs/route.ts`) already threads `key.route` to the executor, and the API path stays BYOK-only.
- `trialEnabled()` + `pickDefaultProvider()` count the Concentrate key.
- `.env.example` documents it.

## Ops to enable
1. Mint one dedicated, **spend-capped** Concentrate key ("Lettertrace Free Tier").
2. Set `TRIAL_CONCENTRATE_API_KEY` in lettertrace's Vercel env.
3. Keep `TRIAL_GOOGLE_API_KEY` (AI Overviews) and `TRIAL_PERPLEXITY_API_KEY`.

## Tests
- 60 trial tests (5 new: served→route, Gemini→route, AI-Overviews→direct, Perplexity→direct, trialEnabled with only the Concentrate key).
- Full suite **701 passing** · `tsc` 0 · `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/128"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789593913&installation_model_id=431526&pr_number=128&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F128&signature=e6696e56d4ae3b58266b7e23d62dd4eb55637cdf9c542a461b9746be0b49d93e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->