### PR TITLE
fix(llm): route provider SDKs through undici so Concentrate grounded runs stop dropping

### DIFF
--- a/lib/llm/index.ts
+++ b/lib/llm/index.ts
@@ -23,11 +23,17 @@ import { normalizeCompetitorList } from "@/lib/competitors";
 const ANSWER_MAX_TOKENS = 1200;
 const UTILITY_MAX_TOKENS = 1500;
 
-// Provider APIs occasionally drop a keep-alive connection mid-response
-// ("Premature close" / "socket hang up"), especially under Node's fetch. Both
-// SDKs retry such transient connection errors with backoff; we raise the count
-// above the default (2) and set an explicit ceiling so a call can't hang.
-const CLIENT_OPTS = { maxRetries: 4, timeout: 60_000 } as const;
+// Both SDKs at these versions (@anthropic-ai/sdk 0.30, openai 4.x) default to
+// node-fetch, which throws "Premature close" reading some providers' response
+// bodies — most consistently the Concentrate gateway's GROUNDED Claude/Gemini
+// replies (large, multi-round web-search answers). Concentrate delivers and
+// BILLS them with a 200; node-fetch just can't read them to completion, while
+// curl and Node's built-in undici fetch read the identical bytes fine. Retries
+// don't help: it's ~100% for those routes, not transient, so every attempt
+// fails AND re-bills (maxRetries × the answer cost, for zero stored data).
+// Routing the SDKs through undici (globalThis.fetch) tolerates the framing and
+// fixes it. Keep the raised retry count + explicit timeout for genuine drops.
+const CLIENT_OPTS = { maxRetries: 4, timeout: 60_000, fetch: globalThis.fetch } as const;
 
 interface BaseCall {
   provider: Provider;


### PR DESCRIPTION
## Symptom
Grounded **Claude and Gemini** runs through the **Concentrate** router fail — `probe-router` and real monitored runs return *"Couldn't reach the AI provider (connection dropped)"*. OpenAI is unaffected.

## Root cause
`@anthropic-ai/sdk@0.30` and `openai@4.x` default to **node-fetch**, which throws `Invalid response body ... Premature close` while *reading the response body* of Concentrate's grounded Claude (`/v1/messages`) and Gemini (`/v1/chat/completions`) replies — large, multi-round web-search answers.

It is **not** Concentrate and **not** the network:
- Concentrate returns **`200` + full tokens + cost** for these (confirmed in its org logs).
- `curl` and Node's built-in **undici** `fetch` read the identical bytes fine.
- Only the SDKs' bundled **node-fetch** chokes.

The existing `CLIENT_OPTS` comment already anticipated *"Premature close … especially under Node's fetch"* and leaned on `maxRetries: 4` — but for these routes it's **~100%, not transient**, so retries don't help and each attempt **re-bills** (200+cost × 5) for zero stored data.

## Fix
Pass `fetch: globalThis.fetch` (undici) via `CLIENT_OPTS`, which every Anthropic/OpenAI client spreads. One line + comment.

## Verification (live Concentrate key, via `scripts/probe-router.ts`)
| Engine | before | after |
|---|---|---|
| `google/gemini-flash-latest` | connection dropped (6/6) | **grounded** |
| `anthropic/claude-sonnet-5` | connection dropped | **grounded** |
| `openai/*` | grounded | grounded (unchanged) |

- `tsc --noEmit`: clean
- `vitest run` (llm/routers/models): **170 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789658864&installation_model_id=431526&pr_number=129&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F129&signature=fc7cdc27677936279273879397ad34b2267ef40925feb8440fc4100c40584846"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->