### PR TITLE
Surface the monitoring schedule on the Runs page, and say when it won't fire

### DIFF
--- a/app/api/project/schedule/route.ts
+++ b/app/api/project/schedule/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { getProject } from "@/lib/data";
+import { humanError } from "@/lib/llm";
+import { logDashboard } from "@/lib/activity";
+import type { Schedule } from "@/lib/types";
+
+const SCHEDULES: Schedule[] = ["off", "daily", "weekly"];
+
+// Schedule-only write, so the Runs page can offer the toggle where people
+// actually go looking for it. POST /api/project is a full-form upsert —
+// requires name and brand_name, and rewrites aliases, domains and description
+// from the body — so a control that only wants to flip the schedule can't
+// safely go through it.
+export async function PATCH(request: Request) {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  const schedule = (body as { schedule?: unknown } | null)?.schedule;
+  if (typeof schedule !== "string" || !SCHEDULES.includes(schedule as Schedule)) {
+    return NextResponse.json(
+      { error: "schedule must be one of off, daily or weekly" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const project = await getProject(supabase, user.id);
+    if (!project) {
+      return NextResponse.json({ error: "No project yet" }, { status: 404 });
+    }
+
+    const { data, error } = await supabase
+      .from("projects")
+      .update({ schedule, updated_at: new Date().toISOString() })
+      .eq("id", project.id)
+      .eq("user_id", user.id)
+      .select("*")
+      .single();
+
+    if (error) {
+      return NextResponse.json({ error: humanError(error) }, { status: 500 });
+    }
+
+    await logDashboard(user, request, {
+      category: "project",
+      action: "project.updated",
+      summary: `Set monitoring schedule to ${schedule}`,
+      projectId: project.id,
+      targetType: "project",
+      targetId: project.id,
+      metadata: { schedule },
+    });
+    return NextResponse.json(data);
+  } catch (e) {
+    return NextResponse.json({ error: humanError(e) }, { status: 500 });
+  }
+}

--- a/app/dashboard/runs/page.tsx
+++ b/app/dashboard/runs/page.tsx
@@ -16,6 +16,7 @@ import {
   EmptyState,
 } from "@/components/ui";
 import { RunNow } from "./run-now";
+import { ScheduleControl } from "./schedule-control";
 
 export const dynamic = "force-dynamic";
 
@@ -106,6 +107,15 @@ export default async function RunsPage() {
             providerLabel={PROVIDERS[project.default_provider].label}
           />
         }
+      />
+
+      {/* The schedule lives on the project settings form too, but this page is
+          where people go to make runs happen — it's where "how do I run this
+          daily?" gets asked. */}
+      <ScheduleControl
+        schedule={project.schedule}
+        keySource={key.source}
+        providerLabel={PROVIDERS[project.default_provider].label}
       />
 
       {runs.length === 0 ? (

--- a/app/dashboard/runs/schedule-control.tsx
+++ b/app/dashboard/runs/schedule-control.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { CalendarClock } from "lucide-react";
+import { Card, CardBody, Select } from "@/components/ui";
+import { SCHEDULE_LABELS } from "@/lib/utils";
+import type { KeySource } from "@/lib/trial";
+import type { Schedule } from "@/lib/types";
+
+export function ScheduleControl({
+  schedule: saved,
+  keySource,
+  providerLabel,
+}: {
+  schedule: Schedule;
+  /** Whose key the next run would use. Scheduled runs are strictly self-funded
+   *  (the cron skips anything but 'own'), so any other source means a schedule
+   *  set here silently never fires — the exact state this control exists to
+   *  make visible instead of silent. */
+  keySource: KeySource;
+  providerLabel: string;
+}) {
+  const router = useRouter();
+  const [schedule, setSchedule] = useState<Schedule>(saved);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function save(next: Schedule) {
+    const previous = schedule;
+    setSchedule(next);
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/project/schedule", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ schedule: next }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok || data?.error) {
+        setSchedule(previous);
+        setError(data?.error ?? "Couldn't save the schedule.");
+        return;
+      }
+      router.refresh();
+    } catch {
+      setSchedule(previous);
+      setError("Network error, please try again.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const scheduled = schedule !== "off";
+  // Trial users can press "Run monitor now", so canRun doesn't capture this —
+  // only an own key lets the cron actually run the project.
+  const willFire = keySource === "own";
+
+  return (
+    <Card>
+      <CardBody className="flex flex-wrap items-center justify-between gap-4 p-5">
+        <div className="flex min-w-0 items-start gap-3">
+          <CalendarClock className="mt-0.5 h-5 w-5 shrink-0 text-ink-faint" />
+          <div className="min-w-0 space-y-0.5">
+            <p className="text-sm font-medium text-ink">Automatic runs</p>
+            {!scheduled && (
+              <p className="text-xs text-ink-faint">
+                Run your prompts on a schedule — around 8:00 UTC — instead of by
+                hand, and build a trend over time.
+              </p>
+            )}
+            {scheduled && willFire && (
+              <p className="text-xs text-ink-faint">
+                Runs {schedule} around 8:00 UTC on your own key.
+              </p>
+            )}
+            {/* The schedule is set but the cron will skip it. Without this line
+                the skip has no surface at all: the cron's "skipped" lands only
+                in its own JSON response and a span attribute. */}
+            {scheduled && !willFire && (
+              <p className="text-xs text-terracotta">
+                Scheduled runs use your own key, so this {SCHEDULE_LABELS[schedule].toLowerCase()}{" "}
+                schedule won&apos;t run yet. Add your {providerLabel} key in{" "}
+                <Link
+                  href="/dashboard/settings"
+                  className="text-terracotta-dark underline hover:text-terracotta"
+                >
+                  Settings
+                </Link>{" "}
+                to turn it on.
+              </p>
+            )}
+            {error && <p className="text-xs text-terracotta">{error}</p>}
+          </div>
+        </div>
+        <Select
+          aria-label="Monitoring schedule"
+          value={schedule}
+          disabled={saving}
+          onChange={(e) => save(e.target.value as Schedule)}
+          className="w-auto"
+        >
+          {(["off", "daily", "weekly"] as Schedule[]).map((s) => (
+            <option key={s} value={s}>
+              {SCHEDULE_LABELS[s]}
+            </option>
+          ))}
+        </Select>
+      </CardBody>
+    </Card>
+  );
+}

--- a/app/dashboard/settings/project-form.tsx
+++ b/app/dashboard/settings/project-form.tsx
@@ -11,14 +11,8 @@ import {
   engineCoverage,
   type RouterCoverage,
 } from "@/lib/routers";
-import { article } from "@/lib/utils";
+import { article, SCHEDULE_LABELS } from "@/lib/utils";
 import type { Project, Provider, Schedule } from "@/lib/types";
-
-const SCHEDULE_LABELS: Record<Schedule, string> = {
-  off: "Manual only",
-  daily: "Daily",
-  weekly: "Weekly",
-};
 
 // The answer engine is stored as a (provider, model) pair; the picker packs
 // both into one "provider:model" option value and unpacks on submit.

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,3 +1,5 @@
+import type { Schedule } from "@/lib/types";
+
 // Tiny className combiner (no external deps). Filters falsy, joins with spaces.
 export function cn(...parts: Array<string | false | null | undefined>): string {
   return parts.filter(Boolean).join(" ");
@@ -106,3 +108,12 @@ export function formatDate(iso: string | null): string {
 export function article(word: string): "a" | "an" {
   return /^[aeiou]/i.test(word.trim()) ? "an" : "a";
 }
+
+/** The one wording of each schedule option, shared by every surface that
+ *  offers the setting (Settings form, Runs page) so the same choice can't be
+ *  called two different things. */
+export const SCHEDULE_LABELS: Record<Schedule, string> = {
+  off: "Manual only",
+  daily: "Daily",
+  weekly: "Weekly",
+};


### PR DESCRIPTION
## What

Prompted by Mathew's "how do I set it up to run once a day?" — the daily scheduler already exists end-to-end (`projects.schedule`, the 08:00 UTC Vercel cron, `isDue`), but it was hidden in the Settings form, and even when set, the cron's self-funded-only rule meant a trial-keyed project was skipped with no trace in the UI.

- **New "Automatic runs" card on the Runs page** (the page where people go to make runs happen) with the Manual only / Daily / Weekly selector, saving on change.
- **The silent skip is now visible**: when a schedule is set but the run key isn't the user's own (complimentary tokens, no key, mismatch), the card says the schedule won't run and links to Settings. Previously the skip surfaced only in the cron's JSON response and a span attribute.
- **New `PATCH /api/project/schedule`** for the schedule-only write. `POST /api/project` is a full-form upsert (requires name/brand_name, rewrites aliases/domains/description), so the inline control couldn't safely reuse it. Same cookie auth + activity logging.
- `SCHEDULE_LABELS` moved to `lib/utils` so the Settings form and the new card share one wording.

## What this deliberately does not change

- New projects still default to `schedule: "off"` — flipping the default spends real money for own-key users, so that's a product call.
- The cron itself is untouched.

## Testing

- `npm test` — 738 passing
- `tsc --noEmit` and `next lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WV3hpgdqARW5DFCtTupT9

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789838719&installation_model_id=431526&pr_number=142&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F142&signature=af30d8f3aac363a82213be9b2387d3014f00529ba90136e404647ef34dde113e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->