### PR TITLE
fix(llm): add ALWAYS_SEARCH instruction to force native Gemini grounding via Concentrate

### DIFF
--- a/lib/llm/index.ts
+++ b/lib/llm/index.ts
@@ -764,6 +764,14 @@ async function openaiWebSearch(
   const isGemini = plan?.slug?.startsWith("google/") ?? false;
   const searchTool = isGemini ? { type: "web_search" } : { type: "web_search_preview" };
   const searchToolChoice: unknown = isGemini ? "required" : { type: "web_search_preview" };
+  // tool_choice "required" hard-forces OpenAI, but Concentrate maps our
+  // web_search tool to Gemini's {googleSearch:{}}, which is model-decides — so
+  // "required" doesn't strictly force a Gemini search (per Concentrate). It
+  // searches consistently in practice, but we add the same ALWAYS_SEARCH
+  // instruction lettertrace uses on the DIRECT Gemini path as belt-and-
+  // suspenders, keeping native Google grounding. OpenAI needs none — it's
+  // hard-forced. (Not Exa: that's a third-party engine, non-representative.)
+  const geminiSearchInstruction = isGemini ? ALWAYS_SEARCH.replace(/^-\s*/, "") : undefined;
 
   interface ResponsesBody {
     status?: string;
@@ -795,6 +803,9 @@ async function openaiWebSearch(
           // cites nothing. Verified through Concentrate for both OpenAI and
           // Gemini: forced returns sources even for a memory-answerable question.
           tool_choice: searchToolChoice,
+          // Gemini-only: the ALWAYS_SEARCH nudge (see geminiSearchInstruction),
+          // since tool_choice doesn't hard-force Gemini's native search.
+          ...(geminiSearchInstruction ? { instructions: geminiSearchInstruction } : {}),
           // Ask the Responses API to attach the searched result URLs to the
           // web_search_call item. The 5.6 models search every time (the browse
           // is forced) but attach inline url_citation annotations only ~70% of


### PR DESCRIPTION
## Context
Concentrate confirmed a Gemini-specific caveat: on the Responses path, `tool_choice: "required"` hard-forces OpenAI/Anthropic, but our `web_search` tool maps to Gemini's `{googleSearch:{}}`, which is **model-decides** — so `required` doesn't strictly force a Gemini search. Their forced alternative (`engine: exa`) uses a **third-party** search engine, which is non-representative for GEO (real Gemini users get Google Search).

## Testing showed it grounds reliably anyway…
Across memory-answerable prompts (incl. "capital of France"), our Responses path grounded **every run** with **native `vertexaisearch` sources**. So this is belt-and-suspenders, not a bug fix.

## …but we close the gap with the lever we already trust
Add the **`ALWAYS_SEARCH` instruction** (the same one lettertrace uses to force the **direct** Gemini path) via the Responses `instructions` field, **Gemini-only**. Keeps native Google grounding; **not** Exa. OpenAI is untouched — its `tool_choice` is a real hard-force.

## Verified
- Live: Gemini grounds (7–14 native sources) with the instruction; OpenAI unaffected.
- `tsc --noEmit` clean; 124 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/135"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789678787&installation_model_id=431526&pr_number=135&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F135&signature=082ccbc2b06840b9cde113fe134ce8facee6fb5ae5d436196b48938ada6d59b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->