### PR TITLE
The visibility overhaul: steerable prompts, multi-engine runs, overall visibility

### DIFF
--- a/app/api/cron/run/route.ts
+++ b/app/api/cron/run/route.ts
@@ -2,7 +2,13 @@ import crypto from "node:crypto";
 import { NextResponse } from "next/server";
 import { createServiceClient } from "@/lib/supabase/server";
 import { executeRun, sweepAbandonedRuns } from "@/lib/engine";
-import { resolveRunKey } from "@/lib/trial";
+import {
+  resolveRunKey,
+  consumeTrialRunFor,
+  recordTrialUsageFor,
+  recordTrialSpendFor,
+  runBudgetMicros,
+} from "@/lib/trial";
 import { withSpan } from "@/lib/otel";
 import type { Span } from "@opentelemetry/api";
 import type { Project } from "@/lib/types";
@@ -83,17 +89,29 @@ async function sweepAndRun(span: Span) {
       // with "no key" as the only trace. The resolver also knows whether the
       // project's grounding survives the route.
       //
-      // Scheduled runs stay strictly self-funded: `source` is 'own' for both a
-      // direct key and a router key, and anything else — including a trial with
-      // free runs left — is skipped, so an unattended schedule can never spend
-      // the operator's allowance.
+      // Scheduled runs execute on the user's own key, or on the trial while
+      // its allowance lasts — "cadence from the onset": onboarding starts
+      // every project on a daily schedule, and the trial funds the beginning.
+      // The same atomic gate as manual runs applies, via the service-scoped
+      // RPC (auth.uid() doesn't exist here); when the allowance is out — or
+      // the RPC isn't applied to this database yet — the consume returns
+      // false and the project is skipped, exactly as it always was.
       const key = await resolveRunKey(supabase, project.user_id, project);
-      if (key.source !== "own" || !key.apiKey) {
+      const usable =
+        (key.source === "own" || key.source === "trial") && Boolean(key.apiKey);
+      if (!usable) {
         results.push({
           projectId: project.id,
           status: "skipped",
           reason: key.source === "own" ? "no key" : key.source,
         });
+        continue;
+      }
+      if (
+        key.source === "trial" &&
+        !(await consumeTrialRunFor(supabase, project.user_id))
+      ) {
+        results.push({ projectId: project.id, status: "skipped", reason: "exhausted" });
         continue;
       }
 
@@ -102,8 +120,9 @@ async function sweepAndRun(span: Span) {
         project,
         provider: key.provider,
         model: key.model,
-        apiKey: key.apiKey,
+        apiKey: key.apiKey!,
         route: key.route,
+        budgetMicros: runBudgetMicros(key),
         context: {
           channel: "cron",
           actorType: "cron",
@@ -111,6 +130,10 @@ async function sweepAndRun(span: Span) {
           actorLabel: "Scheduler",
         },
       });
+      if (key.source === "trial") {
+        await recordTrialUsageFor(supabase, project.user_id, result.tokensUsed);
+        await recordTrialSpendFor(supabase, project.user_id, result.spendMicros);
+      }
       results.push({
         projectId: project.id,
         status: result.status,

--- a/app/api/onboarding/complete/route.ts
+++ b/app/api/onboarding/complete/route.ts
@@ -5,13 +5,19 @@ import { executeRun } from "@/lib/engine";
 import { humanError } from "@/lib/llm";
 import {
   resolveRunKey,
+  resolveRunKeyFor,
   consumeTrialRun,
   recordTrialUsage,
   recordTrialSpend,
   runBudgetMicros,
   pickDefaultProvider,
   engineKeyMessage,
+  trialCoveredProviders,
+  trialRunLimit,
+  getTrialUsage,
+  type ResolvedKey,
 } from "@/lib/trial";
+import { trialSpendLimitMicros } from "@/lib/pricing";
 import { defaultModelFor } from "@/lib/models";
 import { coveredProviders } from "@/lib/routers";
 import { normalizeCompetitorList } from "@/lib/competitors";
@@ -152,7 +158,11 @@ export async function POST(request: Request) {
       description,
       default_provider: provider,
       default_model: model,
-      schedule: "off",
+      // "Cadence from the onset": a new project monitors on a schedule from
+      // day one (trial-funded until the allowance runs out, then unblocked by
+      // the user's own key) instead of being a one-shot demo whose schedule
+      // hides in Settings. The Runs page control turns it off in one click.
+      schedule: "daily",
     })
     .select("*")
     .single();
@@ -216,9 +226,32 @@ export async function POST(request: Request) {
     if (rows.length) await supabase.from("prompts").insert(rows);
   }
 
-  // Immediately run the first search.
-  const key = await resolveRunKey(supabase, user.id, project);
-  if (!key.apiKey) {
+  // First measurement is a SWEEP: one run per engine the account can fund —
+  // the user's own coverage, plus the trial's while the allowance lasts — in
+  // parallel, so the wall clock stays roughly one run. Probing every engine on
+  // the first run maximizes the chance of finding a mention at all, which is
+  // the moment the product proves itself.
+  const usage = await getTrialUsage(supabase, user.id);
+  const trialActive =
+    usage.runs < trialRunLimit() && usage.spendMicros < trialSpendLimitMicros();
+  const sweep = Array.from(
+    new Set([...runnable, ...(trialActive ? trialCoveredProviders(true) : [])]),
+  );
+  // The project's own engine leads: its run is the one the response points at.
+  sweep.sort((a, b) =>
+    a === project.default_provider ? -1 : b === project.default_provider ? 1 : 0,
+  );
+
+  const keys: ResolvedKey[] = [];
+  for (const p of sweep) {
+    const k = await resolveRunKeyFor(supabase, user.id, p, defaultModelFor(p), {
+      webSearch: true,
+    });
+    if ((k.source === "own" || k.source === "trial") && k.apiKey) keys.push(k);
+  }
+
+  if (keys.length === 0) {
+    const key = await resolveRunKey(supabase, user.id, project);
     return NextResponse.json({
       projectId: project.id,
       ran: false,
@@ -229,8 +262,15 @@ export async function POST(request: Request) {
     });
   }
 
-  // Atomically consume a free run before executing (see /api/runs).
-  if (key.source === "trial" && !(await consumeTrialRun(supabase))) {
+  // Atomically consume a free run per trial-funded engine BEFORE executing
+  // (see /api/runs). Sequential on purpose: the sweep stops being granted runs
+  // at exactly the engine where the allowance ran out.
+  const funded: ResolvedKey[] = [];
+  for (const k of keys) {
+    if (k.source === "trial" && !(await consumeTrialRun(supabase))) continue;
+    funded.push(k);
+  }
+  if (funded.length === 0) {
     return NextResponse.json({
       projectId: project.id,
       ran: false,
@@ -238,36 +278,55 @@ export async function POST(request: Request) {
     });
   }
 
-  try {
-    const result = await executeRun({
-      supabase,
-      project,
-      provider: key.provider,
-      model: key.model,
-      apiKey: key.apiKey,
-      route: key.route,
-      budgetMicros: runBudgetMicros(key),
-      context: {
-        channel: "dashboard",
-        actorType: "user",
-        actorId: user.id,
-        actorLabel: user.email ?? "You",
-      },
-    });
-    if (key.source === "trial") {
-      await recordTrialUsage(supabase, result.tokensUsed);
-      await recordTrialSpend(supabase, result.spendMicros);
-    }
-    return NextResponse.json({
-      projectId: project.id,
-      ran: true,
-      runId: result.runId,
-      status: result.status,
-    });
-  } catch (e) {
+  // Trial-funded runs share the remaining spend budget rather than each
+  // claiming all of it — the recorded overshoot past the cap is otherwise
+  // multiplied by however many runs launched from the same snapshot.
+  const trialRuns = funded.filter((k) => k.source === "trial").length;
+
+  const settled = await Promise.allSettled(
+    funded.map(async (k) => {
+      const budget = runBudgetMicros(k);
+      const result = await executeRun({
+        supabase,
+        project,
+        provider: k.provider,
+        model: k.model,
+        apiKey: k.apiKey!,
+        route: k.route,
+        budgetMicros: budget === null ? null : Math.floor(budget / Math.max(trialRuns, 1)),
+        context: {
+          channel: "dashboard",
+          actorType: "user",
+          actorId: user.id,
+          actorLabel: user.email ?? "You",
+        },
+      });
+      if (k.source === "trial") {
+        await recordTrialUsage(supabase, result.tokensUsed);
+        await recordTrialSpend(supabase, result.spendMicros);
+      }
+      return { provider: k.provider, runId: result.runId, status: result.status };
+    }),
+  );
+
+  const runs = settled.flatMap((s) => (s.status === "fulfilled" ? [s.value] : []));
+
+  if (runs.length === 0) {
+    const firstFailure = settled.find(
+      (s): s is PromiseRejectedResult => s.status === "rejected",
+    );
     return NextResponse.json(
-      { projectId: project.id, ran: false, error: humanError(e) },
+      { projectId: project.id, ran: false, error: humanError(firstFailure?.reason) },
       { status: 200 },
     );
   }
+
+  return NextResponse.json({
+    projectId: project.id,
+    ran: true,
+    // The default engine's run (the sweep is sorted so it launched first).
+    runId: runs[0].runId,
+    status: runs[0].status,
+    runs,
+  });
 }

--- a/app/api/onboarding/onboarding-competitors.test.ts
+++ b/app/api/onboarding/onboarding-competitors.test.ts
@@ -53,7 +53,19 @@ vi.mock("@/lib/trial", () => ({
   })),
   engineKeyMessage: () => "add a key",
   recordTrialUsage: vi.fn(),
+  recordTrialSpend: vi.fn(),
   consumeTrialRun: vi.fn(),
+  resolveRunKeyFor: vi.fn(async () => ({
+    source: "none",
+    provider: "anthropic",
+    model: "claude-sonnet-4-6",
+    requested: { provider: "anthropic", model: "claude-sonnet-4-6" },
+  })),
+  runBudgetMicros: () => null,
+  // No trial in these tests: zero usage, but zero covered engines too.
+  getTrialUsage: vi.fn(async () => ({ runs: 0, spendMicros: 0 })),
+  trialRunLimit: () => 15,
+  trialCoveredProviders: () => [],
 }));
 vi.mock("@/lib/engine", () => ({ executeRun: vi.fn() }));
 

--- a/app/api/onboarding/onboarding-route.test.ts
+++ b/app/api/onboarding/onboarding-route.test.ts
@@ -22,8 +22,20 @@ vi.mock("@/lib/llm", () => ({ humanError: (e: unknown) => String(e) }));
 vi.mock("@/lib/trial", () => ({
   pickDefaultProvider: () => "anthropic",
   resolveRunKey: vi.fn(),
+  resolveRunKeyFor: vi.fn(async () => ({
+    source: "none",
+    provider: "anthropic",
+    model: "claude-sonnet-4-6",
+    requested: { provider: "anthropic", model: "claude-sonnet-4-6" },
+  })),
   recordTrialUsage: vi.fn(),
+  recordTrialSpend: vi.fn(),
   consumeTrialRun: vi.fn(),
+  runBudgetMicros: () => null,
+  // No trial in these tests: zero usage, but zero covered engines too.
+  getTrialUsage: vi.fn(async () => ({ runs: 0, spendMicros: 0 })),
+  trialRunLimit: () => 15,
+  trialCoveredProviders: () => [],
 }));
 vi.mock("@/lib/engine", () => ({ executeRun: vi.fn() }));
 

--- a/app/api/project/reanalyze/route.ts
+++ b/app/api/project/reanalyze/route.ts
@@ -1,0 +1,128 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { getProject } from "@/lib/data";
+import { scrapeDomain } from "@/lib/scrape";
+import { suggestFromSite, humanError } from "@/lib/llm";
+import { PROVIDERS } from "@/lib/models";
+import { resolveKey, recordTrialUsage, recordTrialSpend } from "@/lib/trial";
+import { spendMicros } from "@/lib/pricing";
+import { logDashboard } from "@/lib/activity";
+import type { Topic } from "@/lib/types";
+
+export const maxDuration = 60;
+export const dynamic = "force-dynamic";
+
+// POST /api/project/reanalyze
+// Re-run the onboarding site analysis for an existing project: re-read the
+// site, fold in the workspace description and the topics already tracked, and
+// return DRAFT topic suggestions. Nothing is saved — the user accepts each
+// suggestion (POST /api/topics with prompts) or ignores it. Onboarding was the
+// only caller of scrapeDomain/suggestFromSite before this; a project whose
+// prompts drifted from what the company actually does had no way back.
+export async function POST(request: Request) {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const project = await getProject(supabase, user.id);
+  if (!project) {
+    return NextResponse.json({ error: "Create a project first" }, { status: 400 });
+  }
+
+  const providerLabel = PROVIDERS[project.default_provider].label;
+  // Lenient resolution on purpose: suggestions are drafts the user reviews
+  // before anything is saved, so any key they hold will do — same stance as
+  // competitor suggestions and the Generate button.
+  const key = await resolveKey(supabase, user.id, project.default_provider, project.default_model);
+
+  if (key.source === "none") {
+    return NextResponse.json(
+      { error: `Add a ${providerLabel} key in Settings first.` },
+      { status: 400 },
+    );
+  }
+  if (key.source === "exhausted") {
+    return NextResponse.json(
+      {
+        error: `You've used all ${key.limit ?? 0} free runs. Add your own ${providerLabel} key in Settings to keep going.`,
+        trialExhausted: true,
+      },
+      { status: 402 },
+    );
+  }
+
+  // Best-effort scrape of the primary domain. A failed read is not fatal here
+  // the way it is in onboarding: an existing project usually has a description
+  // to work from, and the model is told the site was unreadable.
+  const domain = project.brand_domains[0] ?? null;
+  const scrape = domain ? await scrapeDomain(domain) : null;
+  const siteText = scrape?.ok ? (scrape.text ?? "") : "";
+
+  if (!siteText && !project.description) {
+    return NextResponse.json(
+      {
+        error: domain
+          ? `We couldn't read ${domain} (${scrape?.error ?? "unknown error"}) and this workspace has no description. Add one in Settings ("What does your brand do?") and try again.`
+          : `This workspace has no brand domain and no description. Add either in Settings and try again.`,
+      },
+      { status: 400 },
+    );
+  }
+
+  const { data: topicRows } = await supabase
+    .from("topics")
+    .select("name")
+    .eq("project_id", project.id);
+  const existingTopics = ((topicRows ?? []) as Pick<Topic, "name">[]).map((t) => t.name);
+
+  try {
+    const { description, topics, tokens } = await suggestFromSite({
+      provider: key.provider,
+      model: key.model,
+      apiKey: key.apiKey!,
+      brandName: project.brand_name,
+      siteText,
+      description: project.description,
+      existingTopics,
+    });
+
+    // Metered even though no free RUN is consumed: these endpoints spend the
+    // operator's key, so without this a script could call them forever.
+    if (key.source === "trial") {
+      await recordTrialUsage(supabase, tokens);
+      await recordTrialSpend(
+        supabase,
+        spendMicros({ provider: key.provider, model: key.model, tokens }),
+      );
+    }
+
+    // Belt-and-braces: the model is told not to repeat tracked topics, but a
+    // rename-level duplicate ("Payroll software" vs "payroll tools") is on the
+    // model; only exact case-insensitive repeats are cheap to catch here.
+    const taken = new Set(existingTopics.map((t) => t.trim().toLowerCase()));
+    const fresh = topics.filter((t) => !taken.has(t.name.trim().toLowerCase()));
+
+    await logDashboard(user, request, {
+      category: "topic",
+      action: "topic.reanalyzed",
+      summary: `Re-analyzed the site and drafted ${fresh.length} topic suggestion${fresh.length === 1 ? "" : "s"}`,
+      projectId: project.id,
+      targetType: "project",
+      targetId: project.id,
+      metadata: { count: fresh.length, tokens, keySource: key.source, scraped: Boolean(siteText) },
+    });
+
+    return NextResponse.json({
+      suggestions: fresh,
+      // Surfaced so the UI can say the drafts came from the description alone —
+      // a silently unread site would otherwise look like a thin model response.
+      scraped: Boolean(siteText),
+      scrapeError: scrape && !scrape.ok ? scrape.error ?? null : null,
+      inferredDescription: description || null,
+    });
+  } catch (e) {
+    return NextResponse.json({ error: humanError(e) }, { status: 500 });
+  }
+}

--- a/app/api/runs/route.ts
+++ b/app/api/runs/route.ts
@@ -3,9 +3,10 @@ import { createClient } from "@/lib/supabase/server";
 import { getProject } from "@/lib/data";
 import { executeRun } from "@/lib/engine";
 import { humanError } from "@/lib/llm";
-import { PROVIDERS } from "@/lib/models";
+import { PROVIDERS, isProvider, resolveEngine } from "@/lib/models";
 import {
   resolveRunKey,
+  resolveRunKeyFor,
   consumeTrialRun,
   recordTrialUsage,
   recordTrialSpend,
@@ -17,7 +18,10 @@ export const maxDuration = 800;
 export const dynamic = "force-dynamic";
 
 // POST /api/runs, execute a monitoring run now for the signed-in user's project.
-export async function POST() {
+// Optional body { provider } runs this one run on another engine (that
+// provider's default model) without touching the project — the loop behind
+// "Run on all engines". No body preserves the original behavior exactly.
+export async function POST(request: Request) {
   const supabase = createClient();
 
   const {
@@ -32,8 +36,40 @@ export async function POST() {
     return NextResponse.json({ error: "Create a project first" }, { status: 400 });
   }
 
-  const providerLabel = PROVIDERS[project.default_provider].label;
-  const key = await resolveRunKey(supabase, user.id, project);
+  let overrideProvider: string | null = null;
+  try {
+    const body = (await request.json()) as { provider?: unknown } | null;
+    if (typeof body?.provider === "string" && body.provider.length > 0) {
+      overrideProvider = body.provider;
+    }
+  } catch {
+    // No/invalid body: run the project default, as this endpoint always has.
+  }
+
+  if (overrideProvider !== null && !isProvider(overrideProvider)) {
+    return NextResponse.json(
+      { error: `Unknown provider "${overrideProvider}". Use one of: ${Object.keys(PROVIDERS).join(", ")}.` },
+      { status: 400 },
+    );
+  }
+  // Same validate-then-resolve order as the v1 trigger: an override naming an
+  // engine the catalog doesn't offer must fail before a run row can exist.
+  const engine = overrideProvider
+    ? resolveEngine(overrideProvider, undefined)
+    : resolveEngine(project.default_provider, project.default_model);
+  if (!engine.ok) {
+    return NextResponse.json({ error: engine.message }, { status: 400 });
+  }
+  const providerLabel = PROVIDERS[engine.provider].label;
+  // An override resolves like any run for that engine, trial included: the
+  // trial funds multi-engine runs (each one atomically consumes a free run
+  // below, so a 3-engine sweep costs 3 of the allowance — that's the deal the
+  // raised cap exists to cover).
+  const key = overrideProvider
+    ? await resolveRunKeyFor(supabase, user.id, engine.provider, engine.model, {
+        webSearch: project.use_web_search,
+      })
+    : await resolveRunKey(supabase, user.id, project);
 
   // The selected engine has no key. Refusing beats running: the alternative is
   // storing another assistant's answers under this project's trend line.

--- a/app/api/topics/[id]/generate/route.ts
+++ b/app/api/topics/[id]/generate/route.ts
@@ -78,6 +78,9 @@ export async function POST(
       apiKey: key.apiKey!,
       topicName: topic.name,
       topicDescription: topic.description,
+      // The Settings blurb has promised this field "helps generate better
+      // monitoring prompts" since before it was true. Now it's true.
+      brandDescription: project.description,
       count,
     });
 

--- a/app/api/topics/[id]/route.ts
+++ b/app/api/topics/[id]/route.ts
@@ -6,6 +6,67 @@ import { logDashboard } from "@/lib/activity";
 
 export const dynamic = "force-dynamic";
 
+// Edit a topic's context after creation. The description steers question
+// generation (generateVariations injects it), and until this existed it was
+// settable only in the moment the topic was created — the one moment the user
+// least knows what to write in it.
+export async function PATCH(
+  request: Request,
+  { params }: { params: { id: string } },
+) {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const project = await getProject(supabase, user.id);
+  if (!project) {
+    return NextResponse.json({ error: "No project found." }, { status: 400 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request body." }, { status: 400 });
+  }
+  const { description } = (body ?? {}) as { description?: unknown };
+  if (description !== null && typeof description !== "string") {
+    return NextResponse.json(
+      { error: "description must be a string or null." },
+      { status: 400 },
+    );
+  }
+  const clean =
+    typeof description === "string" && description.trim() ? description.trim() : null;
+
+  try {
+    const { data, error } = await supabase
+      .from("topics")
+      .update({ description: clean })
+      .eq("id", params.id)
+      .eq("project_id", project.id)
+      .select()
+      .maybeSingle();
+
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    if (!data) return NextResponse.json({ error: "Topic not found." }, { status: 404 });
+
+    await logDashboard(user, request, {
+      category: "topic",
+      action: "topic.updated",
+      summary: clean ? "Updated a topic's context" : "Cleared a topic's context",
+      projectId: project.id,
+      targetType: "topic",
+      targetId: params.id,
+    });
+    return NextResponse.json(data);
+  } catch (e) {
+    return NextResponse.json({ error: humanError(e) }, { status: 500 });
+  }
+}
+
 export async function DELETE(
   request: Request,
   { params }: { params: { id: string } },

--- a/app/api/topics/route.ts
+++ b/app/api/topics/route.ts
@@ -28,9 +28,11 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Invalid request body." }, { status: 400 });
   }
 
-  const { name, description } = (body ?? {}) as {
+  const { name, description, prompts, source } = (body ?? {}) as {
     name?: unknown;
     description?: unknown;
+    prompts?: unknown;
+    source?: unknown;
   };
 
   if (typeof name !== "string" || !name.trim()) {
@@ -39,6 +41,16 @@ export async function POST(request: Request) {
 
   const cleanDescription =
     typeof description === "string" && description.trim() ? description.trim() : null;
+
+  // Optional starter questions, so accepting a re-analysis suggestion is one
+  // request (topic + its questions) instead of one per question. Their source
+  // is caller-declared: the re-analysis flow inserts AI drafts, everything
+  // else defaults to manual — same values the prompts table constrains.
+  const initialPrompts = (Array.isArray(prompts) ? prompts : [])
+    .map((p) => (typeof p === "string" ? p.trim() : ""))
+    .filter((p) => p.length > 0)
+    .slice(0, 20);
+  const promptSource = source === "ai" ? ("ai" as const) : ("manual" as const);
 
   try {
     const { data, error } = await supabase
@@ -52,13 +64,34 @@ export async function POST(request: Request) {
       .single();
 
     if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+    const topicId = (data as { id: string }).id;
+    if (initialPrompts.length > 0) {
+      const { error: promptErr } = await supabase.from("prompts").insert(
+        initialPrompts.map((text) => ({
+          project_id: project.id,
+          topic_id: topicId,
+          text,
+          source: promptSource,
+          is_active: true,
+        })),
+      );
+      // Non-fatal: the topic is real either way, and the Generate button can
+      // refill it. Refusing here would strand a created topic behind an error.
+      if (promptErr) {
+        console.error("[topics] initial prompt insert failed:", promptErr.message);
+      }
+    }
+
     await logDashboard(user, request, {
       category: "topic",
       action: "topic.created",
-      summary: `Created topic "${name.trim()}"`,
+      summary: initialPrompts.length
+        ? `Created topic "${name.trim()}" with ${initialPrompts.length} question${initialPrompts.length === 1 ? "" : "s"}`
+        : `Created topic "${name.trim()}"`,
       projectId: project.id,
       targetType: "topic",
-      targetId: (data as { id: string }).id,
+      targetId: topicId,
     });
     return NextResponse.json(data);
   } catch (e) {

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -17,7 +17,12 @@ import {
   SectionHeading,
   StatCard,
 } from "@/components/ui";
-import { ShareBars, SentimentDonut, TrendChart } from "@/components/dashboard/charts-lazy";
+import {
+  ShareBars,
+  SentimentDonut,
+  TrendChart,
+  EngineTrendChart,
+} from "@/components/dashboard/charts-lazy";
 import { MeasurementNote } from "@/components/dashboard/measurement-note";
 import { Onboarding } from "./onboarding";
 import { createClient } from "@/lib/supabase/server";
@@ -30,9 +35,9 @@ import {
   computeTopicStats,
   type EntityStat,
 } from "@/lib/metrics";
-import { modelLabel } from "@/lib/models";
+import { modelLabel, PROVIDERS } from "@/lib/models";
 import { formatDate, pct, timeAgo } from "@/lib/utils";
-import type { Mention, Run, Source, Topic } from "@/lib/types";
+import type { Mention, Provider, Run, Source, Topic } from "@/lib/types";
 
 export const dynamic = "force-dynamic";
 
@@ -222,18 +227,35 @@ export default async function DashboardPage() {
   // --------------------------------------------------------------
   const latestRun = runs[0];
 
-  // One batched fetch covers the latest run AND the 10-run trend: all mentions
+  // Runs can span answer engines now. The latest run per engine feeds the
+  // by-engine card and the overall rollup; the trend goes per-engine (and
+  // deeper) the moment a second engine appears, because ten mixed runs is only
+  // ~three points per line.
+  const engineLatest = new Map<Provider, Run>();
+  for (const run of runs) {
+    if (!engineLatest.has(run.provider as Provider)) {
+      engineLatest.set(run.provider as Provider, run);
+    }
+  }
+  const multiEngine = engineLatest.size > 1;
+
+  // One batched fetch covers the latest run AND the trend: all mentions
   // for those runs in a single IN query, grouped in memory, replacing ~2
   // queries per historical run. Per-run answer counts come straight from
   // runs.completed_count (set by the engine), so no response rows are fetched
   // for counting — responses are only read for the latest run's topic split.
-  const trendRuns = runs.slice(0, 10);
+  const trendRuns = runs.slice(0, multiEngine ? 20 : 10);
   const trendIds = trendRuns.map((r) => r.id);
+  // Each engine's latest run may sit outside the trend window; its mentions
+  // are still needed for the by-engine card.
+  const mentionIds = Array.from(
+    new Set([...trendIds, ...Array.from(engineLatest.values(), (r) => r.id)]),
+  );
 
   const [mentionsResult, latestResponsesResult, topicsList, latestSourcesResult] = await Promise.all([
-    // NOTE: capped at 1000 rows by PostgREST; fine for 10 runs of mention rows
+    // NOTE: capped at 1000 rows by PostgREST; fine for ~20 runs of mention rows
     // (only detected entities produce rows). Revisit if trend depth grows.
-    supabase.from("mentions").select("*").in("run_id", trendIds),
+    supabase.from("mentions").select("*").in("run_id", mentionIds),
     supabase.from("responses").select("topic_id").eq("run_id", latestRun.id),
     supabase.from("topics").select("*").eq("project_id", project.id),
     supabase
@@ -273,7 +295,10 @@ export default async function DashboardPage() {
     totalResponses,
   );
 
-  // Trend across the last 10 completed runs (chronological).
+  // Trend across recent completed runs (chronological). Single-engine keeps
+  // the visibility + share pair; once runs span engines each run becomes a
+  // point on its own engine's visibility line — a blended line would zigzag
+  // between numbers that aren't comparable.
   const trendData = trendRuns
     .slice()
     .reverse()
@@ -288,6 +313,47 @@ export default async function DashboardPage() {
         share: Math.round(s.brandShareOfVoice * 100),
       };
     });
+  const engineSeries = Array.from(engineLatest.keys(), (p) => ({
+    key: p,
+    label: PROVIDERS[p]?.label ?? p,
+  }));
+  const engineTrendData = trendRuns
+    .slice()
+    .reverse()
+    .map((run) => {
+      const s = computeRunSummary(
+        mentionsByRun.get(run.id) ?? [],
+        responseCountByRun.get(run.id) ?? 0,
+      );
+      return {
+        date: formatDate(run.created_at),
+        [run.provider]: Math.round(s.brandMentionRate * 100),
+      };
+    });
+
+  // Latest run per engine → the by-engine card and the overall rollup.
+  // Rollup per the design doc: a simple mean across engines, each counted
+  // equally ("average across N engines" — explainable beats clever), with an
+  // engine dropping out of the rollup once its latest run is older than 30
+  // days. Stale engines stay visible in the card, tagged with their age.
+  const STALE_MS = 30 * 24 * 60 * 60 * 1000;
+  const engineRows = Array.from(engineLatest.entries(), ([provider, run]) => {
+    const s = computeRunSummary(mentionsByRun.get(run.id) ?? [], run.completed_count);
+    return {
+      provider,
+      label: PROVIDERS[provider]?.label ?? provider,
+      model: modelLabel(run.provider, run.model),
+      visibility: s.brandMentionRate,
+      share: s.brandShareOfVoice,
+      ranAt: run.created_at,
+      stale: Date.now() - new Date(run.created_at).getTime() > STALE_MS,
+    };
+  }).sort((a, b) => b.visibility - a.visibility);
+  const rollupRows = engineRows.filter((r) => !r.stale);
+  const overallVisibility =
+    rollupRows.length > 0
+      ? rollupRows.reduce((sum, r) => sum + r.visibility, 0) / rollupRows.length
+      : null;
 
   // Share-of-voice leaderboard (brand + competitors, desc by share).
   const shareEntities: EntityStat[] = [...stats].sort(
@@ -382,6 +448,49 @@ export default async function DashboardPage() {
         competitorsTracked={competitors}
       />
 
+      {/* Visibility by engine + the overall rollup. Only once a second engine
+          has data — for a single engine the headline stats already say it. */}
+      {multiEngine && (
+        <Card>
+          <CardBody>
+            <div className="flex flex-wrap items-baseline justify-between gap-3">
+              <div>
+                <h3 className="text-lg font-semibold text-ink">Overall AI visibility</h3>
+                <p className="mt-0.5 text-sm text-ink-soft">
+                  {overallVisibility !== null
+                    ? `Average across ${rollupRows.length} engine${rollupRows.length === 1 ? "" : "s"}, latest run each.`
+                    : "No engine has run in the last 30 days."}
+                </p>
+              </div>
+              {overallVisibility !== null && (
+                <span className="text-3xl font-semibold tracking-tight text-ink">
+                  {pct(overallVisibility)}
+                </span>
+              )}
+            </div>
+            <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+              {engineRows.map((row) => (
+                <div key={row.provider} className="rounded border border-ink/10 p-3.5">
+                  <p className="text-xs font-medium uppercase tracking-wide text-ink-faint">
+                    {row.label}
+                  </p>
+                  <p className="mt-1 text-2xl font-semibold text-ink">{pct(row.visibility)}</p>
+                  <p className="mt-1 text-xs text-ink-soft">
+                    share of voice {pct(row.share)}
+                  </p>
+                  <p className="mt-0.5 text-xs text-ink-faint">
+                    {row.model} · {timeAgo(row.ranAt)}
+                    {/* Stale engines stay listed but leave the rollup — an
+                        engine last measured a month ago isn't "overall" truth. */}
+                    {row.stale && " · not in average"}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </CardBody>
+        </Card>
+      )}
+
       {/* Trend + sentiment donut */}
       <div className="grid gap-6 lg:grid-cols-3">
         <Card className="lg:col-span-2">
@@ -390,11 +499,17 @@ export default async function DashboardPage() {
               <div>
                 <h3 className="text-lg font-semibold text-ink">Visibility over time</h3>
                 <p className="mt-0.5 text-sm text-ink-soft">
-                  Brand visibility and share of voice across recent runs.
+                  {multiEngine
+                    ? "Brand visibility across recent runs, one line per answer engine."
+                    : "Brand visibility and share of voice across recent runs."}
                 </p>
               </div>
             </div>
-            <TrendChart data={trendData} />
+            {multiEngine ? (
+              <EngineTrendChart data={engineTrendData} series={engineSeries} />
+            ) : (
+              <TrendChart data={trendData} />
+            )}
           </CardBody>
         </Card>
 

--- a/app/dashboard/runs/page.tsx
+++ b/app/dashboard/runs/page.tsx
@@ -1,9 +1,18 @@
 import { ArrowRight, PlayCircle } from "lucide-react";
 import { createClient } from "@/lib/supabase/server";
-import { getProject } from "@/lib/data";
-import { resolveRunKey, engineKeyMessage, nextRunMessage } from "@/lib/trial";
+import { getProject, getConfiguredProviders, getRouterKeysPublic } from "@/lib/data";
+import {
+  resolveRunKey,
+  engineKeyMessage,
+  nextRunMessage,
+  trialEnabled,
+  trialCoveredProviders,
+  trialRunLimit,
+  getTrialUsage,
+} from "@/lib/trial";
+import { trialSpendLimitMicros } from "@/lib/pricing";
 import { PROVIDERS, modelLabel } from "@/lib/models";
-import { ROUTERS } from "@/lib/routers";
+import { ROUTERS, coveredProviders } from "@/lib/routers";
 import { timeAgo } from "@/lib/utils";
 import { isAbandoned, settleAbandonedRun, INTERRUPTED_RUN_ERROR } from "@/lib/engine";
 import type { Run, RunStatus } from "@/lib/types";
@@ -16,6 +25,7 @@ import {
   EmptyState,
 } from "@/components/ui";
 import { RunNow } from "./run-now";
+import { RunAllEngines } from "./run-all-engines";
 import { ScheduleControl } from "./schedule-control";
 
 export const dynamic = "force-dynamic";
@@ -60,6 +70,33 @@ export default async function RunsPage() {
   const key = await resolveRunKey(supabase, user.id, project);
   const canRun = key.source === "own" || key.source === "trial";
 
+  // Every engine this account can fund a run on right now: engines the user's
+  // own credentials cover, plus — while the trial allowance lasts — the ones
+  // the operator's trial keys serve. This is the "run on all engines" list;
+  // the run endpoint re-checks funding per run, so this is display truth, not
+  // an authorization.
+  const [configured, routerRows] = await Promise.all([
+    getConfiguredProviders(supabase, user.id),
+    getRouterKeysPublic(supabase, user.id),
+  ]);
+  const ownCovered = coveredProviders({
+    direct: configured,
+    routers: routerRows.map((k) => ({ router: k.router, searchVerified: k.search_verified ?? [] })),
+    webSearch: project.use_web_search,
+  });
+  let available = ownCovered;
+  if (trialEnabled()) {
+    const usage = await getTrialUsage(supabase, user.id);
+    const trialActive =
+      usage.runs < trialRunLimit() && usage.spendMicros < trialSpendLimitMicros();
+    if (trialActive) {
+      available = Array.from(
+        new Set([...ownCovered, ...trialCoveredProviders(project.use_web_search)]),
+      );
+    }
+  }
+  const engineList = available.map((p) => ({ provider: p, label: PROVIDERS[p].label }));
+
   const { count: activePrompts } = await supabase
     .from("prompts")
     .select("id", { count: "exact", head: true })
@@ -100,12 +137,22 @@ export default async function RunsPage() {
         // different model — see nextRunMessage.
         description={canRun ? nextRunMessage(key) : engineKeyMessage(key)}
         action={
-          <RunNow
-            canRun={canRun}
-            keySource={key.source}
-            activePrompts={activePrompts ?? 0}
-            providerLabel={PROVIDERS[project.default_provider].label}
-          />
+          <div className="flex flex-col items-start gap-2 sm:items-end">
+            <RunNow
+              canRun={canRun}
+              keySource={key.source}
+              activePrompts={activePrompts ?? 0}
+              providerLabel={PROVIDERS[project.default_provider].label}
+            />
+            {/* Only when there's a second engine to offer — a one-engine
+                "run on all engines" is the same button twice. */}
+            {engineList.length >= 2 && (
+              <RunAllEngines
+                engines={engineList}
+                disabled={(activePrompts ?? 0) === 0}
+              />
+            )}
+          </div>
         }
       />
 

--- a/app/dashboard/runs/run-all-engines.tsx
+++ b/app/dashboard/runs/run-all-engines.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Layers } from "lucide-react";
+import { Button } from "@/components/ui";
+
+/**
+ * "Run everywhere" is a loop of ordinary runs, one per engine the account can
+ * fund (own keys or the trial's coverage) — the server enforces funding per
+ * run, this component just drives the loop. Sequential on purpose: each run
+ * already fans out its prompts with internal concurrency, and two runs racing
+ * would double-load the same providers for no wall-clock win the user can see.
+ */
+export function RunAllEngines({
+  engines,
+  disabled,
+}: {
+  engines: { provider: string; label: string }[];
+  /** Mirrors RunNow's gating (no active prompts, etc.). */
+  disabled?: boolean;
+}) {
+  const router = useRouter();
+  const [progress, setProgress] = useState<string | null>(null);
+  const [errors, setErrors] = useState<string[]>([]);
+
+  async function runAll() {
+    setErrors([]);
+    const failures: string[] = [];
+    for (let i = 0; i < engines.length; i++) {
+      const engine = engines[i];
+      setProgress(`Running ${engine.label} (${i + 1}/${engines.length})…`);
+      try {
+        const res = await fetch("/api/runs", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ provider: engine.provider }),
+        });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok || data?.error) {
+          failures.push(`${engine.label}: ${data?.error ?? "run failed"}`);
+        }
+      } catch {
+        failures.push(`${engine.label}: network error`);
+      }
+      // Refresh between engines so finished runs appear while later ones work.
+      router.refresh();
+    }
+    setProgress(null);
+    setErrors(failures);
+    router.refresh();
+  }
+
+  return (
+    <div className="flex flex-col items-start gap-1.5 sm:items-end">
+      <Button
+        variant="secondary"
+        onClick={runAll}
+        loading={progress !== null}
+        loadingText={progress ?? "Running…"}
+        disabled={disabled || progress !== null}
+      >
+        <Layers className="h-4 w-4" /> Run on all {engines.length} engines
+      </Button>
+      {errors.map((e) => (
+        <p key={e} className="text-xs text-terracotta">
+          {e}
+        </p>
+      ))}
+    </div>
+  );
+}

--- a/app/dashboard/runs/schedule-control.tsx
+++ b/app/dashboard/runs/schedule-control.tsx
@@ -54,9 +54,10 @@ export function ScheduleControl({
   }
 
   const scheduled = schedule !== "off";
-  // Trial users can press "Run monitor now", so canRun doesn't capture this —
-  // only an own key lets the cron actually run the project.
-  const willFire = keySource === "own";
+  // The cron runs own-key projects, and trial projects while the allowance
+  // lasts ("cadence from the onset"). Everything else it skips — that's the
+  // state worth shouting about.
+  const willFire = keySource === "own" || keySource === "trial";
 
   return (
     <Card>
@@ -71,9 +72,22 @@ export function ScheduleControl({
                 hand, and build a trend over time.
               </p>
             )}
-            {scheduled && willFire && (
+            {scheduled && keySource === "own" && (
               <p className="text-xs text-ink-faint">
                 Runs {schedule} around 8:00 UTC on your own key.
+              </p>
+            )}
+            {scheduled && keySource === "trial" && (
+              <p className="text-xs text-ink-faint">
+                Runs {schedule} around 8:00 UTC on complimentary tokens while
+                they last. Add your {providerLabel} key in{" "}
+                <Link
+                  href="/dashboard/settings"
+                  className="text-terracotta-dark hover:text-terracotta"
+                >
+                  Settings
+                </Link>{" "}
+                to keep it going after that.
               </p>
             )}
             {/* The schedule is set but the cron will skip it. Without this line
@@ -81,15 +95,19 @@ export function ScheduleControl({
                 in its own JSON response and a span attribute. */}
             {scheduled && !willFire && (
               <p className="text-xs text-terracotta">
-                Scheduled runs use your own key, so this {SCHEDULE_LABELS[schedule].toLowerCase()}{" "}
-                schedule won&apos;t run yet. Add your {providerLabel} key in{" "}
+                This {SCHEDULE_LABELS[schedule].toLowerCase()} schedule
+                won&apos;t run
+                {keySource === "exhausted"
+                  ? ": your free runs are used up. "
+                  : ": no usable key for your answer engine. "}
+                Add your {providerLabel} key in{" "}
                 <Link
                   href="/dashboard/settings"
                   className="text-terracotta-dark underline hover:text-terracotta"
                 >
                   Settings
                 </Link>{" "}
-                to turn it on.
+                to turn it {keySource === "exhausted" ? "back on" : "on"}.
               </p>
             )}
             {error && <p className="text-xs text-terracotta">{error}</p>}

--- a/app/dashboard/topics/topics-client.tsx
+++ b/app/dashboard/topics/topics-client.tsx
@@ -13,7 +13,7 @@ import {
   Select,
   Spinner,
 } from "@/components/ui";
-import { Plus, Sparkles, Trash2, X } from "lucide-react";
+import { Check, Pencil, Plus, RefreshCw, Sparkles, Trash2, X } from "lucide-react";
 import { NeedsKeyNotice } from "@/components/dashboard/needs-key-notice";
 import { article } from "@/lib/utils";
 
@@ -107,6 +107,9 @@ export function TopicsClient({ topics, prompts, hasKey, providerLabel }: Props) 
         <NeedsKeyNotice providerLabel={providerLabel} action="auto-generate variations" />
       )}
 
+      {/* Re-analyze */}
+      <ReanalyzeSection hasKey={hasKey} providerLabel={providerLabel} />
+
       {/* Topics list */}
       {topics.length === 0 ? (
         <p className="px-1 text-sm text-ink-faint">
@@ -126,6 +129,156 @@ export function TopicsClient({ topics, prompts, hasKey, providerLabel }: Props) 
         </div>
       )}
     </div>
+  );
+}
+
+interface TopicSuggestion {
+  name: string;
+  prompts: string[];
+}
+
+/** Re-run the onboarding site analysis on demand. Suggestions are drafts: each
+ *  is accepted (one request creates the topic + its questions) or ignored, so
+ *  a bad model day costs nothing. */
+function ReanalyzeSection({
+  hasKey,
+  providerLabel,
+}: {
+  hasKey: boolean;
+  providerLabel: string;
+}) {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [suggestions, setSuggestions] = useState<TopicSuggestion[] | null>(null);
+  const [scraped, setScraped] = useState(true);
+  const [addingName, setAddingName] = useState<string | null>(null);
+
+  async function reanalyze() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/project/reanalyze", { method: "POST" });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(body?.error ?? "Could not re-analyze the site.");
+        return;
+      }
+      setSuggestions(body?.suggestions ?? []);
+      setScraped(Boolean(body?.scraped));
+    } catch {
+      setError("Something went wrong. Try again.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function accept(s: TopicSuggestion) {
+    setAddingName(s.name);
+    setError(null);
+    try {
+      const res = await fetch("/api/topics", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: s.name, prompts: s.prompts, source: "ai" }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(body?.error ?? "Could not add the topic.");
+        return;
+      }
+      setSuggestions((prev) => (prev ?? []).filter((x) => x.name !== s.name));
+      router.refresh();
+    } catch {
+      setError("Something went wrong. Try again.");
+    } finally {
+      setAddingName(null);
+    }
+  }
+
+  return (
+    <Card>
+      <CardBody className="space-y-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="min-w-0">
+            <h3 className="text-base font-semibold text-ink">Re-analyze your site</h3>
+            <p className="mt-0.5 text-sm text-ink-soft">
+              Re-read your site and workspace description, and draft topics you
+              aren&apos;t tracking yet. Nothing is added until you accept it.
+            </p>
+          </div>
+          <Button
+            variant="secondary"
+            onClick={reanalyze}
+            disabled={!hasKey || loading}
+            title={!hasKey ? `Add ${article(providerLabel)} ${providerLabel} key in Settings to enable` : undefined}
+          >
+            {loading ? <Spinner /> : <RefreshCw className="h-4 w-4" />}
+            {loading ? "Analyzing…" : "Re-analyze"}
+          </Button>
+        </div>
+
+        {error && <p className="text-sm text-terracotta-dark">{error}</p>}
+
+        {suggestions && suggestions.length === 0 && !error && (
+          <p className="text-sm text-ink-faint">
+            Nothing new to suggest — your current topics already cover what the
+            analysis found.
+          </p>
+        )}
+
+        {suggestions && suggestions.length > 0 && (
+          <div className="space-y-3">
+            {!scraped && (
+              <p className="text-xs text-ink-faint">
+                Your site couldn&apos;t be read, so these drafts come from your
+                workspace description alone.
+              </p>
+            )}
+            {suggestions.map((s) => (
+              <div
+                key={s.name}
+                className="rounded border border-ink/10 bg-paper-shade/40 p-4"
+              >
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="text-sm font-semibold text-ink">{s.name}</p>
+                    <ul className="mt-1.5 space-y-1">
+                      {s.prompts.map((p) => (
+                        <li key={p} className="text-sm text-ink-soft">
+                          {p}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                  <div className="flex shrink-0 items-center gap-2">
+                    <Button
+                      size="sm"
+                      onClick={() => accept(s)}
+                      disabled={addingName !== null}
+                    >
+                      {addingName === s.name ? <Spinner /> : <Plus className="h-4 w-4" />}
+                      Add topic
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() =>
+                        setSuggestions((prev) => (prev ?? []).filter((x) => x.name !== s.name))
+                      }
+                      disabled={addingName !== null}
+                      aria-label={`Dismiss suggestion ${s.name}`}
+                    >
+                      <X className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardBody>
+    </Card>
   );
 }
 
@@ -152,7 +305,36 @@ function TopicCard({
 
   const [deletingTopic, setDeletingTopic] = useState(false);
 
+  const [editingDesc, setEditingDesc] = useState(false);
+  const [descDraft, setDescDraft] = useState(topic.description ?? "");
+  const [savingDesc, setSavingDesc] = useState(false);
+  const [descError, setDescError] = useState<string | null>(null);
+
   const activeCount = prompts.filter((p) => p.is_active).length;
+
+  async function handleSaveDescription(e: React.FormEvent) {
+    e.preventDefault();
+    setSavingDesc(true);
+    setDescError(null);
+    try {
+      const res = await fetch(`/api/topics/${topic.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ description: descDraft.trim() || null }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setDescError(body?.error ?? "Could not save the context.");
+        return;
+      }
+      setEditingDesc(false);
+      router.refresh();
+    } catch {
+      setDescError("Something went wrong. Try again.");
+    } finally {
+      setSavingDesc(false);
+    }
+  }
 
   async function handleGenerate() {
     setGenerating(true);
@@ -218,11 +400,53 @@ function TopicCard({
       <CardBody className="space-y-5">
         {/* Header */}
         <div className="flex flex-wrap items-start justify-between gap-3">
-          <div className="min-w-0">
+          <div className="min-w-0 flex-1">
             <h3 className="text-lg font-semibold text-ink">{topic.name}</h3>
-            {topic.description && (
-              <p className="mt-1 text-sm text-ink-soft">{topic.description}</p>
+            {/* The description steers question generation, so it's editable in
+                place — it used to be settable only at creation, which is the
+                one moment the user least knows what to write in it. */}
+            {editingDesc ? (
+              <form onSubmit={handleSaveDescription} className="mt-1.5 flex max-w-xl items-center gap-2">
+                <Input
+                  value={descDraft}
+                  onChange={(e) => setDescDraft(e.target.value)}
+                  placeholder="Context to steer the questions, e.g. who buys this and why"
+                  maxLength={300}
+                  disabled={savingDesc}
+                  autoFocus
+                  aria-label={`Context for topic ${topic.name}`}
+                />
+                <Button type="submit" size="sm" disabled={savingDesc}>
+                  {savingDesc ? <Spinner /> : <Check className="h-4 w-4" />}
+                  Save
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  disabled={savingDesc}
+                  onClick={() => {
+                    setEditingDesc(false);
+                    setDescDraft(topic.description ?? "");
+                    setDescError(null);
+                  }}
+                >
+                  Cancel
+                </Button>
+              </form>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setEditingDesc(true)}
+                className="group mt-1 flex items-center gap-1.5 text-left"
+              >
+                <span className={topic.description ? "text-sm text-ink-soft" : "text-sm text-ink-faint"}>
+                  {topic.description ?? "Add context to steer the generated questions"}
+                </span>
+                <Pencil className="h-3.5 w-3.5 shrink-0 text-ink-faint opacity-0 transition group-hover:opacity-100" />
+              </button>
             )}
+            {descError && <p className="mt-1 text-sm text-terracotta-dark">{descError}</p>}
             <p className="mt-2 text-xs text-ink-faint">
               {prompts.length} {prompts.length === 1 ? "prompt" : "prompts"}
               {prompts.length > 0 && ` · ${activeCount} active`}

--- a/components/dashboard/charts-lazy.tsx
+++ b/components/dashboard/charts-lazy.tsx
@@ -15,6 +15,14 @@ export const TrendChart = dynamic(() => import("./charts").then((m) => m.TrendCh
   loading: () => <ChartSkeleton height={280} />,
 });
 
+export const EngineTrendChart = dynamic(
+  () => import("./charts").then((m) => m.EngineTrendChart),
+  {
+    ssr: false,
+    loading: () => <ChartSkeleton height={280} />,
+  },
+);
+
 export const ShareBars = dynamic(() => import("./charts").then((m) => m.ShareBars), {
   ssr: false,
   loading: () => <ChartSkeleton height={180} />,

--- a/components/dashboard/charts.tsx
+++ b/components/dashboard/charts.tsx
@@ -144,6 +144,76 @@ export function TrendChart({
   );
 }
 
+// One color per answer engine, stable across renders so Claude is always the
+// same line week to week. Terracotta stays the brand's color on the
+// single-engine chart, so the engine palette starts elsewhere.
+const ENGINE_COLORS = ["#129C82", "#E07850", "#6F87C8", "#C8A24A", "#B06FC8"];
+
+/**
+ * Visibility over time, one line per answer engine. Replaces the blended
+ * single-line trend whenever runs span engines: Claude's 40% and Gemini's 12%
+ * aren't points on one series, and a line that zigzags between them reads as
+ * volatility that never happened. Each run extends only its own engine's line
+ * (connectNulls bridges the gaps where other engines ran).
+ */
+export function EngineTrendChart({
+  data,
+  series,
+}: {
+  /** Chronological rows: { date, [engineKey]: visibility 0..100 } */
+  data: Record<string, string | number | null>[];
+  series: { key: string; label: string }[];
+}) {
+  const t = useChartTheme();
+  if (!data || data.length === 0 || series.length === 0) {
+    return <Placeholder label="No runs to chart yet" height={280} />;
+  }
+  const labelOf = new Map(series.map((s) => [s.key, s.label]));
+  return (
+    <ResponsiveContainer width="100%" height={280}>
+      <LineChart data={data} margin={{ top: 8, right: 12, bottom: 4, left: -8 }}>
+        <CartesianGrid stroke={t.grid} vertical={false} />
+        <XAxis dataKey="date" tick={t.axisTick} tickLine={false} axisLine={{ stroke: t.grid }} />
+        <YAxis
+          domain={[0, 100]}
+          tick={t.axisTick}
+          tickLine={false}
+          axisLine={false}
+          tickFormatter={(v: number) => `${v}%`}
+          width={44}
+        />
+        <Tooltip
+          contentStyle={t.tooltipStyle}
+          formatter={(value: number, name: string) => [
+            `${Math.round(value)}%`,
+            labelOf.get(name) ?? name,
+          ]}
+        />
+        <Legend
+          iconType="plainline"
+          wrapperStyle={t.legendStyle}
+          formatter={(value: string) => labelOf.get(value) ?? value}
+        />
+        {series.map((s, i) => {
+          const color = ENGINE_COLORS[i % ENGINE_COLORS.length];
+          return (
+            <Line
+              key={s.key}
+              type="monotone"
+              dataKey={s.key}
+              stroke={color}
+              strokeWidth={2.5}
+              connectNulls
+              dot={{ r: 3, fill: color, strokeWidth: 0 }}
+              activeDot={{ r: 5 }}
+            />
+          );
+        })}
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}
+
 export function ShareBars({
   data,
 }: {

--- a/lib/llm/index.ts
+++ b/lib/llm/index.ts
@@ -1519,11 +1519,19 @@ export async function generateVariations(
   opts: BaseCall & {
     topicName: string;
     topicDescription?: string | null;
+    /** What the monitored company does (projects.description). Context only —
+     *  the questions must still never name the brand; this steers them toward
+     *  the buyers and use cases the company actually serves. */
+    brandDescription?: string | null;
     count: number;
   },
 ): Promise<{ variations: string[]; tokens: number }> {
   const user = `Topic: ${opts.topicName}${
     opts.topicDescription ? `\nContext: ${opts.topicDescription}` : ""
+  }${
+    opts.brandDescription
+      ? `\nThe company being monitored (context only — NEVER name it in the questions): ${opts.brandDescription}`
+      : ""
   }
 
 Generate ${opts.count} distinct questions a person might ask an AI assistant related to this topic. Return a JSON array of ${opts.count} strings.`;
@@ -1686,15 +1694,31 @@ export interface SiteSuggestion {
 
 /** From scraped site text, infer what the company does and suggest topics + prompts. */
 export async function suggestFromSite(
-  opts: BaseCall & { brandName: string; siteText: string },
+  opts: BaseCall & {
+    brandName: string;
+    siteText: string;
+    /** Operator-provided context (projects.description). Onboarding has only
+     *  the site; re-analysis has both, and this is often the better signal —
+     *  it's what the user SAID the company does, not what a marketing page
+     *  implies. Also the only signal when the site can't be read. */
+    description?: string | null;
+    /** Topics already tracked, so re-analysis proposes what's missing instead
+     *  of re-deriving the same three topics every time. */
+    existingTopics?: string[];
+  },
 ): Promise<SiteSuggestion & { tokens: number }> {
+  const siteText = opts.siteText.slice(0, 6000);
   const user = `Company: ${opts.brandName}
-
+${opts.description ? `\nWhat the company says it does: ${opts.description}\n` : ""}
 Website text:
 """
-${opts.siteText.slice(0, 6000)}
+${siteText || "(the site could not be read — work from the company name and description above)"}
 """
-
+${
+  opts.existingTopics?.length
+    ? `\nTopics already being monitored (do NOT repeat these or close variants of them — propose what's missing):\n${opts.existingTopics.map((t) => `- ${t}`).join("\n")}\n`
+    : ""
+}
 Return a JSON object of this shape:
 {
   "description": "one concise sentence describing what the company does",

--- a/lib/pricing.test.ts
+++ b/lib/pricing.test.ts
@@ -105,8 +105,9 @@ describe("spend", () => {
 });
 
 describe("the ceiling", () => {
-  it("defaults to $5", () => {
-    expect(trialSpendLimitMicros()).toBe(5_000_000);
+  it("defaults to $15", () => {
+    // Raised from $5 in the visibility overhaul, alongside the run allowance.
+    expect(trialSpendLimitMicros()).toBe(15_000_000);
   });
 
   it("is configurable", () => {
@@ -116,7 +117,7 @@ describe("the ceiling", () => {
 
   it("treats zero as a real setting, not as unset", () => {
     // "0" is how an operator turns the free tier off entirely. Reading it as
-    // missing would hand out the $5 default to exactly the deployment that
+    // missing would hand out the $15 default to exactly the deployment that
     // asked for none.
     process.env.TRIAL_SPEND_LIMIT_USD = "0";
     expect(trialSpendLimitMicros()).toBe(0);
@@ -124,7 +125,7 @@ describe("the ceiling", () => {
 
   it("falls back to the default on a malformed value", () => {
     process.env.TRIAL_SPEND_LIMIT_USD = "five dollars";
-    expect(trialSpendLimitMicros()).toBe(5_000_000);
+    expect(trialSpendLimitMicros()).toBe(15_000_000);
   });
 
   it("formats as money for the refusal message", () => {

--- a/lib/pricing.ts
+++ b/lib/pricing.ts
@@ -116,7 +116,9 @@ export function spendMicros(input: SpendInput): number {
   return micros > 0 ? micros : 0;
 }
 
-const DEFAULT_TRIAL_SPEND_LIMIT_USD = 5;
+// Raised 5 → 15 alongside TRIAL_RUN_LIMIT (see lib/trial.ts): the trial funds
+// multi-engine runs now, so the dollar ceiling scales with the run allowance.
+const DEFAULT_TRIAL_SPEND_LIMIT_USD = 15;
 
 /**
  * The per-user ceiling on operator-funded spend, in micro-dollars

--- a/lib/trial.ts
+++ b/lib/trial.ts
@@ -42,7 +42,10 @@ import { formatUsd, trialSpendLimitMicros } from "@/lib/pricing";
 // spend, but the gate is runs.
 // ------------------------------------------------------------------
 
-const DEFAULT_TRIAL_RUN_LIMIT = 5;
+// Raised 5 → 15 in the Aug 2026 visibility overhaul (the "2–4× the cap" call):
+// the trial now funds multi-engine runs and the start of a monitoring cadence,
+// so the old allowance was ~1.5 clicks of the new first-run experience.
+const DEFAULT_TRIAL_RUN_LIMIT = 15;
 
 /** The configurable per-user free-run allowance (env: TRIAL_RUN_LIMIT). */
 export function trialRunLimit(): number {
@@ -122,6 +125,18 @@ function trialCredFor(
  *  one per-provider direct key. */
 export function trialEnabled(): boolean {
   return !!trialConcentrateKey() || PROVIDER_IDS.some((p) => trialKeyFor(p));
+}
+
+/**
+ * The engines the trial can fund, for a project's grounding setting. This is
+ * what "run on every engine" means for an account that hasn't brought a key:
+ * the answer depends only on the operator's env (which trial keys exist, what
+ * the Concentrate key can serve) — allowance is checked separately, per run.
+ */
+export function trialCoveredProviders(webSearch: boolean): Provider[] {
+  return PROVIDER_IDS.filter(
+    (p) => trialCredFor(p, trialModelFor(p, defaultModelFor(p)), webSearch) !== null,
+  );
 }
 
 /** How many free trial runs this user has already consumed. */
@@ -638,4 +653,57 @@ export async function consumeTrialRun(supabase: SupabaseClient): Promise<boolean
   });
   if (error) return false;
   return data === true;
+}
+
+// ---------------------------------------------------------------------------
+// Service-role variants, for the scheduler.
+//
+// The self-scoped RPCs above key on auth.uid(), which a service-role request
+// doesn't have — that gap is why scheduled runs used to be own-key only. The
+// cron runs trial-funded projects now ("cadence from the onset"), so it needs
+// the same atomic gate and meters, addressed by user id. The *_for functions
+// are execute-restricted to service_role in the schema; called with any other
+// client they simply error, and every helper below degrades to the safe
+// answer ("no run granted" / "nothing recorded") rather than throwing — so a
+// deployment whose database hasn't applied the migration behaves exactly as
+// before: trial projects are skipped, not crashed.
+// ---------------------------------------------------------------------------
+
+/** consumeTrialRun for the scheduler: same atomic check-and-take, by user id. */
+export async function consumeTrialRunFor(
+  supabase: SupabaseClient,
+  userId: string,
+): Promise<boolean> {
+  const { data, error } = await supabase.rpc("consume_trial_run_for", {
+    uid: userId,
+    max_runs: trialRunLimit(),
+  });
+  if (error) return false;
+  return data === true;
+}
+
+/** recordTrialUsage for the scheduler. */
+export async function recordTrialUsageFor(
+  supabase: SupabaseClient,
+  userId: string,
+  tokens: number,
+): Promise<void> {
+  if (!tokens || tokens <= 0) return;
+  await supabase.rpc("increment_trial_tokens_for", {
+    uid: userId,
+    amount: Math.round(tokens),
+  });
+}
+
+/** recordTrialSpend for the scheduler. */
+export async function recordTrialSpendFor(
+  supabase: SupabaseClient,
+  userId: string,
+  micros: number,
+): Promise<void> {
+  if (!micros || micros <= 0) return;
+  await supabase.rpc("increment_trial_spend_for", {
+    uid: userId,
+    amount: Math.round(micros),
+  });
 }

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -127,6 +127,57 @@ begin
 end;
 $$;
 
+-- Scheduler variants of the three trial meters, addressed by user id instead
+-- of auth.uid(). The cron runs trial-funded scheduled projects ("cadence from
+-- the onset"), and a service-role request has no auth.uid() to self-scope on.
+-- Execute is revoked from every client-facing role: only service_role may call
+-- these, so no user can ever touch another user's allowance through them.
+-- Safe to re-run.
+create or replace function public.consume_trial_run_for(uid uuid, max_runs integer)
+returns boolean
+language plpgsql
+security definer set search_path = public
+as $$
+begin
+  update public.profiles
+    set trial_runs_used = trial_runs_used + 1
+    where id = uid
+      and trial_runs_used < greatest(max_runs, 0);
+  return found;
+end;
+$$;
+revoke execute on function public.consume_trial_run_for(uuid, integer)
+  from public, anon, authenticated;
+grant execute on function public.consume_trial_run_for(uuid, integer) to service_role;
+
+create or replace function public.increment_trial_tokens_for(uid uuid, amount bigint)
+returns bigint
+language sql
+security definer set search_path = public
+as $$
+  update public.profiles
+    set trial_tokens_used = trial_tokens_used + greatest(amount, 0)
+    where id = uid
+    returning trial_tokens_used;
+$$;
+revoke execute on function public.increment_trial_tokens_for(uuid, bigint)
+  from public, anon, authenticated;
+grant execute on function public.increment_trial_tokens_for(uuid, bigint) to service_role;
+
+create or replace function public.increment_trial_spend_for(uid uuid, amount bigint)
+returns bigint
+language sql
+security definer set search_path = public
+as $$
+  update public.profiles
+    set trial_spend_micros = trial_spend_micros + greatest(amount, 0)
+    where id = uid
+    returning trial_spend_micros;
+$$;
+revoke execute on function public.increment_trial_spend_for(uuid, bigint)
+  from public, anon, authenticated;
+grant execute on function public.increment_trial_spend_for(uuid, bigint) to service_role;
+
 -- ---------- provider_keys (BYOK, encrypted) -------------------------
 create table if not exists public.provider_keys (
   id uuid primary key default gen_random_uuid(),


### PR DESCRIPTION
Implements the team-reviewed design plan: **[The Visibility Overhaul](https://claude.ai/code/artifact/f3599c3e-8cc2-455c-824c-3563cd853588)**. Decided items are built as decided; open questions are built to the doc's stated lean or the conservative default (noted below).

## 01 — Steerable prompts & re-analysis
- The workspace description now actually feeds question generation (`generateVariations`), and `suggestFromSite` takes the description + already-tracked topics. The Settings copy that promised this is finally true.
- Topic context is editable in place on the Topics page (new `PATCH /api/topics/:id`).
- **Re-analyze** (new `POST /api/project/reanalyze` + Topics page UI): re-reads the site, folds in the description, drafts only topics you aren't tracking; accept/dismiss per draft, nothing saves unreviewed. Works from the description alone when the site can't be read.
- `POST /api/topics` accepts starter prompts so accepting a draft is one request.

## 02 — Multi-engine runs
- `POST /api/runs` takes an optional `{ provider }` override — **trial included** (Q3 decision); every run still atomically consumes a free run.
- **"Run on all N engines"** on the Runs page: sequential loop over the engines the account can fund (own coverage + trial coverage while the allowance lasts).
- **Cadence from the onset**: onboarding's first run is a parallel sweep across every fundable engine (trial-funded runs split the remaining spend budget), and new projects start on a **daily schedule** instead of `off`.
- **The cron now runs trial-funded scheduled projects** via new service-scoped RPCs (`consume_trial_run_for`, `increment_trial_tokens_for`, `increment_trial_spend_for` — execute revoked from all client roles, granted to `service_role`). If the DB migration isn't applied yet, the consume errors safely and the cron skips trial projects exactly as before.
- Trial defaults raised 3× (mid of the 2–4× call): **15 runs / $15**, still env-overridable via `TRIAL_RUN_LIMIT` / `TRIAL_SPEND_LIMIT_USD`.

## 03 — Overall AI visibility
- Overview gets a **by-engine card**: latest visibility + share of voice per engine, with an **Overall AI visibility** rollup — simple mean across engines (Q5 lean), engines whose latest run is >30 days old shown but dropped from the average (Q6 lean).
- The trend chart becomes **one line per engine** the moment runs span engines (deeper 20-run window), replacing the blended zigzag. Single-engine projects keep the existing visibility + share chart.

## Not built (open per the doc)
- Q1 stale-prompt deactivation, Q4 scheduled fan-out (cadence runs the default engine only for now), Q7 narrative report, Q8 visibility frontier, Q2 stress test (separate effort).

## Deploy notes
- ⚠️ **DB migration required** for trial-funded scheduled runs: apply the three `*_for` functions from `supabase/schema.sql` (idempotent). Until applied, the cron behaves exactly as today.
- If `TRIAL_RUN_LIMIT` / `TRIAL_SPEND_LIMIT_USD` are set in Vercel env, they override the new 15/$15 defaults — update or unset them to take the raise.

## Testing
- `npm test` — 738 passing (onboarding mocks + pricing default tests updated)
- `tsc --noEmit`, `next lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WV3hpgdqARW5DFCtTupT9

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789847940&installation_model_id=431526&pr_number=143&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F143&signature=1d7802a623b7a2a248b4d1b0a0aadd080ca14371ee1da000dbbe91666184a442"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->