### PR TITLE
fix(llm): route Google AI Overviews through Concentrate (stop direct-key 429 storm)

### DIFF
--- a/app/dashboard/settings/routers-manager.tsx
+++ b/app/dashboard/settings/routers-manager.tsx
@@ -298,13 +298,15 @@ function EngineStatus({
   checks: Check[] | null;
 }) {
   // Engines that still need a direct key on this router: the base providers it
-  // doesn't serve, plus Google AI Overviews — a pseudo-model that never routes
-  // through any gateway (routerSlug is null for it), even when the router serves
-  // the Gemini assistant. Computed rather than hardcoded so it stays truthful as
-  // a router gains coverage (e.g. Concentrate now grounds Gemini).
+  // doesn't serve, plus Google AI Overviews UNLESS this router's Google grounding
+  // is verified. AI Overviews is grounded-always and rides the Gemini path on its
+  // backing slug, so it routes wherever a router carries Google's native search
+  // (Concentrate, once verified) and needs a direct key everywhere else (the
+  // routers whose Google search is "none", or an unverified key). Computed rather
+  // than hardcoded so it stays truthful as a router gains coverage.
   const needsOwnKey = [
     ...(Object.keys(PROVIDERS) as Provider[]).filter((p) => !served.includes(p)).map((p) => PROVIDERS[p].label),
-    "Google AI Overviews",
+    ...(searchVerified.includes("google") ? [] : ["Google AI Overviews"]),
   ];
   const needsOwnKeyList =
     needsOwnKey.length === 1

--- a/lib/llm/index.ts
+++ b/lib/llm/index.ts
@@ -1,7 +1,12 @@
 import Anthropic from "@anthropic-ai/sdk";
 import OpenAI from "openai";
 import type { Provider, RouteInfo, RouterId, Sentiment } from "@/lib/types";
-import { GOOGLE_AI_OVERVIEWS_MODEL, PROVIDERS, analysisModelFor } from "@/lib/models";
+import {
+  AI_OVERVIEWS_BACKING_MODEL,
+  GOOGLE_AI_OVERVIEWS_MODEL,
+  PROVIDERS,
+  analysisModelFor,
+} from "@/lib/models";
 import {
   ROUTERS,
   routerSlug,
@@ -771,7 +776,21 @@ async function openaiWebSearch(
   // instruction lettertrace uses on the DIRECT Gemini path as belt-and-
   // suspenders, keeping native Google grounding. OpenAI needs none — it's
   // hard-forced. (Not Exa: that's a third-party engine, non-representative.)
-  const geminiSearchInstruction = isGemini ? ALWAYS_SEARCH.replace(/^-\s*/, "") : undefined;
+  //
+  // The AI-Overviews surface routes here too (its google/* backing slug makes
+  // isGemini true), but it is not a plain Gemini answer: it needs the overview
+  // persona the direct path applies via AI_OVERVIEW_SYSTEM. That prompt already
+  // ends with ALWAYS_SEARCH, so it carries the search push as well — send it in
+  // full instead of the bare nudge, keeping the routed overview identical in
+  // voice and grounding to the direct one. Detected from the requested model,
+  // which stays `google-ai-overviews` (the surface) even though the slug is the
+  // backing Gemini model.
+  const isOverview = model === GOOGLE_AI_OVERVIEWS_MODEL;
+  const geminiSearchInstruction = isOverview
+    ? AI_OVERVIEW_SYSTEM
+    : isGemini
+      ? ALWAYS_SEARCH.replace(/^-\s*/, "")
+      : undefined;
 
   interface ResponsesBody {
     status?: string;
@@ -902,10 +921,8 @@ const GOOGLE_MAX_RETRY_WAIT_MS = 45_000;
 // allows 300s for every prompt in the run, so a single prompt must not be able
 // to eat it and starve the rest.
 const GOOGLE_RETRY_BUDGET_MS = 90_000;
-// The real Gemini model the "Google AI Overviews" engine runs on. AI Overviews
-// are served by a fast Gemini model over Google Search, so we back them with
-// Flash and always ground the answer in Search.
-const AI_OVERVIEWS_BACKING_MODEL = "gemini-flash-latest";
+// The Gemini model the AI-Overviews pseudo-model runs on is AI_OVERVIEWS_BACKING_MODEL
+// (lib/models), shared with the router slug map so direct and routed AIO hit one model.
 // Gemini "thinking" tokens are billed as output and drawn from the same budget
 // as the visible answer, so a small maxOutputTokens gets spent on thoughts and
 // the answer comes back truncated (finishReason MAX_TOKENS) — measured on

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -1,11 +1,20 @@
 import type { Provider } from "./types";
 
-// Google AI Overviews is exposed as a distinct answer engine, but it runs on
-// the same Google (Gemini) key: it is a pseudo-model under the `google`
-// provider that always grounds in Google Search and answers in the terse,
-// synthesized style Google shows at the top of a results page. The adapter
-// (lib/llm) maps this id onto a real Gemini model for the actual API call.
+// Google AI Overviews is exposed as a distinct answer engine: it is a
+// pseudo-model under the `google` provider that always grounds in Google Search
+// and answers in the terse, synthesized style Google shows at the top of a
+// results page. The adapter (lib/llm) maps this id onto a real Gemini model for
+// the actual API call — the backing model below. It runs on a direct Google key
+// OR through a router that carries Google's native grounding (Concentrate); the
+// run still records `google-ai-overviews` as the surface either way.
 export const GOOGLE_AI_OVERVIEWS_MODEL = "google-ai-overviews";
+
+// The real Gemini model the "Google AI Overviews" engine runs on. AI Overviews
+// are served by a fast Gemini model over Google Search, so we back them with
+// Flash and always ground the answer in Search. Shared here (not buried in the
+// adapter) because the router slug map has to resolve the pseudo-model to this
+// same backing model, so a direct AIO call and a routed one hit one model.
+export const AI_OVERVIEWS_BACKING_MODEL = "gemini-flash-latest";
 
 export interface ModelOption {
   id: string;

--- a/lib/routers.test.ts
+++ b/lib/routers.test.ts
@@ -143,11 +143,17 @@ describe("routerSlug", () => {
     expect(routerSlug("concentrate", "openai", "gpt-4o")).toBe("openai/gpt-4o");
   });
 
-  it("refuses the AI Overviews pseudo-model", () => {
-    // It isn't a model any router has: it's a Gemini call plus our own system
-    // prompt. Mapping it to a slug would send the request somewhere real and
-    // return something that isn't an AI Overview.
-    expect(routerSlug("concentrate", "google", GOOGLE_AI_OVERVIEWS_MODEL)).toBeNull();
+  it("resolves the AI Overviews pseudo-model to its backing Gemini slug", () => {
+    // It isn't a model any router has: it's a Gemini call plus our overview
+    // system prompt. It routes on its backing model's slug (the adapter re-applies
+    // the overview prompt), so a router that carries Google grounding can serve
+    // it — the same slug Gemini Flash resolves to.
+    expect(routerSlug("concentrate", "google", GOOGLE_AI_OVERVIEWS_MODEL)).toBe(
+      "google/gemini-2.5-flash",
+    );
+    expect(routerSlug("concentrate", "google", GOOGLE_AI_OVERVIEWS_MODEL)).toBe(
+      routerSlug("concentrate", "google", "gemini-flash-latest"),
+    );
   });
 
   it("refuses an engine the router doesn't serve", () => {
@@ -385,11 +391,18 @@ describe("routed Gemini", () => {
     }
   });
 
-  it("never routes the AI Overviews pseudo-model", () => {
-    // It is our own construct, grounded in Google Search by definition — there
-    // is nothing on a router that could stand in for it.
-    expect(routerSlug("openrouter", "google", GOOGLE_AI_OVERVIEWS_MODEL)).toBeNull();
-    expect(routerSlug("concentrate", "google", GOOGLE_AI_OVERVIEWS_MODEL)).toBeNull();
-    expect(routerSlug("merge", "google", GOOGLE_AI_OVERVIEWS_MODEL)).toBeNull();
+  it("routes the AI Overviews pseudo-model only where Google grounding survives", () => {
+    // AI Overviews is grounded-always, riding the Gemini path on its backing
+    // slug. Every router resolves that slug (a naming question), but the surface
+    // can only be MEASURED where the router carries Google's native search — just
+    // Concentrate. On the others it gets a slug but is refused for the grounded
+    // run it always is, so it stays on a direct key.
+    for (const router of ["openrouter", "concentrate", "merge"] as const) {
+      expect(routerSlug(router, "google", GOOGLE_AI_OVERVIEWS_MODEL)).toBe("google/gemini-2.5-flash");
+    }
+    const grounded = { webSearch: true, verified: ["google"] as Provider[] };
+    expect(routerCanMeasure("concentrate", "google", grounded)).toBe(true);
+    expect(routerCanMeasure("openrouter", "google", grounded)).toBe(false);
+    expect(routerCanMeasure("merge", "google", grounded)).toBe(false);
   });
 });

--- a/lib/routers.ts
+++ b/lib/routers.ts
@@ -1,5 +1,5 @@
 import type { Provider, RouterId } from "./types";
-import { GOOGLE_AI_OVERVIEWS_MODEL, PROVIDERS } from "./models";
+import { AI_OVERVIEWS_BACKING_MODEL, GOOGLE_AI_OVERVIEWS_MODEL, PROVIDERS } from "./models";
 
 // ==================================================================
 // LLM routers (gateways).
@@ -126,13 +126,15 @@ export interface RouterInfo {
 // Not because the models are unreachable — they are — but because some
 // measurement paths don't survive normalization. Perplexity's search is not a
 // parameter at all, it is the product, and its sources arrive in its own shape,
-// so it keeps requiring a direct key. Gemini's standard models DO ground through
-// Concentrate (web_search_options → native Google grounding; see its entry, and
-// gatewaySources for how the redirect-host domains are resolved), but the "Google
-// AI Overviews" engine is a pseudo-model — a real Gemini model plus a forced-
-// search system prompt that imitates the Overviews style, with no gateway
-// equivalent — so it too keeps a direct key (routerSlug refuses it).
-// `engineKeyMessage` says so plainly for the paths that still need a key.
+// so it keeps requiring a direct key. Google's surfaces DO ground through
+// Concentrate: its standard Gemini models via the Responses forced web-search
+// tool → native Google grounding (see its entry, and gatewaySources for how the
+// redirect-host domains are resolved), and the "Google AI Overviews" engine —
+// a pseudo-model that is a Gemini model plus a forced-search overview system
+// prompt — rides the same path on its backing Gemini slug (routerSlug resolves
+// it), with the overview prompt re-applied at call time. Only Concentrate does
+// this: the other routers reach Google but not its native grounding, so they
+// serve Google ungrounded-only and refuse the grounded surfaces.
 
 export const ROUTERS: Record<RouterId, RouterInfo> = {
   concentrate: {
@@ -178,8 +180,10 @@ export const ROUTERS: Record<RouterId, RouterInfo> = {
         // at random (~1/4 of real prompts). Forced on the Responses tool it
         // grounds 12/12, native Google Search (vertexaisearch redirect host), and
         // reuses the Responses source parsing (annotations + action.sources).
-        // NOTE: the google-ai-overviews pseudo-model still can't route —
-        // routerSlug returns null for it — so its projects stay on a direct key.
+        // The google-ai-overviews pseudo-model rides this same path: routerSlug
+        // resolves it to the backing Gemini slug and openaiWebSearch re-applies
+        // the overview system prompt, so AIO routes here too (which offloads its
+        // grounded burst from a single direct key that 429-storms under load).
         shape: "openai-responses",
         search: "passthrough",
         // Our catalog carries Google's rolling ALIASES (gemini-flash-latest),
@@ -364,18 +368,26 @@ export function routerProviders(router: RouterId): Provider[] {
  * The router's slug for one of our catalog models, or null when the router
  * can't serve that provider.
  *
- * The AI Overviews pseudo-model is refused here rather than mapped: it is not a
- * model any router has, it is a Gemini call plus our own system prompt.
+ * The AI Overviews pseudo-model has no model of its own — it is a Gemini call
+ * plus our overview system prompt — so it resolves to the same backing Gemini
+ * model the direct path uses (AI_OVERVIEWS_BACKING_MODEL), letting a router that
+ * carries Google's native grounding serve it. This only answers the naming
+ * question ("which slug"); whether a router may actually MEASURE that grounded
+ * surface is routerCanMeasure's call, and only Concentrate passes Google search
+ * through — so through the other routers AIO gets a slug but is refused for the
+ * grounded run it always is. The run still records `google-ai-overviews`; the
+ * overview instructions are re-applied at call time (openaiWebSearch), so the
+ * routed answer matches the direct one in voice and grounding.
  */
 export function routerSlug(
   router: RouterId,
   provider: Provider,
   model: string,
 ): string | null {
-  if (model === GOOGLE_AI_OVERVIEWS_MODEL) return null;
   const support = routerSupport(router, provider);
   if (!support) return null;
-  return support.slugOverrides?.[model] ?? `${support.slugPrefix}/${model}`;
+  const slugModel = model === GOOGLE_AI_OVERVIEWS_MODEL ? AI_OVERVIEWS_BACKING_MODEL : model;
+  return support.slugOverrides?.[slugModel] ?? `${support.slugPrefix}/${slugModel}`;
 }
 
 /**
@@ -403,19 +415,18 @@ export function routerCanMeasure(
  * Should a capable router be PREFERRED over a direct key for this
  * (provider, model)? Default is no — BYOK wins, the router is the fallback.
  *
- * The one exception is Google's non-Overviews models. Google answers on two
- * surfaces that share the provider: AI Overviews (the google-ai-overviews
- * pseudo-model, which CAN'T route — routerSlug is null) and the Gemini
- * assistant (which can). An account needs a direct Google key for AI Overviews,
- * but with plain BYOK-first that same key would pin the Gemini surface to direct
- * too — so the two surfaces could never sit on different credentials. Reserving
- * the direct key for AI Overviews and preferring the router for real Gemini
- * models is what lets AI-Overviews-direct and Gemini-via-gateway coexist on one
- * account. The router is only actually used when it's verified (routerCanMeasure)
- * and has a slug, so this preference degrades safely to the direct key.
+ * The exception is Google, on BOTH its surfaces — the Gemini assistant and the
+ * AI-Overviews pseudo-model. A direct Google key can serve either, but a single
+ * key can't absorb the fleet's grounded burst across every org: the direct AIO
+ * path 429/503-storms under load, while Concentrate carries the same Google
+ * volume from a pooled backend. So both surfaces prefer a verified router and
+ * fall to the direct key only when none can measure Google's grounding. The
+ * router is used only when it's verified (routerCanMeasure) and has a slug
+ * (routerSlug now resolves AIO to its backing Gemini model), so this preference
+ * degrades safely to the direct key.
  */
-export function prefersRouter(provider: Provider, model: string): boolean {
-  return provider === "google" && model !== GOOGLE_AI_OVERVIEWS_MODEL;
+export function prefersRouter(provider: Provider, _model: string): boolean {
+  return provider === "google";
 }
 
 /**

--- a/lib/trial.test.ts
+++ b/lib/trial.test.ts
@@ -352,10 +352,11 @@ describe("resolveRunKeyFor with a router credential", () => {
     expect(nextRunMessage(k)).toContain("Claude Opus 4.8");
   });
 
-  // Google answers on two surfaces sharing the provider: AI Overviews (can't
-  // route) and the Gemini assistant (can). An account keeps a Google direct key
-  // for AI Overviews, and BYOK-first would pin Gemini to it too — so real Gemini
-  // is router-preferred, letting the two surfaces sit on different credentials.
+  // Google answers on two surfaces sharing the provider — the Gemini assistant
+  // and AI Overviews — and both now prefer a verified router over a direct key,
+  // because a single direct Google key can't absorb the fleet's grounded burst.
+  // The direct key is the fallback for either surface when no router can measure
+  // Google's grounding.
   it("routes real Gemini through a verified router even when a Google direct key exists", async () => {
     ownsKeysFor("google");
     hasRouter("concentrate", ["google"]);
@@ -365,9 +366,21 @@ describe("resolveRunKeyFor with a router credential", () => {
     expect(k.route?.router).toBe("concentrate");
   });
 
-  it("keeps AI Overviews on the direct Google key (it can't route)", async () => {
+  it("routes AI Overviews through a verified router even when a Google direct key exists", async () => {
+    // AI Overviews now prefers a router that carries Google grounding, on its
+    // backing Gemini slug — offloading its grounded burst from a single direct
+    // key that 429-storms under fleet load. The direct key becomes the fallback.
     ownsKeysFor("google");
     hasRouter("concentrate", ["google"]);
+    const k = await runKeyFor(db(0), "user-1", "google", GOOGLE_AI_OVERVIEWS_MODEL, { webSearch: true });
+    expect(k.source).toBe("own");
+    expect(k.apiKey).toBe("key-for-concentrate");
+    expect(k.route?.router).toBe("concentrate");
+  });
+
+  it("degrades AI Overviews to the direct Google key when the router isn't verified for Google", async () => {
+    ownsKeysFor("google");
+    hasRouter("concentrate", []); // Google grounding not confirmed on this key
     const k = await runKeyFor(db(0), "user-1", "google", GOOGLE_AI_OVERVIEWS_MODEL, { webSearch: true });
     expect(k.source).toBe("own");
     expect(k.apiKey).toBe("key-for-google");
@@ -650,8 +663,9 @@ describe("the free-tier spend ceiling", () => {
 
 // The free tier can be funded by one shared Concentrate key instead of four
 // direct provider keys: it routes the engines Concentrate serves through the
-// gateway (one capped key, discount) and falls back to per-provider trial keys
-// for the engines it can't (AI Overviews, Perplexity).
+// gateway (one capped key, discount) — including AI Overviews, on its backing
+// Gemini slug — and falls back to per-provider trial keys for the ones it can't
+// (Perplexity).
 describe("free tier through a shared Concentrate key", () => {
   it("routes a served engine through Concentrate", async () => {
     process.env.TRIAL_CONCENTRATE_API_KEY = "sk-cn-trial";
@@ -669,13 +683,17 @@ describe("free tier through a shared Concentrate key", () => {
     expect(k.route?.router).toBe("concentrate");
   });
 
-  it("falls back to a direct trial key for AI Overviews (Concentrate can't route it)", async () => {
+  it("routes AI Overviews through the shared Concentrate key (on its backing Gemini slug)", async () => {
+    // The trial Concentrate key is trusted for the grounding it statically
+    // supports (concentrateTrialServes), and Google grounding is passthrough — so
+    // AI Overviews rides the gateway on its backing slug like real Gemini, rather
+    // than falling to a per-provider direct trial key.
     process.env.TRIAL_CONCENTRATE_API_KEY = "sk-cn-trial";
     process.env.TRIAL_GOOGLE_API_KEY = "trial-google";
     const k = await runKeyFor(db(0), "user-1", "google", GOOGLE_AI_OVERVIEWS_MODEL, { webSearch: true });
     expect(k.source).toBe("trial");
-    expect(k.apiKey).toBe("trial-google");
-    expect(k.route).toBeUndefined();
+    expect(k.apiKey).toBe("sk-cn-trial");
+    expect(k.route?.router).toBe("concentrate");
   });
 
   it("falls back to a direct trial key for Perplexity (not in Concentrate's catalog)", async () => {

--- a/lib/trial.ts
+++ b/lib/trial.ts
@@ -84,8 +84,8 @@ export function trialModelFor(provider: Provider, fallback: string): string {
 /** The operator's shared Concentrate (router) key for free-tier runs (env:
  *  TRIAL_CONCENTRATE_API_KEY). One capped gateway key can fund the whole free
  *  tier for every engine Concentrate serves — Claude, GPT, Gemini — instead of a
- *  direct key per provider. Engines it can't serve (AI Overviews, Perplexity)
- *  still use their per-provider TRIAL_*_API_KEY. */
+ *  direct key per provider. Engines it can't serve (Perplexity) still use their
+ *  per-provider TRIAL_*_API_KEY. */
 export function trialConcentrateKey(): string | null {
   const v = process.env.TRIAL_CONCENTRATE_API_KEY;
   return v && v.trim() ? v.trim() : null;
@@ -383,15 +383,17 @@ export async function resolveRunKeyFor(
         verified: rk.searchVerified,
       }) &&
       // Measuring the ENGINE isn't enough — a router with no slug for this exact
-      // model (e.g. the google-ai-overviews pseudo-model) would fail at planRoute.
-      // Keep those on the direct/trial path instead of selecting a route that dies.
+      // model would fail at planRoute. Keep those on the direct/trial path
+      // instead of selecting a route that dies. (Both Google surfaces resolve a
+      // slug now — the AI-Overviews pseudo-model to its backing Gemini model.)
       routerSlug(rk.router, provider, requested.model) !== null,
   );
 
-  // Router-preferred models (Google's non-Overviews surfaces) route through a
-  // capable router even when a direct key is present — the direct key stays
-  // reserved for the AI-Overviews surface it alone can serve. Everything else is
-  // BYOK-first: the direct key wins and the router is the fallback.
+  // Router-preferred models (both of Google's surfaces — Gemini and AI
+  // Overviews) route through a capable router even when a direct key is present:
+  // a single direct Google key can't absorb the fleet's grounded burst, so the
+  // pooled gateway carries it and the direct key is the fallback. Everything
+  // else is BYOK-first: the direct key wins and the router is the fallback.
   if (usable && prefersRouter(provider, requested.model)) {
     return { ...base, source: "own", apiKey: usable.apiKey, route: routeOf(usable) };
   }
@@ -402,8 +404,8 @@ export async function resolveRunKeyFor(
 
   // The operator's shared key, but only for the engine actually chosen. Prefer
   // the Concentrate trial key (routes through the gateway — one capped key,
-  // discount) for engines it can serve; AI Overviews / Perplexity fall to their
-  // per-provider direct trial key.
+  // discount) for engines it can serve (now including AI Overviews, on its
+  // backing Gemini slug); Perplexity falls to its per-provider direct trial key.
   const limit = trialRunLimit();
   const cap = trialSpendLimitMicros();
   const trialCred = trialCredFor(provider, requested.model, opts.webSearch);


### PR DESCRIPTION
## Why

The **AI Overviews** surface (`google-ai-overviews`) ran only on a **direct Google key** — `routerSlug` returned `null` for it and `prefersRouter` excluded it, so it went through `googleRunQuery`/`googleGenerate`. A single Tier-2 key can't absorb the fleet's grounded burst across every org (amplified by `GOOGLE_MAX_ATTEMPTS` retries), so the cron **429/503-stormed** and AIO coverage collapsed to ~0%.

Concentrate already carries the **same Gemini volume at 99.3%** from a pooled backend (#134/#135), and AIO is just a Gemini model + a forced-search overview system prompt. So route it the same way.

## What

- **`routerSlug`** — resolve the AIO pseudo-model to its backing Gemini slug (`AI_OVERVIEWS_BACKING_MODEL` → `google/gemini-2.5-flash`) instead of `null`. Naming only: `routerCanMeasure` still gates measurability, and only Concentrate passes Google's native search through, so the other routers get a slug but refuse the always-grounded surface (they keep AIO on a direct key).
- **`prefersRouter`** — prefer a verified router for **both** Google surfaces (Gemini + AIO), degrading to the direct key when none can measure Google's grounding.
- **`openaiWebSearch`** — when the requested model is `google-ai-overviews`, send the full `AI_OVERVIEW_SYSTEM` as Responses `instructions` (it already ends with `ALWAYS_SEARCH`) instead of the bare Gemini nudge — keeping the routed overview identical in voice and grounding to the direct one. Native Google grounding (`vertexaisearch`); **not** the exa engine.
- Share `AI_OVERVIEWS_BACKING_MODEL` from `lib/models` so the direct path and the router slug map resolve the pseudo-model to one backing model.
- Settings "needs its own key" list drops AIO when a router's Google grounding is verified; routers/trial comments + tests refreshed.

## Measurement note

The run still records **`google-ai-overviews`** (the surface tag) — only the upstream slug is the backing Gemini model — so surface classification is unchanged. This is a **one-time AIO cut-over** (direct-native → Concentrate-native; same model + native Google grounding). As with the routed Gemini path already in prod, routed Google sources attribute to the `vertexaisearch` redirect host rather than the resolved domain (pre-existing #134 behavior, not introduced here).

## Verification

Live against the Concentrate key: AIO grounds **4/4** with native `vertexaisearch` sources and Overview-style answers (incl. the memory-answerable "capital of France" → 4 sources); plain Gemini still grounds and OpenAI is unaffected. `tsc --noEmit` clean, **723 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/136"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789682316&installation_model_id=431526&pr_number=136&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F136&signature=3889aab3cac8e6456373ce0dda87e294229081e586c692a7a347049ed5e4563b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->