### PR TITLE
fix(llm): force Gemini web search via Concentrate Responses tool (grounds reliably)

### DIFF
--- a/lib/llm/index.ts
+++ b/lib/llm/index.ts
@@ -22,6 +22,16 @@ import { normalizeCompetitorList } from "@/lib/competitors";
 
 const ANSWER_MAX_TOKENS = 1200;
 const UTILITY_MAX_TOKENS = 1500;
+// OpenAI's Responses grounded path needs its own, much larger output budget.
+// max_output_tokens there caps reasoning + search + answer TOGETHER, and the
+// gpt-5.6 (reasoning) models spend thousands of tokens thinking and searching
+// before writing anything — at ANSWER_MAX_TOKENS (1200) they exhaust the budget
+// mid-reasoning and return status "incomplete" on real (non-trivial) prompts,
+// which fails the run. Verified: 1200 fails 4/4 real prompts; 4000-8000 all
+// complete and ground richly (8-12 inline citations + dozens of searched
+// sources). Non-reasoning gpt-4o is unaffected (it completes well under 1200),
+// and the model stops when done, so the higher cap is headroom, not a floor.
+const OPENAI_SEARCH_MAX_OUTPUT_TOKENS = 8000;
 
 // Both SDKs at these versions (@anthropic-ai/sdk 0.30, openai 4.x) default to
 // node-fetch, which throws "Premature close" reading some providers' response
@@ -786,7 +796,9 @@ async function openaiWebSearch(
           // scripts/probe-router.ts + the Concentrate response shape.
           include: ["web_search_call.action.sources"],
           input: prompt,
-          max_output_tokens: ANSWER_MAX_TOKENS,
+          // Big budget: reasoning + search + answer share this cap, and gpt-5.6
+          // returns "incomplete" at ANSWER_MAX_TOKENS (see the constant's note).
+          max_output_tokens: OPENAI_SEARCH_MAX_OUTPUT_TOKENS,
           ...plan?.extraBody,
         }),
       });

--- a/lib/llm/index.ts
+++ b/lib/llm/index.ts
@@ -520,9 +520,9 @@ export async function runQuery(
 ): Promise<QueryResult> {
   const webSearch = opts.webSearch ?? false;
 
-  // A routed answer. Only anthropic/openai get here — the router registry serves
-  // no others, and lib/trial refuses the combination before a run starts — so
-  // this sits above the Google/Perplexity branches rather than inside them.
+  // A routed answer (anthropic / openai / gemini through the router) — the
+  // registry serves no others, and lib/trial refuses the combination before a
+  // run starts — so this sits above the Google/Perplexity direct branches.
   if (opts.route) {
     const plan = planRoute(opts.route, opts.provider, opts.model, { webSearch });
     if (plan.shape === "anthropic") {
@@ -531,8 +531,9 @@ export async function runQuery(
         : anthropicChat(opts.apiKey, opts.model, undefined, opts.prompt, ANSWER_MAX_TOKENS, plan)
             .then((res) => ({ ...res, sources: [] }));
     }
-    // A router mirroring the Responses API takes the direct OpenAI path
-    // wholesale, forced tool_choice and all, so the measurement is the same one.
+    // The Responses API path with a forced web-search tool: OpenAI, and Gemini
+    // via Concentrate (openaiWebSearch picks the right tool per slug). Same
+    // forced measurement in both cases.
     if (plan.shape === "openai-responses" && webSearch) {
       return openaiWebSearch(opts.apiKey, opts.model, opts.prompt, plan);
     }
@@ -751,10 +752,18 @@ async function openaiWebSearch(
   prompt: string,
   plan?: RoutePlan,
 ): Promise<QueryResult> {
-  // A router that mirrors the Responses API answers on its own host; the body
-  // below is unchanged, which is the point — a routed OpenAI measurement is the
-  // same request as a direct one, forcing included.
+  // Serves two surfaces through the same Responses API + forced web search:
+  // direct/routed OpenAI, and Gemini via Concentrate (its google/* slug). A
+  // routed measurement is the same request as a direct one, forcing included.
   const url = plan ? `${plan.baseUrl}/responses` : "https://api.openai.com/v1/responses";
+
+  // OpenAI's Responses search tool is `web_search_preview`. Concentrate's
+  // unified tool — what Gemini needs — is `web_search`, forced with tool_choice
+  // "required". Gemini's other path (chat-completions `web_search_options`) only
+  // HINTS, so it grounded at random (~1/4); on this forced tool it grounds 12/12.
+  const isGemini = plan?.slug?.startsWith("google/") ?? false;
+  const searchTool = isGemini ? { type: "web_search" } : { type: "web_search_preview" };
+  const searchToolChoice: unknown = isGemini ? "required" : { type: "web_search_preview" };
 
   interface ResponsesBody {
     status?: string;
@@ -781,12 +790,11 @@ async function openaiWebSearch(
         headers: { Authorization: `Bearer ${apiKey}`, "content-type": "application/json" },
         body: JSON.stringify({
           model: plan ? plan.slug : model,
-          tools: [{ type: "web_search_preview" }],
-          // Force the browse; left to choose, the model often answers from
-          // memory and cites nothing. Verified to survive routing: through
-          // Concentrate this returns sources even for a question the model can
-          // answer from recall, where the same request unforced returns none.
-          tool_choice: { type: "web_search_preview" },
+          tools: [searchTool],
+          // Force the browse; left to choose, the model answers from memory and
+          // cites nothing. Verified through Concentrate for both OpenAI and
+          // Gemini: forced returns sources even for a memory-answerable question.
+          tool_choice: searchToolChoice,
           // Ask the Responses API to attach the searched result URLs to the
           // web_search_call item. The 5.6 models search every time (the browse
           // is forced) but attach inline url_citation annotations only ~70% of

--- a/lib/routers.test.ts
+++ b/lib/routers.test.ts
@@ -118,16 +118,20 @@ describe("OpenRouter request body", () => {
     expect(body.plugins).toBeUndefined();
   });
 
-  it("Concentrate adds web_search_options only for grounded Google", () => {
-    // Gemini grounds through Concentrate's chat surface only when
-    // web_search_options is present; Claude and OpenAI carry their own forced
-    // search tool on their own shapes, so they get nothing extra.
-    expect(ROUTERS.concentrate.extraBody!("google", { webSearch: true })).toEqual({
-      web_search_options: {},
-    });
+  it("Concentrate adds nothing extra — every engine forces its own search tool", () => {
+    // Gemini used to rely on a `web_search_options` hint here; it now goes
+    // through the Responses API with a forced `web_search` tool (like OpenAI),
+    // so no provider needs extraBody.
+    expect(ROUTERS.concentrate.extraBody!("google", { webSearch: true })).toEqual({});
     expect(ROUTERS.concentrate.extraBody!("google", { webSearch: false })).toEqual({});
     expect(ROUTERS.concentrate.extraBody!("anthropic", { webSearch: true })).toEqual({});
     expect(ROUTERS.concentrate.extraBody!("openai", { webSearch: true })).toEqual({});
+  });
+
+  it("Concentrate serves Gemini on the openai-responses shape", () => {
+    // The forced web_search tool lives on the Responses path; the old
+    // openai-chat shape only hinted and grounded at random.
+    expect(ROUTERS.concentrate.providers.google?.shape).toBe("openai-responses");
   });
 });
 

--- a/lib/routers.ts
+++ b/lib/routers.ts
@@ -147,12 +147,11 @@ export const ROUTERS: Record<RouterId, RouterInfo> = {
     anthropicBaseUrl: "https://api.concentrate.ai",
     // Concentrate's API reference documents bearer auth for the whole API.
     anthropicAuth: "bearer",
-    // Gemini grounds through the chat surface only when web_search_options is
-    // present — Concentrate forwards it to Google's native grounding. Claude and
-    // OpenAI carry their own forced search tool on their own shapes (anthropic /
-    // openai-responses), so they need nothing extra here.
-    extraBody: (provider, { webSearch }) =>
-      provider === "google" && webSearch ? { web_search_options: {} } : {},
+    // Every engine forces its own web search tool on its own shape (anthropic /
+    // openai-responses) — Gemini included, now that it goes through the Responses
+    // API with a forced `web_search` tool rather than the chat-completions
+    // `web_search_options` hint it used to ignore — so nothing extra is needed.
+    extraBody: () => ({}),
     providers: {
       anthropic: {
         shape: "anthropic",
@@ -171,18 +170,17 @@ export const ROUTERS: Record<RouterId, RouterInfo> = {
         slugPrefix: "openai",
       },
       google: {
-        // Grounded and measurable via web_search_options. The 2026-08-02 probe
-        // saw only ungrounded answers, but as of 2026-08-17 Concentrate forwards
-        // Gemini's native Google-Search grounding: the router's extraBody adds
-        // `web_search_options: {}`, and the reply carries url_citation annotations
-        // backed by Google's vertexaisearch redirect host. It grounds
-        // consistently — even a memory-answerable question ("capital of France")
-        // searched — so no forcing lever is needed. The real domain rides in the
-        // annotation title, which gatewaySources resolves (the same shape the
-        // direct Google path handles). NOTE: the google-ai-overviews pseudo-model
-        // still can't route — routerSlug returns null for it — so its projects
-        // stay on a direct key.
-        shape: "openai-chat",
+        // Gemini goes through the SAME Responses API + forced web-search tool as
+        // OpenAI (shape "openai-responses"), just with Concentrate's `web_search`
+        // tool + tool_choice "required" instead of `web_search_preview` (openai-
+        // WebSearch branches on the google/* slug). The old chat-completions
+        // `web_search_options` path only HINTED — Gemini ignored it and grounded
+        // at random (~1/4 of real prompts). Forced on the Responses tool it
+        // grounds 12/12, native Google Search (vertexaisearch redirect host), and
+        // reuses the Responses source parsing (annotations + action.sources).
+        // NOTE: the google-ai-overviews pseudo-model still can't route —
+        // routerSlug returns null for it — so its projects stay on a direct key.
+        shape: "openai-responses",
         search: "passthrough",
         // Our catalog carries Google's rolling ALIASES (gemini-flash-latest),
         // which no router resolves — every model needs an explicit slug, and


### PR DESCRIPTION
## Symptom
Gemini via Concentrate grounds at random — ~1/4 of real prompts, identical requests returning 0–21 citations. GEO citation/mention data on Gemini is unreliable.

## Root cause (not a missing Concentrate feature)
lettertrace routed Gemini through **chat-completions `web_search_options: {}`**, which Concentrate's docs treat as a **hint** — Gemini ignores it on questions it thinks it knows and answers from memory (no citations). Concentrate's *documented* web search is a **`web_search` tool on the Responses API**, forceable with `tool_choice: "required"`. We were using the wrong mechanism.

## Fix
Route Gemini through the same Responses path as OpenAI (`shape: "openai-responses"`); `openaiWebSearch` branches on the `google/*` slug to send `tools:[{type:"web_search"}]` + `tool_choice:"required"` instead of `web_search_preview`. Removes the now-dead `web_search_options` extraBody. Reuses the Responses source parsing (#131) and output budget (#132).

## Verified (live Concentrate key)
| prompt | before | after (forced Responses tool) |
|---|---|---|
| Cloudflare / Reclaim / Joice | grounded ~1/4 | **12/12** grounded, 7–20 sources, native Google Search (vertexaisearch) |

End-to-end via `runQuery`: 8/9 (the one miss is an empty-answer that fails loudly, not a silent blank). `tsc --noEmit` clean; **160 unit tests pass**.

## Result
Gemini stays on Concentrate (off the throttled Google key) *and* grounds reliably. AI Overviews is unaffected — it can't route through a gateway and keeps its forced-grounded direct-key path. Two separate, reliably-grounded Google surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789674832&installation_model_id=431526&pr_number=134&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F134&signature=8e15e1b95f1b97d39ae66e1a1b67168b6afb339075ac49a11275b5d7fbf75f78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->