### PR TITLE
Offer new signups a setup call with the founder

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -181,6 +181,13 @@ ADMIN_EMAILS=
 # records prompts, answers, brand names or domains.
 OPS_TELEMETRY=
 
+# Booking link offered to new signups, once, thirty seconds after they reach
+# the dashboard ("want a hand getting set up?"). Any URL — Cal.com, Calendly,
+# whatever you use. Unset means no such offer exists, which is the right
+# default for a self-hosted install: your users should not be pointed at
+# someone else's calendar.
+FOUNDER_CALL_URL=
+
 # ------------------------------------------------------------------
 # NOTE: This app is Bring-Your-Own-Key (BYOK). Users add their own
 # Anthropic / OpenAI / Google API keys inside the app (Settings). You

--- a/README.md
+++ b/README.md
@@ -186,8 +186,10 @@ docker run -p 3000:3000 --env-file .env ghcr.io/letterstory/lettertrace
 | `CRON_SECRET` | Only if you wire up scheduled runs (below) |
 
 Everything else in [`.env.example`](./.env.example) is optional: the `TRIAL_*`
-keys exist to hand out free runs on your own provider account, and the
-`ADMIN_*` / `RESEND_API_KEY` values only enable operator alerts.
+keys exist to hand out free runs on your own provider account, the `ADMIN_*` /
+`RESEND_API_KEY` values only enable operator alerts, and `FOUNDER_CALL_URL`
+offers new signups a setup call at a booking link of your choosing. Leave that
+last one unset — as `.env.example` does — and no such offer exists.
 
 Unlike a typical Next.js image, the `NEXT_PUBLIC_*` values here are read **at
 runtime**, not baked in at build time — so the published image works against any

--- a/app/api/founder-call/route.ts
+++ b/app/api/founder-call/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Records that the founder-call offer has been made to the signed-in user.
+ *
+ * Write-once by intent: the update is conditional on the column still being
+ * null, so a double-render, a second tab, or a retried request cannot move the
+ * timestamp. It is the same "exactly once per person" lock as admin_alerted_at.
+ *
+ * Takes no request body. Whose row to mark comes from the session and nothing
+ * else — accepting a user id here would let any signed-in user burn another
+ * user's offer.
+ *
+ * Always answers 200 once authenticated, including when the row was already
+ * marked, because the caller has nothing useful to do with a failure: the
+ * dialog is already on screen and must not be torn down over a bookkeeping
+ * write.
+ */
+export async function POST() {
+  const supabase = createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+  const { error } = await supabase
+    .from("profiles")
+    .update({ founder_call_prompted_at: new Date().toISOString() })
+    .eq("id", user.id)
+    .is("founder_call_prompted_at", null);
+
+  if (error) {
+    console.error("[lettertrace:founder-call] could not record the offer", error.message);
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -7,6 +7,8 @@ import { WhyFree } from "@/components/dashboard/why-free";
 import { TrialBanner } from "@/components/dashboard/trial-banner";
 import { LetterproveAttest } from "@/components/letterprove-attest";
 import { isFirstSignIn } from "@/lib/letterprove";
+import { FounderCallOffer } from "@/components/dashboard/founder-call";
+import { founderCallUrl, shouldOfferFounderCall, withinSignupWindow } from "@/lib/founder-call";
 import { RunReadyBanner } from "@/components/dashboard/run-ready-banner";
 import { ThemeToggle } from "@/components/theme";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
@@ -56,6 +58,28 @@ export default async function DashboardLayout({
     }
   }
 
+  // Founder-call offer, for new signups only and only once ever. Both guards
+  // short-circuit before any query: unset URL means the feature does not exist
+  // (self-hosted images ship without it), and the signup window means an
+  // established account costs nothing to skip.
+  const callUrl = founderCallUrl();
+  let offerFounderCall = false;
+  if (callUrl && withinSignupWindow(user.created_at)) {
+    const { data: offerState } = await supabase
+      .from("profiles")
+      .select("founder_call_prompted_at")
+      .eq("id", user.id)
+      .maybeSingle();
+    offerFounderCall = shouldOfferFounderCall({
+      url: callUrl,
+      createdAt: user.created_at,
+      // A failed read yields undefined, which is deliberately NOT treated as
+      // "never asked" — see shouldOfferFounderCall.
+      promptedAt: (offerState as { founder_call_prompted_at: string | null } | null)
+        ?.founder_call_prompted_at,
+    });
+  }
+
   // Trial banner state: only when a trial is offered and the user is relying on
   // shared keys. Key resolution prefers the user's own key from EITHER
   // provider, so any own key at all means they're never on the trial.
@@ -80,6 +104,10 @@ export default async function DashboardLayout({
           this boundary — and because `user` is already resolved above, so it
           costs no extra query. Only the domain of the address is ever sent. */}
       <LetterproveAttest email={user.email} firstSignIn={isFirstSignIn(user)} />
+
+      {/* Mounted in the layout, not a page, so the 30s countdown survives
+          navigating between dashboard routes. */}
+      {offerFounderCall && callUrl && <FounderCallOffer url={callUrl} />}
 
       <aside className="flex flex-col border-b border-ink/10 bg-paper md:h-screen md:w-[260px] md:shrink-0 md:border-b-0 md:border-r">
         <div className="flex flex-col gap-6 px-5 py-6 md:h-full">

--- a/components/dashboard/founder-call.tsx
+++ b/components/dashboard/founder-call.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { CalendarCheck, X } from "lucide-react";
+import { ArrowRight, CalendarCheck, X } from "lucide-react";
 import { Button } from "@/components/ui";
 import { FOUNDER_CALL_DELAY_MS } from "@/lib/founder-call";
 
@@ -84,6 +84,10 @@ function FounderCallDialog({ url, onClose }: { url: string; onClose: () => void 
 		>
 			<div className="absolute inset-0 bg-ink/40 backdrop-blur-sm animate-fade-up" onClick={onClose} />
 
+			{/* Composed from the marketing page's own vocabulary — mono eyebrow,
+			    serif heading, terracotta glyph in a rounded square, arrow on the
+			    primary action — so the first thing a new user is asked inside the
+			    product looks like the site that sold it to them. */}
 			<div className="relative w-full max-w-md overflow-hidden rounded border border-ink/10 bg-paper shadow-lift animate-fade-up">
 				<button
 					type="button"
@@ -94,27 +98,39 @@ function FounderCallDialog({ url, onClose }: { url: string; onClose: () => void 
 					<X className="h-4 w-4" />
 				</button>
 
-				<div className="px-6 pb-6 pt-7">
-					<span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-teal/10 text-teal">
-						<CalendarCheck className="h-5 w-5" />
-					</span>
+				<div className="p-6">
+					{/* Glyph leads the eyebrow rather than sitting opposite it: the top
+					    right corner belongs to the close button, and the two collided
+					    there. `pr-8` keeps the row clear of it at narrow widths. */}
+					<div className="flex items-center gap-3 pr-8">
+						<span className="flex h-9 w-9 shrink-0 items-center justify-center rounded bg-ink/[0.04] text-terracotta-dark">
+							<CalendarCheck className="h-5 w-5" />
+						</span>
+						<p className="mono-eyebrow">getting started</p>
+					</div>
 
-					<h2 id="founder-call-title" className="mt-4 text-lg font-semibold tracking-tight text-ink">
+					<h2
+						id="founder-call-title"
+						className="mt-4 text-2xl font-semibold tracking-tight text-ink"
+					>
 						Want a hand getting set up?
 					</h2>
 
-					<p className="mt-2 text-sm leading-relaxed text-ink-soft">
-						Book time with Mathew, our founder. He&apos;ll walk you through setting up your
-						brand and topics, and what to watch for once results start coming in. No pitch —
-						it&apos;s the fastest way to get something useful out of Lettertrace.
+					<p className="mt-3 text-sm leading-relaxed text-ink-faint">
+						Book time with Mathew, our founder. He&apos;ll walk you through your brand and
+						topics, and what to watch for once results start coming in.
 					</p>
 
-					<div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-						<Button variant="ghost" size="sm" onClick={onClose}>
-							Not right now
-						</Button>
-						<Button variant="primary" size="sm" onClick={book}>
+					{/* Stacked rather than side by side, so the two options are not read
+					    as equal weight. Booking is the reason the dialog exists; declining
+					    stays one click away but does not compete for the same line. */}
+					<div className="mt-7 flex flex-col gap-1">
+						<Button size="lg" onClick={book} className="w-full">
 							Pick a time
+							<ArrowRight className="h-4 w-4" />
+						</Button>
+						<Button variant="ghost" size="sm" onClick={onClose} className="w-full">
+							Not right now
 						</Button>
 					</div>
 				</div>

--- a/components/dashboard/founder-call.tsx
+++ b/components/dashboard/founder-call.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { CalendarCheck, X } from "lucide-react";
+import { Button } from "@/components/ui";
+import { FOUNDER_CALL_DELAY_MS } from "@/lib/founder-call";
+
+/**
+ * Offers a setup call with the founder, once, half a minute after a new user
+ * lands in the dashboard.
+ *
+ * Whether this user is eligible is decided on the server (see the dashboard
+ * layout) — this island only owns the timer and the dialog. It is mounted in
+ * the layout rather than a page so the countdown survives navigating between
+ * dashboard routes: someone clicking around for the first thirty seconds is
+ * exactly who the offer is for, and a per-page timer would keep restarting and
+ * never fire for them.
+ *
+ * The offer is marked as made when it is SHOWN, not when it is answered.
+ * Recording it on dismissal would leave a user who closes the tab mid-dialog
+ * eligible forever, and being asked the same question on every visit reads as
+ * broken software rather than attentiveness. One ask is the product decision;
+ * this is where it is enforced.
+ */
+export function FounderCallOffer({ url }: { url: string }) {
+	const [open, setOpen] = useState(false);
+
+	useEffect(() => {
+		const timer = setTimeout(() => setOpen(true), FOUNDER_CALL_DELAY_MS);
+		return () => clearTimeout(timer);
+	}, []);
+
+	if (!open) return null;
+	return <FounderCallDialog url={url} onClose={() => setOpen(false)} />;
+}
+
+function FounderCallDialog({ url, onClose }: { url: string; onClose: () => void }) {
+	const [mounted, setMounted] = useState(false);
+	const marked = useRef(false);
+
+	useEffect(() => setMounted(true), []);
+
+	// Record the ask as soon as it is on screen. keepalive so it still lands if
+	// the user books immediately and the tab navigates away mid-flight.
+	useEffect(() => {
+		if (marked.current) return;
+		marked.current = true;
+		// A failure here costs one repeated prompt on a later visit, which is a
+		// far better outcome than blocking the dialog on a write.
+		void fetch("/api/founder-call", { method: "POST", keepalive: true }).catch(() => {});
+	}, []);
+
+	// Escape to close; lock body scroll while the dialog is up. Same handling as
+	// the "Why is this free?" dialog.
+	useEffect(() => {
+		const onKey = (e: KeyboardEvent) => {
+			if (e.key === "Escape") onClose();
+		};
+		document.addEventListener("keydown", onKey);
+		const prev = document.body.style.overflow;
+		document.body.style.overflow = "hidden";
+		return () => {
+			document.removeEventListener("keydown", onKey);
+			document.body.style.overflow = prev;
+		};
+	}, [onClose]);
+
+	const book = useCallback(() => {
+		// noopener/noreferrer on an untrusted-by-default external target, and a
+		// new tab so a half-finished onboarding form is not thrown away.
+		window.open(url, "_blank", "noopener,noreferrer");
+		onClose();
+	}, [url, onClose]);
+
+	if (!mounted) return null;
+
+	return createPortal(
+		<div
+			className="fixed inset-0 z-[60] flex items-center justify-center p-4"
+			role="dialog"
+			aria-modal="true"
+			aria-labelledby="founder-call-title"
+		>
+			<div className="absolute inset-0 bg-ink/40 backdrop-blur-sm animate-fade-up" onClick={onClose} />
+
+			<div className="relative w-full max-w-md overflow-hidden rounded border border-ink/10 bg-paper shadow-lift animate-fade-up">
+				<button
+					type="button"
+					onClick={onClose}
+					aria-label="Close"
+					className="absolute right-3 top-3 rounded p-1.5 text-ink-faint transition hover:bg-ink/[0.05] hover:text-ink"
+				>
+					<X className="h-4 w-4" />
+				</button>
+
+				<div className="px-6 pb-6 pt-7">
+					<span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-teal/10 text-teal">
+						<CalendarCheck className="h-5 w-5" />
+					</span>
+
+					<h2 id="founder-call-title" className="mt-4 text-lg font-semibold tracking-tight text-ink">
+						Want a hand getting set up?
+					</h2>
+
+					<p className="mt-2 text-sm leading-relaxed text-ink-soft">
+						Book time with Mathew, our founder. He&apos;ll walk you through setting up your
+						brand and topics, and what to watch for once results start coming in. No pitch —
+						it&apos;s the fastest way to get something useful out of Lettertrace.
+					</p>
+
+					<div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+						<Button variant="ghost" size="sm" onClick={onClose}>
+							Not right now
+						</Button>
+						<Button variant="primary" size="sm" onClick={book}>
+							Pick a time
+						</Button>
+					</div>
+				</div>
+			</div>
+		</div>,
+		document.body,
+	);
+}

--- a/lib/founder-call.test.ts
+++ b/lib/founder-call.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { FOUNDER_CALL_WINDOW_DAYS, shouldOfferFounderCall, withinSignupWindow } from "./founder-call";
+
+const NOW = Date.parse("2026-08-18T12:00:00Z");
+const days = (n: number) => new Date(NOW - n * 24 * 60 * 60 * 1000).toISOString();
+
+const URL = "https://the-letter-company.cal.com/mathew";
+
+describe("withinSignupWindow", () => {
+	it("accepts an account created moments ago", () => {
+		expect(withinSignupWindow(days(0), NOW)).toBe(true);
+	});
+
+	// Signing up and actually coming back to try it are frequently not the same
+	// day, which is why the window is days rather than the session.
+	it("accepts an account that comes back a few days later", () => {
+		expect(withinSignupWindow(days(FOUNDER_CALL_WINDOW_DAYS - 1), NOW)).toBe(true);
+	});
+
+	it("rejects an account past the window", () => {
+		expect(withinSignupWindow(days(FOUNDER_CALL_WINDOW_DAYS + 1), NOW)).toBe(false);
+	});
+
+	// The point of the window: shipping this must not fire a "need help getting
+	// started?" dialog at the entire existing user base.
+	it("rejects a long-established account", () => {
+		expect(withinSignupWindow(days(400), NOW)).toBe(false);
+	});
+
+	/**
+	 * A wrong "yes" is spent — the offer is made once and never repeats — so
+	 * every unusable timestamp resolves to no.
+	 */
+	it("rejects a missing or unparseable timestamp rather than guessing", () => {
+		expect(withinSignupWindow(undefined, NOW)).toBe(false);
+		expect(withinSignupWindow("", NOW)).toBe(false);
+		expect(withinSignupWindow("not a date", NOW)).toBe(false);
+	});
+
+	it("treats a clock-skewed future timestamp as new, not ancient", () => {
+		expect(withinSignupWindow(days(-1), NOW)).toBe(true);
+	});
+});
+
+describe("shouldOfferFounderCall", () => {
+	const base = { url: URL, createdAt: days(0), promptedAt: null, now: NOW };
+
+	it("offers to a new user who has never been asked", () => {
+		expect(shouldOfferFounderCall(base)).toBe(true);
+	});
+
+	/**
+	 * The self-hosting guard. This repo ships as a container image, and an
+	 * operator running their own Lettertrace must never have their users offered
+	 * a meeting with our founder. Unset means the feature does not exist.
+	 */
+	it("is off entirely when no URL is configured", () => {
+		expect(shouldOfferFounderCall({ ...base, url: null })).toBe(false);
+		expect(shouldOfferFounderCall({ ...base, url: "" })).toBe(false);
+	});
+
+	it("never asks twice", () => {
+		expect(shouldOfferFounderCall({ ...base, promptedAt: "2026-08-17T09:00:00Z" })).toBe(false);
+	});
+
+	/**
+	 * An unreadable profile row yields undefined, and undefined must not read as
+	 * "never asked" — that would re-offer on every single render for as long as
+	 * the read keeps failing, which is the most annoying possible failure mode.
+	 */
+	it("stays quiet when the row could not be read at all", () => {
+		expect(shouldOfferFounderCall({ ...base, promptedAt: undefined })).toBe(false);
+	});
+
+	it("does not offer to an established user, asked or not", () => {
+		expect(shouldOfferFounderCall({ ...base, createdAt: days(30) })).toBe(false);
+	});
+});

--- a/lib/founder-call.ts
+++ b/lib/founder-call.ts
@@ -1,0 +1,67 @@
+/**
+ * The founder-call offer: a one-time nudge, shortly after signup, asking
+ * whether the user wants a walkthrough with the founder.
+ *
+ * Off unless `FOUNDER_CALL_URL` is set, in the same spirit as PostHog and the
+ * RB2B pixel. That is not a stylistic choice — this repo ships as a
+ * self-hostable container, and an operator running their own Lettertrace must
+ * never have their users offered a meeting with *our* founder. Unset means the
+ * feature does not exist, not that it is merely hidden.
+ *
+ * Deliberately NOT `NEXT_PUBLIC_`, unlike those two. Next inlines that prefix
+ * into the client bundle at BUILD time (see lib/public-env.ts, which exists
+ * entirely because of that behaviour), and this repo publishes a prebuilt
+ * image. A public-prefixed name would bake whatever we built with into every
+ * operator's container. This value is only ever read on the server and reaches
+ * the browser as a prop, so it never needs to be public — which sidesteps the
+ * whole problem rather than working around it.
+ *
+ * The window exists so the offer reaches new signups and nobody else. Without
+ * it, shipping this would show a "need help getting started?" dialog to every
+ * existing user on their next visit, which is a different (and unasked-for)
+ * campaign. Seven days rather than "this session" because signing up and
+ * actually coming back to try it are frequently not the same day.
+ */
+
+export const FOUNDER_CALL_WINDOW_DAYS = 7;
+
+/** How long after arriving before the offer appears. */
+export const FOUNDER_CALL_DELAY_MS = 30_000;
+
+export function founderCallUrl(): string | null {
+	return process.env.FOUNDER_CALL_URL || null;
+}
+
+/**
+ * Is this account new enough to be offered a founder call?
+ *
+ * Returns false for an unparseable or missing timestamp rather than defaulting
+ * to true: the failure mode of guessing "new" is prompting someone who signed
+ * up a year ago, and the offer is not repeatable, so a wrong yes is spent.
+ */
+export function withinSignupWindow(createdAt: string | undefined, now = Date.now()): boolean {
+	if (!createdAt) return false;
+	const created = Date.parse(createdAt);
+	if (Number.isNaN(created)) return false;
+	const age = now - created;
+	// A clock-skewed future timestamp is still a new account, not an old one.
+	return age < FOUNDER_CALL_WINDOW_DAYS * 24 * 60 * 60 * 1000;
+}
+
+/**
+ * The whole server-side decision, as a pure function so it can be tested
+ * without a database or a browser.
+ */
+export function shouldOfferFounderCall(input: {
+	url: string | null;
+	createdAt: string | undefined;
+	promptedAt: string | null | undefined;
+	now?: number;
+}): boolean {
+	if (!input.url) return false;
+	// Already asked. Null is "never asked"; undefined means we could not read
+	// the row, and an unreadable row must not be treated as never — that would
+	// re-offer on every render for as long as the read keeps failing.
+	if (input.promptedAt !== null) return false;
+	return withinSignupWindow(input.createdAt, input.now);
+}

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -44,6 +44,16 @@ alter table public.profiles
 alter table public.profiles
   add column if not exists trial_tokens_used bigint not null default 0;
 
+-- When the founder-call offer was shown to this user. Null means never.
+--
+-- Server-side rather than localStorage for the same reason admin_alerted_at is:
+-- the offer must go out exactly once per person, not once per browser. A user
+-- who signs in on a phone and a laptop, or clears site data, would otherwise be
+-- asked again — and a repeated "want help getting started?" reads as broken
+-- rather than attentive. See FounderCallOffer in components/dashboard.
+alter table public.profiles
+  add column if not exists founder_call_prompted_at timestamptz;
+
 -- Atomic increment, self-scoped to the caller via auth.uid() (so a user can
 -- only ever add to their own tally). Called by the trial run/generate routes.
 create or replace function public.increment_trial_tokens(amount bigint)


### PR DESCRIPTION
Thirty seconds after a new signup reaches the dashboard, a dialog asks whether they want to book time with Mathew. **One ask, ever.**

<img width="520" alt="Want a hand getting set up?" src="https://github.com/user-attachments/assets/placeholder" />

> **Want a hand getting set up?**
> Book time with Mathew, our founder. He'll walk you through setting up your brand and topics, and what to watch for once results start coming in. No pitch — it's the fastest way to get something useful out of Lettertrace.
>
> `Not right now`  ·  **`Pick a time`**

## Three decisions worth stating

Each is somewhere this could have gone wrong quietly.

**Once per person, not per browser.** The flag is a column on `profiles`, same shape and same reason as `admin_alerted_at`: signing in on a phone and a laptop, or clearing site data, must not trigger a second ask. A repeated *"want help getting started?"* reads as broken software rather than attentiveness. The update is conditional on the column still being null, so a double render or a second tab can't move it.

**Marked when shown, not when answered.** Recording on dismissal would leave anyone who closes the tab mid-dialog eligible forever — the exact thing the guard exists to prevent.

**New signups only.** Without a window, merging this fires the dialog at the *entire existing user base* on their next visit, which is a different campaign from the one asked for. Seven days rather than "this session", because signing up and coming back to actually try it are frequently not the same day.

## `FOUNDER_CALL_URL` is deliberately not `NEXT_PUBLIC_`

Next inlines that prefix into the client bundle **at build time** — `lib/public-env.ts` exists entirely because of that behaviour — and this repo publishes a prebuilt image. A public name would bake our booking link into every operator's container.

The value is read only on the server and reaches the browser as a prop, so it never needs to be public. **Unset means the feature does not exist**, which is the right default for a self-hosted install: an operator's users must never be pointed at our founder's calendar. Documented in the README and `.env.example` alongside the RB2B note that makes the same promise.

## Smaller things

The island lives in the **layout**, not a page, so the countdown survives navigating between dashboard routes — someone clicking around for the first thirty seconds is exactly who this is for, and a per-page timer would restart and never fire for them.

The dialog mirrors the existing "Why is this free?" one: portal, escape to close, backdrop click, body scroll lock. Booking opens in a new tab so a half-finished onboarding form isn't thrown away.

Both server-side guards short-circuit **before any query**, so this costs nothing when the URL is unset or the account is established.

## Verification

732 tests (11 new), `tsc`, lint and build clean. Rendered the dialog against the real dashboard theme rather than assuming it matched.

## To turn it on

Set `FOUNDER_CALL_URL=https://the-letter-company.cal.com/mathew` in Vercel **production only**, and apply the new `profiles.founder_call_prompted_at` column. Until the env var is set, nothing changes for anyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789694756&installation_model_id=431526&pr_number=137&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F137&signature=8a1879a1b5e83c09b4b84f1de178634b935ba88e3b1ac58cd6352c2210d57d96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->