### PR TITLE
The specificity ladder: tier-tagged questions + the visibility frontier (Q8a)

### DIFF
--- a/app/api/topics/[id]/generate/route.ts
+++ b/app/api/topics/[id]/generate/route.ts
@@ -101,12 +101,15 @@ export async function POST(
       );
     }
 
-    const rows = variations.map((text) => ({
+    const rows = variations.map((v) => ({
       project_id: project.id,
       topic_id: topic.id,
-      text,
+      text: v.text,
       source: "ai" as const,
       is_active: true,
+      // The ladder tier the generator assigned, so the frontier readout can
+      // say WHERE the brand appears, not just whether.
+      specificity: v.specificity,
     }));
 
     const { data, error } = await supabase.from("prompts").insert(rows).select();

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -37,7 +37,7 @@ import {
 } from "@/lib/metrics";
 import { modelLabel, PROVIDERS } from "@/lib/models";
 import { formatDate, pct, timeAgo } from "@/lib/utils";
-import type { Mention, Provider, Run, Source, Topic } from "@/lib/types";
+import type { Mention, Provider, Run, Source, Specificity, Topic } from "@/lib/types";
 
 export const dynamic = "force-dynamic";
 
@@ -252,21 +252,33 @@ export default async function DashboardPage() {
     new Set([...trendIds, ...Array.from(engineLatest.values(), (r) => r.id)]),
   );
 
-  const [mentionsResult, latestResponsesResult, topicsList, latestSourcesResult] = await Promise.all([
-    // NOTE: capped at 1000 rows by PostgREST; fine for ~20 runs of mention rows
-    // (only detected entities produce rows). Revisit if trend depth grows.
-    supabase.from("mentions").select("*").in("run_id", mentionIds),
-    supabase.from("responses").select("topic_id").eq("run_id", latestRun.id),
-    supabase.from("topics").select("*").eq("project_id", project.id),
-    supabase
-      .from("sources")
-      .select("response_id, url, is_owned")
-      .eq("run_id", latestRun.id),
-  ]);
+  const [mentionsResult, latestResponsesResult, topicsList, latestSourcesResult, promptTierResult] =
+    await Promise.all([
+      // NOTE: capped at 1000 rows by PostgREST; fine for ~20 runs of mention rows
+      // (only detected entities produce rows). Revisit if trend depth grows.
+      supabase.from("mentions").select("*").in("run_id", mentionIds),
+      supabase
+        .from("responses")
+        .select("id, topic_id, prompt_id")
+        .eq("run_id", latestRun.id),
+      supabase.from("topics").select("*").eq("project_id", project.id),
+      supabase
+        .from("sources")
+        .select("response_id, url, is_owned")
+        .eq("run_id", latestRun.id),
+      // Ladder tiers, for the frontier readout below.
+      supabase
+        .from("prompts")
+        .select("id, specificity")
+        .eq("project_id", project.id)
+        .not("specificity", "is", null),
+    ]);
 
   const allMentions = (mentionsResult.data as Mention[] | null) ?? [];
   const latestResponses =
-    (latestResponsesResult.data as { topic_id: string | null }[] | null) ?? [];
+    (latestResponsesResult.data as
+      | { id: string; topic_id: string | null; prompt_id: string | null }[]
+      | null) ?? [];
 
   const mentionsByRun = new Map<string, Mention[]>();
   for (const m of allMentions) {
@@ -354,6 +366,50 @@ export default async function DashboardPage() {
     rollupRows.length > 0
       ? rollupRows.reduce((sum, r) => sum + r.visibility, 0) / rollupRows.length
       : null;
+
+  // The visibility frontier: brand mention rate per ladder tier, latest run.
+  // Where mentions START on the general→niche ladder is the brand's measured
+  // authority — a 0% on general questions next to a 40% on niche ones is a
+  // young brand doing fine, not a product that isn't working.
+  const tierByPrompt = new Map(
+    (
+      (promptTierResult.data as { id: string; specificity: Specificity }[] | null) ?? []
+    ).map((p) => [p.id, p.specificity]),
+  );
+  const mentionedResponseIds = new Set(
+    latestMentions
+      .filter((m) => m.entity_type === "brand" && m.mentioned)
+      .map((m) => m.response_id),
+  );
+  const TIER_ORDER: Specificity[] = ["general", "mid", "niche"];
+  const TIER_LABELS: Record<Specificity, string> = {
+    general: "General",
+    mid: "Mid",
+    niche: "Niche",
+  };
+  const tierStats = TIER_ORDER.map((tier) => {
+    const rows = latestResponses.filter(
+      (r) => r.prompt_id && tierByPrompt.get(r.prompt_id) === tier,
+    );
+    const mentioned = rows.filter((r) => mentionedResponseIds.has(r.id)).length;
+    return {
+      tier,
+      total: rows.length,
+      mentioned,
+      rate: rows.length > 0 ? mentioned / rows.length : 0,
+    };
+  });
+  const measuredTiers = tierStats.filter((t) => t.total > 0);
+  // Most general tier with any mention — TIER_ORDER runs broad to narrow.
+  const frontier = tierStats.find((t) => t.mentioned > 0)?.tier ?? null;
+  const frontierNote =
+    frontier === "general"
+      ? "You appear in the broadest questions about your space."
+      : frontier === "mid"
+        ? "You appear in segment-level questions, not yet in the broadest ones — that top tier is the gap to close."
+        : frontier === "niche"
+          ? "You appear in niche questions only. That's where young brands start; broadening comes as authority grows."
+          : "No tier shows mentions yet. Generate more niche questions to find where you first appear.";
 
   // Share-of-voice leaderboard (brand + competitors, desc by share).
   const shareEntities: EntityStat[] = [...stats].sort(
@@ -483,6 +539,44 @@ export default async function DashboardPage() {
                     {/* Stale engines stay listed but leave the rollup — an
                         engine last measured a month ago isn't "overall" truth. */}
                     {row.stale && " · not in average"}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </CardBody>
+        </Card>
+      )}
+
+      {/* The visibility frontier — only once at least two tiers have answers
+          in the latest run, i.e. the ladder actually got measured. */}
+      {measuredTiers.length >= 2 && (
+        <Card>
+          <CardBody>
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div className="min-w-0">
+                <h3 className="text-lg font-semibold text-ink">Visibility frontier</h3>
+                <p className="mt-0.5 max-w-xl text-sm text-ink-soft">{frontierNote}</p>
+              </div>
+            </div>
+            <div className="mt-4 grid gap-3 sm:grid-cols-3">
+              {tierStats.map((t) => (
+                <div
+                  key={t.tier}
+                  className={`rounded border p-3.5 ${
+                    t.tier === frontier ? "border-terracotta/40" : "border-ink/10"
+                  }`}
+                >
+                  <p className="text-xs font-medium uppercase tracking-wide text-ink-faint">
+                    {TIER_LABELS[t.tier]} questions
+                  </p>
+                  <p className="mt-1 text-2xl font-semibold text-ink">
+                    {t.total > 0 ? pct(t.rate) : "—"}
+                  </p>
+                  <p className="mt-1 text-xs text-ink-faint">
+                    {t.total > 0
+                      ? `${t.mentioned} of ${t.total} answers named you`
+                      : "no tagged questions ran"}
+                    {t.tier === frontier && " · your frontier"}
                   </p>
                 </div>
               ))}

--- a/app/dashboard/topics/topics-client.tsx
+++ b/app/dashboard/topics/topics-client.tsx
@@ -579,10 +579,21 @@ function PromptRow({ prompt }: { prompt: Prompt }) {
         <p className={prompt.is_active ? "text-sm text-ink" : "text-sm text-ink-faint line-through"}>
           {prompt.text}
         </p>
-        <div className="mt-1">
+        <div className="mt-1 flex items-center gap-1.5">
           <Badge tone={prompt.source === "ai" ? "teal" : "butter"}>
             {prompt.source === "ai" ? "AI" : "Manual"}
           </Badge>
+          {/* Ladder tier, when the generator assigned one. Where on the ladder
+              mentions start is the brand's frontier — see the overview card. */}
+          {prompt.specificity && (
+            <Badge tone="neutral">
+              {prompt.specificity === "general"
+                ? "General"
+                : prompt.specificity === "mid"
+                  ? "Mid"
+                  : "Niche"}
+            </Badge>
+          )}
         </div>
       </div>
       <Button

--- a/lib/llm/google.test.ts
+++ b/lib/llm/google.test.ts
@@ -212,7 +212,11 @@ describe("google JSON utility calls", () => {
     expect(sentBody().generationConfig.responseMimeType).toBe("application/json");
     // Gemini answers a JSON+grounding request with 200 and no candidates at all.
     expect(sentBody().tools).toBeUndefined();
-    expect(res.variations).toEqual(["a", "b"]);
+    // Bare strings are the pre-ladder shape; they parse as untagged questions.
+    expect(res.variations).toEqual([
+      { text: "a", specificity: null },
+      { text: "b", specificity: null },
+    ]);
   });
 
   it("parses a JSON object wrapper as well as a bare array", async () => {
@@ -224,7 +228,34 @@ describe("google JSON utility calls", () => {
       topicName: "CDNs",
       count: 3,
     });
-    expect(res.variations).toEqual(["a", "b", "c"]);
+    expect(res.variations).toEqual([
+      { text: "a", specificity: null },
+      { text: "b", specificity: null },
+      { text: "c", specificity: null },
+    ]);
+  });
+
+  it("keeps valid ladder tiers and drops invented ones", async () => {
+    mockFetch(
+      jsonResponse(
+        ok(
+          '{"questions":[{"question":"a","specificity":"niche"},{"question":"b","specificity":"ultra"},{"question":"","specificity":"mid"}]}',
+        ),
+      ),
+    );
+    const res = await generateVariations({
+      provider: "google",
+      model: "gemini-flash-latest",
+      apiKey: KEY,
+      topicName: "CDNs",
+      count: 3,
+    });
+    // "ultra" isn't a tier — the question survives, the label doesn't. The
+    // empty question is dropped entirely.
+    expect(res.variations).toEqual([
+      { text: "a", specificity: "niche" },
+      { text: "b", specificity: null },
+    ]);
   });
 
   it("parses competitor suggestions", async () => {

--- a/lib/llm/index.ts
+++ b/lib/llm/index.ts
@@ -1,6 +1,6 @@
 import Anthropic from "@anthropic-ai/sdk";
 import OpenAI from "openai";
-import type { Provider, RouteInfo, RouterId, Sentiment } from "@/lib/types";
+import type { Provider, RouteInfo, RouterId, Sentiment, Specificity } from "@/lib/types";
 import {
   AI_OVERVIEWS_BACKING_MODEL,
   GOOGLE_AI_OVERVIEWS_MODEL,
@@ -1512,7 +1512,14 @@ Rules:
 - Keep the remaining questions in a buyer's own words ("What's the best X for Y?", "Who are the main players in X?") so the set reflects real usage, but keep them the minority.
 - Do NOT name any specific brand in the questions unless the brand is part of the topic itself.
 - Vary buyer intent and seniority, not just the wording.
-- Return ONLY a JSON array of strings. No commentary.`;
+- Spread the questions across a specificity ladder and label each one:
+  "general" = the broad category question anyone might ask ("List the top 5 payroll companies by name.")
+  "mid" = qualified by a segment or use case ("Which providers handle payroll for a 20-person startup? Just company names.")
+  "niche" = a specific buyer situation, narrow enough that smaller or newer companies can realistically be named ("Name payroll vendors that support contractor payouts to Brazil for a seed-stage startup.")
+  Aim for a roughly even mix of the three tiers. The named-companies rule applies at every tier.
+- Return ONLY a JSON array of objects shaped {"question": string, "specificity": "general" | "mid" | "niche"}. No commentary.`;
+
+const SPECIFICITY_VALUES = new Set(["general", "mid", "niche"]);
 
 /** Generate natural prompt variations for a topic. */
 export async function generateVariations(
@@ -1525,7 +1532,10 @@ export async function generateVariations(
     brandDescription?: string | null;
     count: number;
   },
-): Promise<{ variations: string[]; tokens: number }> {
+): Promise<{
+  variations: { text: string; specificity: Specificity | null }[];
+  tokens: number;
+}> {
   const user = `Topic: ${opts.topicName}${
     opts.topicDescription ? `\nContext: ${opts.topicDescription}` : ""
   }${
@@ -1544,8 +1554,9 @@ Generate ${opts.count} distinct questions a person might ask an AI assistant rel
     shape === "anthropic"
       ? VARIATION_SYSTEM
       : shape === "openai-chat" || shape === "openai-responses"
-        ? VARIATION_SYSTEM + "\nReturn a JSON object shaped { \"questions\": string[] }."
-        : VARIATION_SYSTEM + "\nReturn a JSON array of strings.";
+        ? VARIATION_SYSTEM +
+          '\nReturn a JSON object shaped { "questions": [{ "question": string, "specificity": string }] }.'
+        : VARIATION_SYSTEM + "\nReturn a JSON array of the objects described above.";
 
   const res = await utilityChat(opts, opts.model, system, user, UTILITY_MAX_TOKENS, true);
 
@@ -1554,9 +1565,28 @@ Generate ${opts.count} distinct questions a person might ask an AI assistant rel
     parsed = (parsed as { questions?: unknown }).questions ?? [];
   }
   const arr = Array.isArray(parsed) ? parsed : [];
+  // Tolerate the pre-ladder shape (bare strings): a model that ignores the
+  // labeling instruction still produces usable questions — they just land
+  // untagged, exactly like manual prompts.
   const variations = arr
-    .map((q) => (typeof q === "string" ? q.trim() : ""))
-    .filter((q) => q.length > 0)
+    .map((q): { text: string; specificity: Specificity | null } | null => {
+      if (typeof q === "string") {
+        const text = q.trim();
+        return text ? { text, specificity: null } : null;
+      }
+      if (q && typeof q === "object") {
+        const o = q as { question?: unknown; specificity?: unknown };
+        const text = typeof o.question === "string" ? o.question.trim() : "";
+        if (!text) return null;
+        const tier =
+          typeof o.specificity === "string" && SPECIFICITY_VALUES.has(o.specificity)
+            ? (o.specificity as Specificity)
+            : null;
+        return { text, specificity: tier };
+      }
+      return null;
+    })
+    .filter((v): v is { text: string; specificity: Specificity | null } => v !== null)
     .slice(0, opts.count);
   return { variations, tokens: res.tokens };
 }

--- a/lib/llm/perplexity.test.ts
+++ b/lib/llm/perplexity.test.ts
@@ -407,7 +407,12 @@ describe("perplexity JSON utility calls", () => {
       topicName: "cdn",
       count: 3,
     });
-    expect(res.variations).toEqual(["a", "b", "c"]);
+    // Bare strings are the pre-ladder shape; they parse as untagged questions.
+    expect(res.variations).toEqual([
+      { text: "a", specificity: null },
+      { text: "b", specificity: null },
+      { text: "c", specificity: null },
+    ]);
   });
 
   it("classifies sentiment and attributes rows to the right entity", async () => {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -129,6 +129,15 @@ export interface Topic {
   created_at: string;
 }
 
+/**
+ * How broad a question is — the specificity ladder. A young brand appears in
+ * niche questions long before general ones, so where on the ladder mentions
+ * start is the brand's measured authority (its "visibility frontier"). Null on
+ * prompts written before the ladder existed, and on manual prompts the user
+ * hasn't classified.
+ */
+export type Specificity = "general" | "mid" | "niche";
+
 export interface Prompt {
   id: string;
   project_id: string;
@@ -138,6 +147,7 @@ export interface Prompt {
   is_active: boolean;
   /** The page this prompt was written to surface, when the caller mapped one. */
   target_url: string | null;
+  specificity: Specificity | null;
   created_at: string;
 }
 

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -373,6 +373,17 @@ create table if not exists public.prompts (
 alter table public.prompts
   add column if not exists target_url text;
 
+-- The specificity ladder: how broad the question is. Where on the ladder a
+-- brand's mentions start is its measured authority (the "visibility
+-- frontier"). Nullable: prompts from before the ladder, and manual prompts
+-- the user hasn't classified, stay untagged. Safe to re-run.
+alter table public.prompts
+  add column if not exists specificity text;
+alter table public.prompts drop constraint if exists prompts_specificity_check;
+alter table public.prompts
+  add constraint prompts_specificity_check
+  check (specificity is null or specificity in ('general', 'mid', 'niche'));
+
 -- ---------- runs -----------------------------------------------------
 create table if not exists public.runs (
   id uuid primary key default gen_random_uuid(),


### PR DESCRIPTION
Re-opened copy of #144 (GitHub closed it when its stacked base branch merged and deleted). Now that #143 is in master, this diff is the ladder alone. Implements **Q8 option (a)** from [the design doc](https://claude.ai/code/artifact/f3599c3e-8cc2-455c-824c-3563cd853588): tier tags + a frontier readout, generation mix static, adaptation suggested-not-silent.

- **Question generation labels each draft** `general` / `mid` / `niche` with an even-mix instruction. Bare-string model responses still parse (untagged), so a model that ignores the labeling degrades gracefully.
- **`prompts.specificity` column** (nullable; idempotent migration in `supabase/schema.sql`). Old and manual prompts stay untagged.
- **Tier badge** on prompt rows in Topics.
- **"Visibility frontier" card** on the overview: brand mention rate per tier for the latest run; the most general tier with mentions is the frontier. Appears once ≥2 tiers have answers.

## Testing
- `npm test` — 739 passing; `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WV3hpgdqARW5DFCtTupT9

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789858753&installation_model_id=431526&pr_number=146&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F146&signature=81b97b7a9a5aa1860fb65c5bfda68101e05745f3c8a7166941d44de11c657b8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->