### PR TITLE
Copy fix, and tag the booking link with where it came from

### DIFF
--- a/components/dashboard/founder-call.tsx
+++ b/components/dashboard/founder-call.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { ArrowRight, CalendarCheck, X } from "lucide-react";
 import { Button } from "@/components/ui";
-import { FOUNDER_CALL_DELAY_MS } from "@/lib/founder-call";
+import { FOUNDER_CALL_DELAY_MS, taggedBookingUrl } from "@/lib/founder-call";
 
 /**
  * Offers a setup call with the founder, once, half a minute after a new user
@@ -69,7 +69,7 @@ function FounderCallDialog({ url, onClose }: { url: string; onClose: () => void 
 	const book = useCallback(() => {
 		// noopener/noreferrer on an untrusted-by-default external target, and a
 		// new tab so a half-finished onboarding form is not thrown away.
-		window.open(url, "_blank", "noopener,noreferrer");
+		window.open(taggedBookingUrl(url), "_blank", "noopener,noreferrer");
 		onClose();
 	}, [url, onClose]);
 
@@ -118,7 +118,7 @@ function FounderCallDialog({ url, onClose }: { url: string; onClose: () => void 
 
 					<p className="mt-3 text-sm leading-relaxed text-ink-faint">
 						Book time with Mathew, our founder. He&apos;ll walk you through your brand and
-						topics, and what to watch for once results start coming in.
+						topics, and what to watch out for once results start coming in.
 					</p>
 
 					{/* Stacked rather than side by side, so the two options are not read

--- a/lib/founder-call.test.ts
+++ b/lib/founder-call.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { FOUNDER_CALL_WINDOW_DAYS, shouldOfferFounderCall, withinSignupWindow } from "./founder-call";
+import { FOUNDER_CALL_WINDOW_DAYS, shouldOfferFounderCall, taggedBookingUrl, withinSignupWindow } from "./founder-call";
 
 const NOW = Date.parse("2026-08-18T12:00:00Z");
 const days = (n: number) => new Date(NOW - n * 24 * 60 * 60 * 1000).toISOString();
 
-const URL = "https://the-letter-company.cal.com/mathew";
+const CAL_LINK = "https://the-letter-company.cal.com/mathew";
 
 describe("withinSignupWindow", () => {
 	it("accepts an account created moments ago", () => {
@@ -43,7 +43,7 @@ describe("withinSignupWindow", () => {
 });
 
 describe("shouldOfferFounderCall", () => {
-	const base = { url: URL, createdAt: days(0), promptedAt: null, now: NOW };
+	const base = { url: CAL_LINK, createdAt: days(0), promptedAt: null, now: NOW };
 
 	it("offers to a new user who has never been asked", () => {
 		expect(shouldOfferFounderCall(base)).toBe(true);
@@ -74,5 +74,36 @@ describe("shouldOfferFounderCall", () => {
 
 	it("does not offer to an established user, asked or not", () => {
 		expect(shouldOfferFounderCall({ ...base, createdAt: days(30) })).toBe(false);
+	});
+});
+
+describe("taggedBookingUrl", () => {
+	it("tags the booking so it can be attributed to this dialog", () => {
+		const u = new URL(taggedBookingUrl("https://the-letter-company.cal.com/mathew"));
+		expect(u.searchParams.get("metadata[source]")).toBe("lettertrace-dashboard");
+		expect(u.origin + u.pathname).toBe("https://the-letter-company.cal.com/mathew");
+	});
+
+	// Pointing FOUNDER_CALL_URL at a link that already carries parameters — a
+	// specific duration, say — must not silently drop them.
+	it("keeps parameters the configured link already had", () => {
+		const u = new URL(taggedBookingUrl("https://cal.com/x/y?duration=20&month=2026-09"));
+		expect(u.searchParams.get("duration")).toBe("20");
+		expect(u.searchParams.get("month")).toBe("2026-09");
+		expect(u.searchParams.get("metadata[source]")).toBe("lettertrace-dashboard");
+	});
+
+	it("does not stack duplicates if the tag is already present", () => {
+		const once = taggedBookingUrl("https://cal.com/x/y");
+		expect(taggedBookingUrl(once)).toBe(once);
+	});
+
+	/**
+	 * A booking link that works is worth more than attribution, so a value that
+	 * is not a URL is handed back untouched rather than mangled or dropped —
+	 * misconfiguration should degrade to "no tracking", never to "no booking".
+	 */
+	it("returns an unparseable value untouched rather than breaking the link", () => {
+		expect(taggedBookingUrl("not a url")).toBe("not a url");
 	});
 });

--- a/lib/founder-call.ts
+++ b/lib/founder-call.ts
@@ -33,6 +33,38 @@ export function founderCallUrl(): string | null {
 }
 
 /**
+ * Tags the booking link so a booking that came from this dialog can be told
+ * apart from one that came from a DM, the site, or a conference badge.
+ *
+ * Cal.com reads `metadata[key]=value` off the URL, stores it on the booking row
+ * and passes it through to webhooks. It is invisible to the person booking,
+ * which is what makes it honest attribution rather than a message: it records
+ * where the click came from and does not put words in their mouth.
+ *
+ * What this CANNOT do is change what the invite says. A Cal event's title,
+ * description and duration live on the event type, not the URL — so making the
+ * meeting read "Lettertrace setup call" is a change on Cal's side, not here.
+ * Because the link is an env var, swapping to a dedicated event type needs no
+ * deploy.
+ *
+ * Any query string already on the configured URL is preserved, so pointing
+ * FOUNDER_CALL_URL at a link that carries its own parameters keeps working.
+ * An unparseable URL is returned untouched rather than dropped — a booking link
+ * that works is worth more than attribution.
+ */
+export const FOUNDER_CALL_SOURCE = "lettertrace-dashboard";
+
+export function taggedBookingUrl(base: string, source = FOUNDER_CALL_SOURCE): string {
+	try {
+		const url = new URL(base);
+		url.searchParams.set("metadata[source]", source);
+		return url.toString();
+	} catch {
+		return base;
+	}
+}
+
+/**
  * Is this account new enough to be offered a founder call?
  *
  * Returns false for an unparseable or missing timestamp rather than defaulting


### PR DESCRIPTION
Two things.

## Copy

"what to watch for" → "what to watch **out** for".

## Attribution

Cal.com reads `metadata[key]=value` off the booking URL, stores it on the booking row, and passes it through to webhooks. So the link now carries:

```
https://the-letter-company.cal.com/mathew?metadata%5Bsource%5D=lettertrace-dashboard
```

Verified it still resolves 200. It's invisible to the person booking, which is what makes it attribution rather than a message — it records where the click came from without putting words in their mouth.

**What this can't do:** change what the invite says. A Cal event's title, description and duration live on the **event type**, not the URL, so no query parameter will make the meeting read "Lettertrace setup call". That's a change on Cal's side — and since the link is an env var, pointing at a dedicated event type later needs no deploy.

Existing parameters are preserved (so a link carrying its own `duration` keeps it), re-tagging is idempotent, and a value that won't parse as a URL is returned untouched: misconfiguration should degrade to *no attribution*, never to *no booking*.

## One bug the new tests caught

The test file had a top-level `const URL = "https://…"` shadowing the global `URL` constructor. Harmless until something in that file actually needed `new URL()`, at which point it failed with `URL is not a constructor`. Renamed to `CAL_LINK`.

738 tests (4 new); `tsc` and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789702088&installation_model_id=431526&pr_number=139&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F139&signature=08d2b7137c594cec23ada52a14a252ff87edd350964c9023ac0af034fc8241dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->