### PR TITLE
fix(llm): raise OpenAI Responses output budget so gpt-5.6 stops returning incomplete

### DIFF
--- a/lib/llm/index.ts
+++ b/lib/llm/index.ts
@@ -22,6 +22,16 @@ import { normalizeCompetitorList } from "@/lib/competitors";
 
 const ANSWER_MAX_TOKENS = 1200;
 const UTILITY_MAX_TOKENS = 1500;
+// OpenAI's Responses grounded path needs its own, much larger output budget.
+// max_output_tokens there caps reasoning + search + answer TOGETHER, and the
+// gpt-5.6 (reasoning) models spend thousands of tokens thinking and searching
+// before writing anything — at ANSWER_MAX_TOKENS (1200) they exhaust the budget
+// mid-reasoning and return status "incomplete" on real (non-trivial) prompts,
+// which fails the run. Verified: 1200 fails 4/4 real prompts; 4000-8000 all
+// complete and ground richly (8-12 inline citations + dozens of searched
+// sources). Non-reasoning gpt-4o is unaffected (it completes well under 1200),
+// and the model stops when done, so the higher cap is headroom, not a floor.
+const OPENAI_SEARCH_MAX_OUTPUT_TOKENS = 8000;
 
 // Both SDKs at these versions (@anthropic-ai/sdk 0.30, openai 4.x) default to
 // node-fetch, which throws "Premature close" reading some providers' response
@@ -786,7 +796,9 @@ async function openaiWebSearch(
           // scripts/probe-router.ts + the Concentrate response shape.
           include: ["web_search_call.action.sources"],
           input: prompt,
-          max_output_tokens: ANSWER_MAX_TOKENS,
+          // Big budget: reasoning + search + answer share this cap, and gpt-5.6
+          // returns "incomplete" at ANSWER_MAX_TOKENS (see the constant's note).
+          max_output_tokens: OPENAI_SEARCH_MAX_OUTPUT_TOKENS,
           ...plan?.extraBody,
         }),
       });


### PR DESCRIPTION
## Symptom
Real (non-trivial) OpenAI grounded prompts fail **4/4** with `OpenAI stopped before finishing the answer (incomplete)` on the gpt-5.6 family. The #130 probe suite missed it because its question ("one news headline") is short enough to fit.

## Root cause
On the Responses path, `max_output_tokens` caps **reasoning + search + answer together**. gpt-5.6 is a reasoning model — it spends thousands of tokens thinking/searching first, so at `ANSWER_MAX_TOKENS` (1200) it hits the cap mid-reasoning and returns `status: incomplete`. gpt-4o doesn't reason, so 1200 was fine for it.

## Fix
Dedicated `OPENAI_SEARCH_MAX_OUTPUT_TOKENS = 8000` for the grounded Responses path only (other paths unchanged).

## Verified (live Concentrate key, real prompts)
| model | status | inline cites | searched sources |
|---|---|---|---|
| gpt-4o | completed | 13 | 7 |
| gpt-5.6-luna | completed | 7 | 66 |
| gpt-4o-mini | completed | 10 | 24 |

All complete and ground. `tsc --noEmit` clean; 124 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789669917&installation_model_id=431526&pr_number=132&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F132&signature=6d1e32909eb3999d4e23cce3c07449614d9e0300ceaca40e4d38284bca939e09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->