### PR TITLE
feat(llm): make gpt-5.6 measurable — probe suite, token-param fix, loud empty-answer failures

### DIFF
--- a/lib/llm/index.ts
+++ b/lib/llm/index.ts
@@ -247,7 +247,13 @@ async function openaiChat(
   messages.push({ role: "user", content: user });
   const params = {
     model: plan ? plan.slug : model,
-    max_tokens: maxTokens,
+    // Not max_tokens: the gpt-5.6 family rejects it outright ("Unsupported
+    // parameter: 'max_tokens' ... Use 'max_completion_tokens' instead"), so the
+    // old field made every ungrounded 5.6 call a hard 400. Probed 2026-08-18:
+    // max_completion_tokens is accepted by gpt-4o, gpt-4o-mini and both 5.6
+    // models directly, and by Concentrate's chat surface for openai AND google
+    // slugs. (OpenRouter/Merge not re-probed; both mirror OpenAI's surface.)
+    max_completion_tokens: maxTokens,
     messages,
     ...(json ? { response_format: { type: "json_object" } } : {}),
     ...(plan?.extraBody ?? {}),
@@ -572,7 +578,10 @@ async function gatewayQuery(
   const client = new OpenAI({ apiKey, baseURL: plan.baseUrl, ...CLIENT_OPTS });
   const params = {
     model: plan.slug,
-    max_tokens: ANSWER_MAX_TOKENS,
+    // Same field as openaiChat, for the same reason: a routed gpt-5.6 call
+    // with max_tokens is a hard 400, and Concentrate accepts the newer field
+    // for every slug family probed (2026-08-18, openai + google).
+    max_completion_tokens: ANSWER_MAX_TOKENS,
     messages: [{ role: "user", content: prompt }],
     ...plan.extraBody,
   };
@@ -710,7 +719,21 @@ async function anthropicWebSearch(
 
 // OpenAI native web search via the Responses API. Uses raw fetch so it doesn't
 // depend on a newer SDK; retries a couple of transient failures. The browse is
-// forced via tool_choice (see below) — verified live for gpt-4o / gpt-4o-mini.
+// forced via tool_choice (see below) — verified live for gpt-4o / gpt-4o-mini,
+// and on 2026-08-18 for gpt-5.6-sol and gpt-5.6-luna, both direct and through
+// Concentrate's Responses mirror (see scripts/probe-openai-models.ts).
+//
+// Two things the 5.6 probes established that gpt-4o never showed:
+// - The 5.6 models run several search rounds plus reasoning per answer —
+//   30-60k total tokens per grounded query where gpt-4o spends ~500. That is
+//   a COST property, not a failure; it just makes trial metering and pricing
+//   assumptions written for gpt-4o an order of magnitude off.
+// - Citations are less reliable: a 5.6 answer can complete a forced browse
+//   (web_search_call items present) and still attach zero url_citation
+//   annotations, and the web_search_call items carry only the queries — no
+//   result URLs — so there is nothing to fall back to, unlike the Anthropic
+//   path's retrieved-but-not-cited results. Such an answer is still grounded;
+//   it is recorded with the sources it actually cited, possibly none.
 async function openaiWebSearch(
   apiKey: string,
   model: string,
@@ -721,8 +744,22 @@ async function openaiWebSearch(
   // below is unchanged, which is the point — a routed OpenAI measurement is the
   // same request as a direct one, forcing included.
   const url = plan ? `${plan.baseUrl}/responses` : "https://api.openai.com/v1/responses";
+
+  interface ResponsesBody {
+    status?: string;
+    incomplete_details?: { reason?: string };
+    output?: { content?: { type?: string; text?: string; annotations?: { url?: string; title?: string }[] }[] }[];
+    usage?: { total_tokens?: number; input_tokens?: number; output_tokens?: number };
+  }
+
+  // The transport retries; the parsing below does not. An answer that came back
+  // incomplete or empty is a deliverable the model produced and billed — on the
+  // 5.6 models a single grounded answer runs 30-60k tokens, so retrying a
+  // deterministic failure re-bills it for zero stored data (the same trap the
+  // node-fetch note on CLIENT_OPTS describes).
+  let j: ResponsesBody | undefined;
   let lastErr: unknown;
-  for (let attempt = 0; attempt < 3; attempt++) {
+  for (let attempt = 0; attempt < 3 && !j; attempt++) {
     try {
       const res = await fetch(url, {
         method: "POST",
@@ -747,31 +784,45 @@ async function openaiWebSearch(
         if (res.status >= 500) { lastErr = err; continue; }
         throw err;
       }
-      const j = (await res.json()) as {
-        output?: { content?: { type?: string; text?: string; annotations?: { url?: string; title?: string }[] }[] }[];
-        usage?: { total_tokens?: number; input_tokens?: number; output_tokens?: number };
-      };
-      let text = "";
-      const raw: CitedSource[] = [];
-      for (const item of j.output ?? []) {
-        for (const c of item.content ?? []) {
-          if (typeof c.text === "string") text += (text ? "\n" : "") + c.text;
-          for (const a of c.annotations ?? []) {
-            const s = a?.url ? safeSource(a.url, a.title ?? null, null) : null;
-            if (s) raw.push(s);
-          }
-        }
-      }
-      const tokens =
-        j.usage?.total_tokens ??
-        (j.usage?.input_tokens ?? 0) + (j.usage?.output_tokens ?? 0);
-      return { text: text.trim(), tokens, sources: dedupeSources(raw) };
+      j = (await res.json()) as ResponsesBody;
     } catch (err) {
       lastErr = err;
       if (err instanceof OpenAI.APIError && err.status && err.status < 500) throw err;
     }
   }
-  throw lastErr ?? new Error("OpenAI web search failed.");
+  if (!j) throw lastErr ?? new Error("OpenAI web search failed.");
+
+  let text = "";
+  const raw: CitedSource[] = [];
+  for (const item of j.output ?? []) {
+    for (const c of item.content ?? []) {
+      if (typeof c.text === "string") text += (text ? "\n" : "") + c.text;
+      for (const a of c.annotations ?? []) {
+        const s = a?.url ? safeSource(a.url, a.title ?? null, null) : null;
+        if (s) raw.push(s);
+      }
+    }
+  }
+  const tokens =
+    j.usage?.total_tokens ??
+    (j.usage?.input_tokens ?? 0) + (j.usage?.output_tokens ?? 0);
+
+  // A 200 that carries nothing measurable must fail loudly — the same stance
+  // as the Gemini and Perplexity adapters, for the same reason: a stored empty
+  // or truncated answer scans as "brand not mentioned" rather than "we never
+  // got an answer". The 5.6 models make both shapes real: reasoning draws from
+  // max_output_tokens, so a budget spent thinking and searching ends the
+  // response with status "incomplete", and what text survived is a fragment,
+  // not the answer.
+  if (j.status === "incomplete") {
+    throw new Error(
+      `OpenAI stopped before finishing the answer (${j.incomplete_details?.reason ?? "incomplete"}).`,
+    );
+  }
+  if (!text.trim()) {
+    throw new Error("OpenAI returned an empty answer.");
+  }
+  return { text: text.trim(), tokens, sources: dedupeSources(raw) };
 }
 
 // --- Google (Gemini) low-level chat + grounding ---------------------------

--- a/lib/llm/openai.test.ts
+++ b/lib/llm/openai.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi } from "vitest";
+
+// ------------------------------------------------------------------
+// OpenAI adapter. Everything here runs against a mocked fetch — the point is
+// the request we build and the responses we survive, not OpenAI's behaviour.
+// Live behaviour is probed separately (scripts/probe-openai-models.ts).
+//
+// The bugs this is guarding against are the ones the 2026-08-18 gpt-5.6 probes
+// surfaced: a chat call carrying a max-tokens field the model family rejects,
+// a grounded answer that comes back incomplete or empty and would be stored as
+// a measurement, and an expensive deterministic failure being retried and
+// re-billed as if it were transient.
+// ------------------------------------------------------------------
+
+// The SDK-backed chat path captures globalThis.fetch once, at module load
+// (CLIENT_OPTS), so the mock has to be a stable delegator installed BEFORE the
+// adapter is imported; each test then swaps what it delegates to.
+let currentFetch: (url: unknown, init?: unknown) => Promise<Response> = async () => {
+  throw new Error("test made an unmocked network call");
+};
+vi.stubGlobal("fetch", (url: unknown, init?: unknown) => currentFetch(url, init));
+
+const { runQuery, humanError } = await import("./index");
+
+const KEY = "sk-test-key";
+
+/** Queue of {status, body} responses; the last repeats once exhausted. A fresh
+ *  Response is constructed per call — bodies can only be read once. */
+let calls: { url: string; body: Record<string, any> }[] = [];
+function mockFetch(...responses: { status?: number; body: unknown }[]) {
+  calls = [];
+  let i = 0;
+  currentFetch = async (url, init) => {
+    const req = init as { body?: string } | undefined;
+    calls.push({ url: String(url), body: req?.body ? JSON.parse(req.body) : {} });
+    const r = responses[Math.min(i++, responses.length - 1)];
+    return new Response(JSON.stringify(r.body), {
+      status: r.status ?? 200,
+      headers: { "content-type": "application/json" },
+    });
+  };
+}
+
+/** A successful Responses-API body, shaped the way the 5.6 models answer:
+ *  web_search_call and reasoning items (no content) ahead of the message. */
+function responsesOk(
+  text: string,
+  annotations: { url?: string; title?: string }[] = [],
+  extra: Record<string, unknown> = {},
+) {
+  return {
+    status: "completed",
+    output: [
+      { type: "web_search_call", status: "completed", action: { type: "search" } },
+      { type: "reasoning", summary: [] },
+      { type: "message", content: [{ type: "output_text", text, annotations }] },
+    ],
+    usage: { total_tokens: 42 },
+    ...extra,
+  };
+}
+
+function chatOk(text: string, totalTokens = 21) {
+  return {
+    choices: [{ message: { role: "assistant", content: text } }],
+    usage: { total_tokens: totalTokens },
+  };
+}
+
+// --- Grounded path (Responses API) — request shape --------------------------
+
+describe("openai runQuery with web search — request shape", () => {
+  it("posts to the Responses API with the browse forced", async () => {
+    mockFetch({ body: responsesOk("answer") });
+    await runQuery({ provider: "openai", model: "gpt-5.6-sol", apiKey: KEY, prompt: "q", webSearch: true });
+
+    expect(calls[0].url).toBe("https://api.openai.com/v1/responses");
+    expect(calls[0].body.model).toBe("gpt-5.6-sol");
+    expect(calls[0].body.tools).toEqual([{ type: "web_search_preview" }]);
+    expect(calls[0].body.tool_choice).toEqual({ type: "web_search_preview" });
+    expect(calls[0].body.input).toBe("q");
+    expect(calls[0].body.max_output_tokens).toBeGreaterThan(0);
+  });
+
+  it("routes through Concentrate's Responses mirror with the router slug, body otherwise identical", async () => {
+    mockFetch({ body: responsesOk("answer") });
+    await runQuery({
+      provider: "openai",
+      model: "gpt-5.6-sol",
+      apiKey: KEY,
+      route: { router: "concentrate", baseUrl: null },
+      prompt: "q",
+      webSearch: true,
+    });
+
+    expect(calls[0].url).toBe("https://api.concentrate.ai/v1/responses");
+    expect(calls[0].body.model).toBe("openai/gpt-5.6-sol");
+    expect(calls[0].body.tool_choice).toEqual({ type: "web_search_preview" });
+  });
+});
+
+// --- Grounded path — response parsing ---------------------------------------
+
+describe("openai runQuery with web search — parsing", () => {
+  it("collects text and cited sources across output items, skipping tool/reasoning items", async () => {
+    mockFetch({
+      body: responsesOk("the answer", [
+        { url: "https://www.example.com/a", title: "A" },
+        { url: "https://example.com/a", title: "dupe of A" },
+        { url: "https://other.org/b", title: "B" },
+        { url: "javascript:alert(1)", title: "unsafe" },
+      ]),
+    });
+    const res = await runQuery({ provider: "openai", model: "gpt-4o", apiKey: KEY, prompt: "q", webSearch: true });
+
+    expect(res.text).toBe("the answer");
+    expect(res.tokens).toBe(42);
+    // www stripped for the domain, per-URL dedupe keeps both distinct URLs of
+    // example.com, the javascript: citation is dropped entirely.
+    expect(res.sources.map((s) => s.url)).toEqual([
+      "https://www.example.com/a",
+      "https://example.com/a",
+      "https://other.org/b",
+    ]);
+    expect(res.sources[0].domain).toBe("example.com");
+  });
+
+  it("returns zero sources for a searched-but-uncited answer rather than failing it", async () => {
+    // Measured on gpt-5.6-luna: a forced browse can complete its searches and
+    // still attach no url_citation annotations. The answer is still grounded;
+    // there is nothing to fall back to (web_search_call carries only queries).
+    mockFetch({ body: responsesOk("uncited but real answer") });
+    const res = await runQuery({ provider: "openai", model: "gpt-5.6-luna", apiKey: KEY, prompt: "q", webSearch: true });
+
+    expect(res.text).toBe("uncited but real answer");
+    expect(res.sources).toEqual([]);
+  });
+
+  it("sums input+output tokens when total_tokens is absent", async () => {
+    const body = responsesOk("answer");
+    body.usage = { input_tokens: 30, output_tokens: 12 } as never;
+    mockFetch({ body });
+    const res = await runQuery({ provider: "openai", model: "gpt-4o", apiKey: KEY, prompt: "q", webSearch: true });
+
+    expect(res.tokens).toBe(42);
+  });
+});
+
+// --- Grounded path — the answers that must fail loudly ----------------------
+
+describe("openai runQuery with web search — unmeasurable answers", () => {
+  it("fails an incomplete answer instead of storing the fragment, without retrying", async () => {
+    // Reasoning draws from max_output_tokens on the 5.6 models, so a spent
+    // budget ends the response with status "incomplete" and fragment text.
+    mockFetch({
+      body: responsesOk("truncated fragm", [], {
+        status: "incomplete",
+        incomplete_details: { reason: "max_output_tokens" },
+      }),
+    });
+    await expect(
+      runQuery({ provider: "openai", model: "gpt-5.6-sol", apiKey: KEY, prompt: "q", webSearch: true }),
+    ).rejects.toThrow(/stopped before finishing.*max_output_tokens/);
+    // Deterministic and already billed (30-60k tokens on 5.6) — one attempt only.
+    expect(calls).toHaveLength(1);
+  });
+
+  it("fails an empty answer instead of storing it, without retrying", async () => {
+    mockFetch({ body: responsesOk("") });
+    await expect(
+      runQuery({ provider: "openai", model: "gpt-4o", apiKey: KEY, prompt: "q", webSearch: true }),
+    ).rejects.toThrow(/empty answer/);
+    expect(calls).toHaveLength(1);
+  });
+});
+
+// --- Grounded path — transport ----------------------------------------------
+
+describe("openai runQuery with web search — transport", () => {
+  it("retries a 5xx and succeeds on the next attempt", async () => {
+    mockFetch({ status: 502, body: { error: { message: "bad gateway" } } }, { body: responsesOk("answer") });
+    const res = await runQuery({ provider: "openai", model: "gpt-4o", apiKey: KEY, prompt: "q", webSearch: true });
+
+    expect(res.text).toBe("answer");
+    expect(calls).toHaveLength(2);
+  });
+
+  it("surfaces a 401 immediately as an invalid key", async () => {
+    mockFetch({ status: 401, body: { error: { message: "bad key" } } });
+    const err = await runQuery({
+      provider: "openai",
+      model: "gpt-4o",
+      apiKey: KEY,
+      prompt: "q",
+      webSearch: true,
+    }).catch((e) => e);
+
+    expect(humanError(err)).toBe("Invalid API key.");
+    expect(calls).toHaveLength(1);
+  });
+});
+
+// --- Ungrounded path (chat completions) -------------------------------------
+
+describe("openai runQuery without web search — chat completions", () => {
+  it("sends max_completion_tokens, never max_tokens", async () => {
+    // The gpt-5.6 family rejects max_tokens with a hard 400 ("Use
+    // 'max_completion_tokens' instead"), so the old field made every
+    // ungrounded 5.6 run fail. Probed accepted on gpt-4o/-mini and both 5.6
+    // models, direct and through Concentrate.
+    mockFetch({ body: chatOk("Paris") });
+    const res = await runQuery({ provider: "openai", model: "gpt-5.6-sol", apiKey: KEY, prompt: "q", webSearch: false });
+
+    expect(calls[0].url).toBe("https://api.openai.com/v1/chat/completions");
+    expect(calls[0].body.model).toBe("gpt-5.6-sol");
+    expect(calls[0].body.max_completion_tokens).toBeGreaterThan(0);
+    expect(calls[0].body).not.toHaveProperty("max_tokens");
+    expect(res.text).toBe("Paris");
+    expect(res.tokens).toBe(21);
+    expect(res.sources).toEqual([]);
+  });
+});

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -51,7 +51,10 @@ export const PROVIDERS: Record<Provider, ProviderInfo> = {
     // moving the default is a deliberate cut-over, not a freshen. The 5.6
     // entries are what ChatGPT actually serves consumers today; nothing is
     // removed because a project pinned to a dropped id would fail its next
-    // run at resolveEngine.
+    // run at resolveEngine. Before moving the default (or pointing a monitored
+    // project at a model this catalog hasn't measured with), run
+    // scripts/probe-openai-models.ts — it checks the grounded and ungrounded
+    // paths a project will actually use, direct and routed.
     models: [
       { id: "gpt-4o", label: "GPT-4o", note: "Legacy flagship" },
       { id: "gpt-5.6-sol", label: "GPT-5.6 Sol", note: "ChatGPT's paid default" },

--- a/scripts/probe-openai-models.ts
+++ b/scripts/probe-openai-models.ts
@@ -1,0 +1,277 @@
+/**
+ * Is a GPT model safe to measure with — before a project is pointed at it?
+ *
+ * The registry comment on openaiWebSearch says "verified live for gpt-4o /
+ * gpt-4o-mini", and that is the whole problem with swapping models: OpenAI's
+ * browse behaviour has historically varied by model AND by API surface
+ * (Responses vs chat-completions, forced vs offered tool). A newer model can
+ * reject the web_search_preview tool, spend the whole output budget on
+ * reasoning, or answer fluently without searching — none of which throw on
+ * their own. This sends the real requests and reports what actually happened.
+ *
+ *   npx tsx scripts/probe-openai-models.ts
+ *   npx tsx scripts/probe-openai-models.ts --models gpt-5.6-sol,gpt-5.6-luna
+ *   npx tsx scripts/probe-openai-models.ts --router concentrate
+ *
+ * Three probes per model:
+ *   1. grounded  — runQuery with webSearch on: the EXACT monitored path
+ *      (Responses API, forced tool_choice), on a question that can't be
+ *      answered from memory. Passes only with sources AND a non-empty answer.
+ *   2. offered   — the same Responses request with the tool merely offered, on
+ *      a question the model knows cold. Diagnostic: shows whether forcing is
+ *      still doing work on this model (it should search when forced even when
+ *      it wouldn't on its own).
+ *   3. ungrounded — runQuery with webSearch off: the chat-completions path a
+ *      non-search project uses. Catches a model that rejects the params the
+ *      adapter sends (e.g. a max-tokens field renamed out from under us).
+ *
+ * The direct key comes from $OPENAI_API_KEY or $TRIAL_OPENAI_API_KEY (or
+ * --key-file <path>), never an argument. With --router, the router key comes
+ * from $ROUTER_API_KEY_<ROUTER> / $ROUTER_API_KEY, same as probe-router.ts.
+ * Costs a few small calls plus two real web searches per model, on that key.
+ *
+ * Use it before changing the OpenAI default in lib/models.ts, before pointing
+ * a monitored project at a model the comment above hasn't named, or when
+ * OpenAI ships a model family and you want to know what broke before the
+ * trend lines tell you.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { PROVIDERS } from "../lib/models";
+import { ROUTERS, isRouterId, routerSlug, routerSupport } from "../lib/routers";
+import { runQuery, humanError } from "../lib/llm";
+import type { RouteInfo, RouterId } from "../lib/types";
+
+/** Read .env.local into the environment, so a key set there is found without
+ *  being exported by hand. Existing variables always win. */
+function loadEnvLocal(): void {
+  const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+  let raw = "";
+  try {
+    raw = readFileSync(resolve(repoRoot, ".env.local"), "utf8");
+  } catch {
+    return;
+  }
+  for (const line of raw.split("\n")) {
+    const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*)$/);
+    if (!m) continue;
+    const value = m[2].trim().replace(/^["']|["']$/g, "");
+    if (value && !process.env[m[1]]) process.env[m[1]] = value;
+  }
+}
+loadEnvLocal();
+
+function parseArgs(argv: string[]) {
+  const positional: string[] = [];
+  const flags: Record<string, string> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg.startsWith("--")) {
+      const [name, inline] = arg.slice(2).split("=");
+      flags[name] = inline ?? argv[++i] ?? "";
+    } else {
+      positional.push(arg);
+    }
+  }
+  return { positional, flags };
+}
+
+/** The key, from a file or the environment — never from an argument, which
+ *  would land in shell history and in `ps`. */
+function readKey(router: RouterId | null, flags: Record<string, string>): string {
+  if (flags["key-file"]) {
+    const key = readFileSync(flags["key-file"], "utf8").trim();
+    if (key) return key;
+    throw new Error(`--key-file ${flags["key-file"]} is empty.`);
+  }
+  const names = router
+    ? [`ROUTER_API_KEY_${router.toUpperCase()}`, "ROUTER_API_KEY"]
+    : ["OPENAI_API_KEY", "TRIAL_OPENAI_API_KEY"];
+  for (const name of names) {
+    const key = process.env[name]?.trim();
+    if (key) return key;
+  }
+  throw new Error(
+    `No key. Set $${names.join(" (or $")}), or pass --key-file <path>. ` +
+      "A key given as an argument would land in your shell history.",
+  );
+}
+
+// A question that cannot be answered from training data — a sourceless reply is
+// evidence the browse didn't happen, not evidence the model already knew. Same
+// prompt probeRouterSearch uses, for the same reason.
+const FRESH_PROMPT =
+  "Search the web and tell me one news headline published in the last 48 hours. Cite the source URL.";
+// A question the model knows cold. Searching on THIS is what proves the forcing
+// lever works — left to choose, a model answers it from memory and cites nothing.
+const MEMORY_PROMPT = "What is the capital of France?";
+
+const ANSWER_MAX_TOKENS = 1200;
+
+interface ProbeRow {
+  model: string;
+  probe: string;
+  ok: boolean;
+  detail: string;
+}
+
+/** The Responses request with the tool OFFERED rather than forced — not a
+ *  production path, so it's built here rather than imported: the diagnostic
+ *  contrast against the forced call, on the same surface. */
+async function offeredProbe(
+  apiKey: string,
+  model: string,
+  route: { baseUrl: string; slug: string } | null,
+): Promise<{ sources: number; text: string; tokens: number }> {
+  const url = route ? `${route.baseUrl}/responses` : "https://api.openai.com/v1/responses";
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${apiKey}`, "content-type": "application/json" },
+    body: JSON.stringify({
+      model: route ? route.slug : model,
+      tools: [{ type: "web_search_preview" }],
+      input: MEMORY_PROMPT,
+      max_output_tokens: ANSWER_MAX_TOKENS,
+    }),
+  });
+  const j = (await res.json().catch(() => ({}))) as {
+    error?: { message?: string };
+    output?: { content?: { text?: string; annotations?: { url?: string }[] }[] }[];
+    usage?: { total_tokens?: number };
+  };
+  if (!res.ok) throw new Error(j.error?.message ?? `HTTP ${res.status}`);
+  let text = "";
+  let sources = 0;
+  for (const item of j.output ?? []) {
+    for (const c of item.content ?? []) {
+      if (typeof c.text === "string") text += c.text;
+      sources += (c.annotations ?? []).filter((a) => a?.url).length;
+    }
+  }
+  return { sources, text: text.trim(), tokens: j.usage?.total_tokens ?? 0 };
+}
+
+async function probeModel(
+  model: string,
+  apiKey: string,
+  route: RouteInfo | null,
+): Promise<ProbeRow[]> {
+  const rows: ProbeRow[] = [];
+  const base = { provider: "openai" as const, model, apiKey, route };
+
+  // 1. The monitored grounded path, exactly as a run sends it.
+  try {
+    const r = await runQuery({ ...base, prompt: FRESH_PROMPT, webSearch: true });
+    const empty = r.text.length === 0;
+    rows.push({
+      model,
+      probe: "grounded (forced, production path)",
+      ok: r.sources.length > 0 && !empty,
+      detail: empty
+        ? `EMPTY ANSWER with ${r.sources.length} sources, ${r.tokens} tokens — would be stored and scanned for zero mentions`
+        : r.sources.length > 0
+          ? `${r.sources.length} sources, ${r.text.length} chars, ${r.tokens} tokens`
+          : `NO SOURCES (${r.text.length} chars, ${r.tokens} tokens) — ungrounded answer would be recorded as grounded`,
+    });
+  } catch (err) {
+    rows.push({ model, probe: "grounded (forced, production path)", ok: false, detail: humanError(err) });
+  }
+
+  // 2. The forcing contrast: offered-only, on a memory-answerable question.
+  try {
+    const routed =
+      route && routerSupport(route.router, "openai")?.shape === "openai-responses"
+        ? {
+            baseUrl: route.baseUrl?.trim() || ROUTERS[route.router].openaiBaseUrl,
+            slug: routerSlug(route.router, "openai", model)!,
+          }
+        : null;
+    const r = await offeredProbe(apiKey, model, routed);
+    rows.push({
+      model,
+      probe: "offered (diagnostic contrast)",
+      ok: true,
+      detail: `${r.sources} sources on a memory-answerable question, ${r.tokens} tokens — ${
+        r.sources > 0 ? "searches even unforced" : "answers from memory unless forced (forcing is load-bearing)"
+      }`,
+    });
+  } catch (err) {
+    // Diagnostic only, but a hard rejection here still matters: it usually means
+    // the tool TYPE is wrong for this model, which the forced probe would have
+    // reported less legibly.
+    rows.push({ model, probe: "offered (diagnostic contrast)", ok: false, detail: humanError(err) });
+  }
+
+  // 3. The ungrounded path a non-search project uses.
+  try {
+    const r = await runQuery({ ...base, prompt: MEMORY_PROMPT, webSearch: false });
+    rows.push({
+      model,
+      probe: "ungrounded (chat-completions path)",
+      ok: r.text.length > 0,
+      detail: r.text.length > 0 ? `${r.text.length} chars, ${r.tokens} tokens` : "EMPTY ANSWER",
+    });
+  } catch (err) {
+    rows.push({ model, probe: "ungrounded (chat-completions path)", ok: false, detail: humanError(err) });
+  }
+
+  return rows;
+}
+
+async function main() {
+  const { flags } = parseArgs(process.argv.slice(2));
+
+  const router: RouterId | null = flags.router
+    ? isRouterId(flags.router)
+      ? flags.router
+      : (() => {
+          throw new Error(`Unknown router "${flags.router}". Supported: ${Object.keys(ROUTERS).join(", ")}.`);
+        })()
+    : null;
+  const route: RouteInfo | null = router ? { router, baseUrl: flags["base-url"] || null } : null;
+  const apiKey = readKey(router, flags);
+
+  // Default to the catalog's current default plus the 5.6 pair — the cut-over
+  // this script exists to gather evidence for.
+  const models = (flags.models || "gpt-4o,gpt-5.6-sol,gpt-5.6-luna")
+    .split(",")
+    .map((m) => m.trim())
+    .filter(Boolean);
+  const catalog = new Set(PROVIDERS.openai.models.map((m) => m.id));
+  for (const m of models) {
+    if (!catalog.has(m)) {
+      console.warn(`note: ${m} is not in the lib/models.ts catalog — probing it anyway.\n`);
+    }
+  }
+
+  console.log(
+    `Probing OpenAI ${route ? `through ${ROUTERS[route.router].label}` : "directly"}: ${models.join(", ")}\n`,
+  );
+
+  let anyFailed = false;
+  for (const model of models) {
+    const rows = await probeModel(model, apiKey, route);
+    console.log(`${model}`);
+    for (const row of rows) {
+      if (!row.ok) anyFailed = true;
+      console.log(`  ${row.ok ? "PASS" : "FAIL"}  ${row.probe}: ${row.detail}`);
+    }
+    console.log("");
+  }
+
+  if (anyFailed) {
+    console.log(
+      "A model that fails the grounded or ungrounded probe must not be offered for that path:\n" +
+        "the failure modes above don't throw in production — they get stored as measurements.",
+    );
+  }
+  // Exits 0 either way, same as probe-router.ts: "this model can't do that" is a
+  // successful probe, and a non-zero exit would make it look like a broken run.
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});


### PR DESCRIPTION
## Why

Slack thread (Mahir, Aug 18): the probes run on lettertrace's defaults — Claude is already moved to sonnet-5, and GPT needs to move from gpt-4o to gpt-5.6, but "GPT might need more testing" because OpenAI's browse behaviour has historically varied by model *and* by API surface. The forced-browse path had only ever been verified live on gpt-4o / gpt-4o-mini. This PR gathers that evidence and fixes what it demanded.

## Live probe evidence (2026-08-18, trial + Concentrate keys)

**gpt-5.6-sol and gpt-5.6-luna are safe to point monitored projects at**, direct and through Concentrate:

| probe | gpt-4o (baseline) | gpt-5.6-sol | gpt-5.6-luna |
|---|---|---|---|
| grounded, forced (production path), direct | ✅ sources, ~500 tok | ✅ sources, 31–43k tok | ✅ sources, 23–33k tok |
| grounded, forced, via Concentrate | ⚠️ flaky (see below) | ✅ 2/2 runs | ✅ 2/2 runs |
| offered-only contrast (memory question) | 0 sources | 0 sources | 0 sources |
| ungrounded (chat-completions), before fix | ✅ | ❌ 400 `max_tokens` | ❌ 400 `max_tokens` |
| ungrounded, after fix | ✅ | ✅ | ✅ |

- **Forcing is still load-bearing on 5.6**: unforced, both models answer memory-answerable questions with zero sources. Forced, they browse (both `web_search_preview` and the newer `web_search` tool types are accepted and honoured).
- **The ungrounded path was hard-broken**: the 5.6 family rejects `max_tokens` with a 400 ("Use 'max_completion_tokens' instead").
- **Cost changes by ~60x**: a 5.6 grounded answer runs multi-round search + reasoning at 30–60k total tokens where gpt-4o spends ~500. Trial metering / pricing assumptions written for 4o are an order of magnitude off for grounded 5.6 runs.
- **Citation variance is real on 5.6**: a forced browse can complete its searches and still attach zero `url_citation` annotations. Unlike the Anthropic path there is nothing to fall back to — `web_search_call` items carry only the queries, no result URLs — so such an answer is recorded as grounded with the sources it actually cited, possibly none.

## Changes

- **`scripts/probe-openai-models.ts`** — the operator-side cut-over suite (sibling of `probe-router.ts`). Per model: the grounded forced-browse path exactly as `runQuery` sends it, an offered-only contrast, and the ungrounded chat-completions path. Direct by default, `--router concentrate` to probe a gateway. Keys from env/`--key-file`, never arguments.
- **`lib/llm/index.ts`** — chat-completions paths (`openaiChat`, `gatewayQuery`) send `max_completion_tokens`. Probed accepted on gpt-4o, gpt-4o-mini, both 5.6 models direct, and on Concentrate's chat surface for openai **and** google slugs (OpenRouter/Merge not re-probed; both mirror OpenAI's surface).
- **`lib/llm/index.ts`** — `openaiWebSearch` now fails loudly on `status: "incomplete"` (reasoning draws from `max_output_tokens` on 5.6, so a spent budget returns fragment text) and on empty answers, matching the Gemini/Perplexity stance: a stored empty/truncated answer scans as "brand not mentioned" rather than "we never got an answer". These failures do **not** retry — the answer was produced and billed, and at 30–60k tokens a deterministic re-bill is the same trap the node-fetch note on `CLIENT_OPTS` describes.
- **`lib/llm/openai.test.ts`** — first mocked coverage for the OpenAI adapter (10 tests): request shape (forcing, Concentrate slug + mirror URL, token field), citation parsing (dedupe, www-stripping, javascript: dropped), searched-but-uncited answers pass through, the two new guards fail without retrying, 5xx retries, 401 surfaces immediately.
- **`lib/models.ts`** — comment only: pointer to the probe script for whoever makes the default cut-over.

## Deliberately not in this PR

- **The catalog default stays `gpt-4o`.** `defaultModelFor("openai")` feeds every project that never picked a model, so flipping it is a measurement cut-over, not a freshen. The letterstory probe projects can be pointed at `gpt-5.6-sol` in the UI now, same as the Claude move.

## Heads-up: the gpt-4o-via-Concentrate failures are real

@mahir — reproducible today: in 2 of 4 grounded runs, Concentrate returned gpt-4o's answer with the `url_citation` annotations stripped (0 sources; the search demonstrably ran — `tool_calls: {web_search: 1}`, `reasoning_tokens: 0` confirms it's really 4o). It also stuffs ~32k input tokens of raw search results into context vs ~340 direct, so routed 4o answers bill ~65x the input. Intermittent, Concentrate-side, and moving to 5.6 sidesteps it — 5.6 cited sources through Concentrate in every run today.

## Testing

- `npx vitest run` — 721 tests pass (10 new)
- `npx tsc --noEmit` — clean
- `npx tsx scripts/probe-openai-models.ts` and `--router concentrate` — all probes pass post-fix (transcript in the table above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789666028&installation_model_id=431526&pr_number=130&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F130&signature=796379593c7d59cf31fd58c6a07ece1bdec24444b9fe316df790f99f3eb27504"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->