### PR TITLE
Remove em-dashes from user-facing copy

### DIFF
--- a/app/admin/accounts/[id]/page.tsx
+++ b/app/admin/accounts/[id]/page.tsx
@@ -123,7 +123,7 @@ function RunSparkline({ series }: { series: { day: string; runs: number }[] }) {
               fill: d.runs === 0 ? "rgb(var(--c-ink) / 0.12)" : "rgb(var(--c-mint-bright))",
             }}
           >
-            <title>{`${d.day} — ${d.runs} run${d.runs === 1 ? "" : "s"}`}</title>
+            <title>{`${d.day} · ${d.runs} run${d.runs === 1 ? "" : "s"}`}</title>
           </rect>
         );
       })}
@@ -368,13 +368,13 @@ export default async function AdminAccountPage({ params }: { params: { id: strin
         <div>
           <h3 className="text-lg font-semibold text-ink">What they monitor</h3>
           <p className="mt-1 max-w-3xl text-sm text-ink-faint">
-            The brands, cadence and competitors this account tracks — one card per organization.
+            The brands, cadence and competitors this account tracks, one card per organization.
           </p>
         </div>
         {projects.length === 0 ? (
           <Card>
             <p className="px-5 py-8 text-sm text-ink-faint">
-              No organizations yet — this account signed up but never set one up.
+              No organizations yet: this account signed up but never set one up.
             </p>
           </Card>
         ) : (
@@ -429,7 +429,7 @@ export default async function AdminAccountPage({ params }: { params: { id: strin
           <span className="text-sm tabular-nums text-ink-faint">{prompts.length}</span>
         </div>
         <p className="max-w-3xl text-sm text-ink-faint">
-          The active questions they ask the engines every run — what they actually care about being
+          The active questions they ask the engines every run: what they actually care about being
           the answer to.
         </p>
         <Card>
@@ -524,13 +524,13 @@ export default async function AdminAccountPage({ params }: { params: { id: strin
           <span className="text-sm tabular-nums text-ink-faint">{activity.length}</span>
         </div>
         <p className="max-w-3xl text-sm text-ink-faint">
-          Everything this account has done lately, whatever the surface — dashboard, API, CLI or the
+          Everything this account has done lately, whatever the surface: dashboard, API, CLI or the
           scheduler.
         </p>
         <Card>
           {activity.length === 0 ? (
             <p className="px-5 py-8 text-sm text-ink-faint">
-              Nothing recorded — either this account is quiet, or activity logging is not populated
+              Nothing recorded: either this account is quiet, or activity logging is not populated
               on this deployment.
             </p>
           ) : (
@@ -555,7 +555,7 @@ export default async function AdminAccountPage({ params }: { params: { id: strin
       </section>
 
       <p className="text-xs text-ink-faint">
-        Operator view — this page shows one account’s own content so you can see who is using the
+        Operator view: this page shows one account’s own content so you can see who is using the
         product and what they monitor.{" "}
         <Link href="/admin/growth" className="underline">
           Back to Growth

--- a/app/admin/growth/page.tsx
+++ b/app/admin/growth/page.tsx
@@ -73,7 +73,7 @@ function RunSparkline({ series }: { series: { day: string; users: number; runs: 
               fill: d.runs === 0 ? "rgb(var(--c-ink) / 0.12)" : "rgb(var(--c-mint-bright))",
             }}
           >
-            <title>{`${d.day} — ${d.runs} run${d.runs === 1 ? "" : "s"}, ${d.users} user${d.users === 1 ? "" : "s"}`}</title>
+            <title>{`${d.day} · ${d.runs} run${d.runs === 1 ? "" : "s"}, ${d.users} user${d.users === 1 ? "" : "s"}`}</title>
           </rect>
         );
       })}
@@ -107,14 +107,14 @@ export default async function GrowthPage({ searchParams }: { searchParams: SP })
     <div className="space-y-10">
       <SectionHeading
         title="Growth"
-        description="Activity measured in runs, and the lead list it produces. Emails are shown in the clear here — this page exists for outbound."
+        description="Activity measured in runs, and the lead list it produces. Emails are shown in the clear here: this page exists for outbound."
         action={<PeopleDirectory accounts={report.accounts} />}
       />
 
       {report.degraded && (
         <Card className="border-terracotta/40 bg-terracotta/[0.04]">
           <p className="px-6 py-4 text-sm text-terracotta-dark">
-            Some figures could not be loaded ({report.degraded}) — treat the numbers below as
+            Some figures could not be loaded ({report.degraded}). Treat the numbers below as
             incomplete rather than as zero.
           </p>
         </Card>
@@ -279,7 +279,7 @@ export default async function GrowthPage({ searchParams }: { searchParams: SP })
           <div>
             <h3 className="text-lg font-semibold text-ink">Lapsed leads</h3>
             <p className="mt-1 max-w-2xl text-sm text-ink-faint">
-              No run in 7 days. Work addresses are the outbound list — and “never ran” is the
+              No run in 7 days. Work addresses are the outbound list, and “never ran” is the
               warmest lead: they wanted this enough to sign up, then bounced off something.
             </p>
           </div>

--- a/app/admin/operators.tsx
+++ b/app/admin/operators.tsx
@@ -119,14 +119,14 @@ export function OperatorsMenu({ roster }: { roster: OperatorRoster }) {
           {unresolved > 0 && (
             <p className="border-t border-ink/5 px-4 py-2.5 text-xs text-terracotta-dark">
               {roster.gate === "user-id"
-                ? "An id matching no account grants nothing — almost certainly a typo, and whoever it was meant for cannot get in."
+                ? "An id matching no account grants nothing. It is almost certainly a typo, and whoever it was meant for cannot get in."
                 : "An allowlisted address with no account can be registered by anyone who guesses it. Switch to ADMIN_USER_IDS."}
             </p>
           )}
 
           {roster.degraded && (
             <p className="border-t border-ink/5 px-4 py-2.5 text-xs text-ink-faint">
-              Accounts could not be fully read ({roster.degraded}) — an entry shown as unmatched may
+              Accounts could not be fully read ({roster.degraded}), so an entry shown as unmatched may
               simply not have been checked.
             </p>
           )}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -64,7 +64,7 @@ export default async function AdminPage({ searchParams }: { searchParams: SP }) 
               <p className="font-semibold text-ink">Access is gated on email addresses</p>
               <p className="text-ink-soft">
                 Safe only while every address in{" "}
-                <code className="font-mono text-xs">ADMIN_EMAILS</code> already has an account —
+                <code className="font-mono text-xs">ADMIN_EMAILS</code> already has an account:
                 signup issues a session immediately, so an allowlisted address nobody has
                 registered can be claimed by whoever guesses it. Set{" "}
                 <code className="font-mono text-xs">ADMIN_USER_IDS</code> instead.
@@ -118,12 +118,12 @@ export default async function AdminPage({ searchParams }: { searchParams: SP }) 
                   `${live.failures.length} distinct run failure${live.failures.length === 1 ? "" : "s"}. `}
                 {!failing &&
                   (live.runs24h.total === 0
-                    ? `No runs in the last ${win.label} — nothing has failed, but nothing has been exercised either.`
+                    ? `No runs in the last ${win.label}: nothing has failed, but nothing has been exercised either.`
                     : `${live.runs24h.completed} of ${live.runs24h.completed + live.runs24h.failed} runs completed.`)}
               </p>
               {live.degraded && (
                 <p className="text-sm text-terracotta-dark">
-                  Some figures could not be loaded ({live.degraded}) — treat the numbers below as
+                  Some figures could not be loaded ({live.degraded}). Treat the numbers below as
                   incomplete rather than as zero.
                 </p>
               )}
@@ -206,7 +206,7 @@ export default async function AdminPage({ searchParams }: { searchParams: SP }) 
 
       <p className="text-xs text-ink-faint">
         Last run {timeAgo(live.lastRunAt)}. Nothing on this page records or displays customer
-        content — prompts, answers and brand names are never written to telemetry.{" "}
+        content: prompts, answers and brand names are never written to telemetry.{" "}
         <Link href="/dashboard" className="underline">
           Back to dashboard
         </Link>

--- a/app/admin/people.tsx
+++ b/app/admin/people.tsx
@@ -225,7 +225,7 @@ function PeopleDialog({ accounts, onClose }: { accounts: AccountRow[]; onClose: 
           {clipped > 0 ? (
             <>
               Showing the first {shown.length.toLocaleString()} of{" "}
-              {filtered.length.toLocaleString()} — refine the search to reach the rest.
+              {filtered.length.toLocaleString()}. Refine the search to reach the rest.
             </>
           ) : (
             <>

--- a/app/admin/runs/[id]/page.tsx
+++ b/app/admin/runs/[id]/page.tsx
@@ -183,7 +183,7 @@ export default async function AdminRunPage({ params }: { params: { id: string } 
         {(responses ?? []).length === 0 ? (
           <Card>
             <p className="px-6 py-8 text-sm text-ink-faint">
-              No answers recorded — the run {run.status === "failed" ? "failed" : "has not produced any yet"}.
+              No answers recorded: the run {run.status === "failed" ? "failed" : "has not produced any yet"}.
             </p>
           </Card>
         ) : (
@@ -249,7 +249,7 @@ export default async function AdminRunPage({ params }: { params: { id: string } 
       </section>
 
       <p className="text-xs text-ink-faint">
-        Operator view — this page shows customer run content so outbound can reference what the
+        Operator view: this page shows customer run content so outbound can reference what the
         account actually saw.
       </p>
     </div>

--- a/app/admin/telemetry.tsx
+++ b/app/admin/telemetry.tsx
@@ -137,7 +137,7 @@ export function Telemetry({
           total={stuck.length}
           shown={shownStuck.length}
           filtering={filtering}
-          hint="Still running after 30 minutes — an invocation that died without writing a status. These never finish on their own."
+          hint="Still running after 30 minutes: an invocation that died without writing a status. These never finish on their own."
         >
           {shownStuck.map((r) => (
             <Row key={r.id} accent>
@@ -197,7 +197,7 @@ export function Telemetry({
               ? "Nothing recorded in the window."
               : // Only when the list is empty. Printed above a populated list it
                 // contradicted the rows directly beneath it.
-                "Telemetry is off — errors outside the run lifecycle are not recorded. Set OPS_TELEMETRY=1 and redeploy. Everything else on this page comes from run history and does not depend on it."
+                "Telemetry is off, so errors outside the run lifecycle are not recorded. Set OPS_TELEMETRY=1 and redeploy. Everything else on this page comes from run history and does not depend on it."
             : "Nothing matches the current filter."
         }
       >

--- a/app/api/cron/letterprove-health/route.ts
+++ b/app/api/cron/letterprove-health/route.ts
@@ -99,7 +99,7 @@ async function handle(request: Request) {
         ...lines,
         "",
         `Configured origin: ${origin}`,
-        "Set NEXT_PUBLIC_LETTERPROVE_ORIGIN if Letterprove has moved, then redeploy —",
+        "Set NEXT_PUBLIC_LETTERPROVE_ORIGIN if Letterprove has moved, then redeploy:",
         "the origin is read at build time.",
       ].join("\n"),
     });

--- a/app/api/mcp/[transport]/route.ts
+++ b/app/api/mcp/[transport]/route.ts
@@ -178,7 +178,7 @@ const handler = createMcpHandler(
 
     server.tool(
       "get_share_of_voice_report",
-      "Share-of-voice report for a monitoring run: how often the brand and each competitor are mentioned in AI assistant answers, with share of voice, prominence, sentiment, and recommendation rate. Also breaks this down per prompt (promptEntities: who gets named for each question) and reports which competitor domains the answers cited per prompt (competitorCitations) — use these to find questions rivals win that you don't. Pass run_id, or just project_id for the latest completed run.",
+      "Share-of-voice report for a monitoring run: how often the brand and each competitor are mentioned in AI assistant answers, with share of voice, prominence, sentiment, and recommendation rate. Also breaks this down per prompt (promptEntities: who gets named for each question) and reports which competitor domains the answers cited per prompt (competitorCitations). Use these to find questions rivals win that you don't. Pass run_id, or just project_id for the latest completed run.",
       {
         run_id: z
           .string()

--- a/app/api/router-keys/route.ts
+++ b/app/api/router-keys/route.ts
@@ -40,7 +40,7 @@ export async function POST(request: Request) {
   await logDashboard(user, request, {
     category: "router_key",
     action: "router_key.saved",
-    summary: `Saved a ${outcome.key.router} router key (${outcome.key.key_hint}) — ${verificationSummary(outcome.verification)}`,
+    summary: `Saved a ${outcome.key.router} router key (${outcome.key.key_hint}): ${verificationSummary(outcome.verification)}`,
     targetType: "router_key",
     targetId: outcome.key.id,
     metadata: {

--- a/app/api/v1/router-keys/[router]/route.ts
+++ b/app/api/v1/router-keys/[router]/route.ts
@@ -70,7 +70,7 @@ export async function PUT(
     statusCode: 200,
     targetType: "router_key",
     targetId: outcome.key.id,
-    summary: `Saved a ${outcome.key.router} router key (${outcome.key.key_hint}) — ${verificationSummary(outcome.verification)}`,
+    summary: `Saved a ${outcome.key.router} router key (${outcome.key.key_hint}): ${verificationSummary(outcome.verification)}`,
     metadata: {
       router: outcome.key.router,
       key_hint: outcome.key.key_hint,

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -406,7 +406,7 @@ export default async function DashboardPage() {
     frontier === "general"
       ? "You appear in the broadest questions about your space."
       : frontier === "mid"
-        ? "You appear in segment-level questions, not yet in the broadest ones — that top tier is the gap to close."
+        ? "You appear in segment-level questions, not yet in the broadest ones. That top tier is the gap to close."
         : frontier === "niche"
           ? "You appear in niche questions only. That's where young brands start; broadening comes as authority grows."
           : "No tier shows mentions yet. Generate more niche questions to find where you first appear.";

--- a/app/dashboard/runs/[id]/page.tsx
+++ b/app/dashboard/runs/[id]/page.tsx
@@ -278,7 +278,7 @@ export default async function RunDetailPage({ params }: { params: { id: string }
         <div className="space-y-3">
           <SectionHeading
             title="Competitors by question"
-            description="Across all replicates: who gets named — and whose site gets cited — for each question. “You’re missing” flags where a competitor shows up and your brand doesn’t."
+            description="Across all replicates: who gets named, and whose site gets cited, for each question. “You’re missing” flags where a competitor shows up and your brand doesn’t."
           />
           <div className="space-y-3">
             {competitionByPrompt.map((p) => (

--- a/app/dashboard/runs/schedule-control.tsx
+++ b/app/dashboard/runs/schedule-control.tsx
@@ -68,7 +68,7 @@ export function ScheduleControl({
             <p className="text-sm font-medium text-ink">Automatic runs</p>
             {!scheduled && (
               <p className="text-xs text-ink-faint">
-                Run your prompts on a schedule — around 8:00 UTC — instead of by
+                Run your prompts on a schedule (around 8:00 UTC) instead of by
                 hand, and build a trend over time.
               </p>
             )}

--- a/app/dashboard/settings/routers-manager.tsx
+++ b/app/dashboard/settings/routers-manager.tsx
@@ -333,10 +333,10 @@ function EngineStatus({
               <span className="text-ink-soft">
                 <span className="font-medium text-ink">{PROVIDERS[provider].label}</span>{" "}
                 {unreachable
-                  ? `not reachable on this key${check?.error ? ` — ${check.error}` : ""}`
+                  ? `not reachable on this key${check?.error ? `: ${check.error}` : ""}`
                   : grounded
                     ? "measurable, live web search confirmed"
-                    : "reachable, but web search isn't confirmed — usable only for projects with web search off"}
+                    : "reachable, but web search isn't confirmed. Usable only for projects with web search off"}
               </span>
             </li>
           );
@@ -346,7 +346,7 @@ function EngineStatus({
           worth naming once, because "my router does 400 models" makes their
           absence surprising. */}
       <p className="text-xs text-ink-faint">
-        {needsOwnKeyList} {needsOwnKey.length === 1 ? "needs its own key" : "need their own keys"} — their answers
+        {needsOwnKeyList} {needsOwnKey.length === 1 ? "needs its own key" : "need their own keys"}: their answers
         aren&apos;t comparable when routed through a gateway.
       </p>
     </div>

--- a/app/dashboard/topics/topics-client.tsx
+++ b/app/dashboard/topics/topics-client.tsx
@@ -222,7 +222,7 @@ function ReanalyzeSection({
 
         {suggestions && suggestions.length === 0 && !error && (
           <p className="text-sm text-ink-faint">
-            Nothing new to suggest — your current topics already cover what the
+            Nothing new to suggest: your current topics already cover what the
             analysis found.
           </p>
         )}

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -23,7 +23,7 @@ export default function PrivacyPage() {
         <p><strong>Provider API keys.</strong> If you bring your own Anthropic or OpenAI key, we store it encrypted (see §5) so scheduled runs can use it. We also store a short hint such as <code>sk-…4a9c</code> so you can tell your keys apart.</p>
         <p><strong>Lettertrace API keys.</strong> Stored only as SHA-256 hashes. The full key is shown once at creation and cannot be recovered by us or by you afterwards.</p>
         <p><strong>Usage counters.</strong> If you use trial runs on our shared provider keys, we count the runs and tokens consumed so we can apply the free-run limit.</p>
-        <p><strong>Marketing-site visitor identification.</strong> On our public marketing pages only — the homepage and legal pages, never while you are signed in to the product — we use a third-party service, RB2B, to identify the business behind a visit and, for some US-based visitors, the individual (typically name, job title, company, LinkedIn profile, and business email), inferred from network and device signals. We use this for business-to-business sales and marketing. It does not run inside the authenticated app, and it is disabled entirely on separately operated (self-hosted) deployments of the software.</p>
+        <p><strong>Marketing-site visitor identification.</strong> On our public marketing pages only (the homepage and legal pages, never while you are signed in to the product), we use a third-party service, RB2B, to identify the business behind a visit and, for some US-based visitors, the individual (typically name, job title, company, LinkedIn profile, and business email), inferred from network and device signals. We use this for business-to-business sales and marketing. It does not run inside the authenticated app, and it is disabled entirely on separately operated (self-hosted) deployments of the software.</p>
         <p>We do not use advertising trackers, we do not sell your information, and we do not build behavioural profiles of you as an account holder.</p>
       </Section>
 
@@ -87,7 +87,7 @@ export default function PrivacyPage() {
       </Section>
 
       <Section n={9} title="Cookies">
-        <p>Within the app we use cookies only for authentication — keeping you signed in and refreshing your session. On our public marketing pages, the RB2B service described in §1 also uses cookies and similar device identifiers to recognise returning business visitors. We do not use advertising cookies. Clearing your cookies signs you out.</p>
+        <p>Within the app we use cookies only for authentication: keeping you signed in and refreshing your session. On our public marketing pages, the RB2B service described in §1 also uses cookies and similar device identifiers to recognise returning business visitors. We do not use advertising cookies. Clearing your cookies signs you out.</p>
       </Section>
 
       <Section n={10} title="Children">

--- a/components/dashboard/trial-banner.tsx
+++ b/components/dashboard/trial-banner.tsx
@@ -57,8 +57,8 @@ export function TrialBanner({
             </p>
             {exhausted && router && (
               <p className="mt-1 text-xs text-ink-faint">
-                One key per assistant, or a single {router.label} key that covers them all —
-                either works.
+                One key per assistant, or a single {router.label} key that covers them all.
+                Either works.
               </p>
             )}
             {!exhausted && limit <= 12 && (

--- a/lib/engine.ts
+++ b/lib/engine.ts
@@ -166,7 +166,7 @@ export async function settleAbandonedRun(
 /** What an interrupted run says for itself. Shared so the sweeper, the status
  *  endpoint and the background catch can't describe it three different ways. */
 export const INTERRUPTED_RUN_ERROR =
-  "The run was interrupted before it finished — the server stopped executing it. Answers stored before that point were kept. Run it again to collect the rest.";
+  "The run was interrupted before it finished: the server stopped executing it. Answers stored before that point were kept. Run it again to collect the rest.";
 
 /**
  * Settle every run that nothing is executing any more.

--- a/lib/notify.ts
+++ b/lib/notify.ts
@@ -129,7 +129,7 @@ export function signupAlert(user: { email?: string | null; id: string; created_a
       `User id: ${user.id}`,
       user.created_at ? `Signed up: ${user.created_at}` : "",
       "",
-      "They have not necessarily run anything yet — this fires when the account",
+      "They have not necessarily run anything yet: this fires when the account",
       "is confirmed and first signed in.",
     ]
       .filter((line) => line !== "")

--- a/lib/router-keys.ts
+++ b/lib/router-keys.ts
@@ -132,7 +132,7 @@ export async function setRouterKey(
       return {
         ok: false,
         code: "invalid",
-        message: "A router base URL must use https — your API key is sent to it.",
+        message: "A router base URL must use https: your API key is sent to it.",
       };
     }
     baseUrl = raw.replace(/\/+$/, "");

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -34,7 +34,7 @@ export function createClient() {
   if (!supabaseUrl || !supabaseAnonKey) {
     throw new Error(
       "Supabase browser config is missing. Set NEXT_PUBLIC_SUPABASE_URL and " +
-        "NEXT_PUBLIC_SUPABASE_ANON_KEY in the server environment — see the " +
+        "NEXT_PUBLIC_SUPABASE_ANON_KEY in the server environment. See the " +
         "self-hosting section of the README.",
     );
   }


### PR DESCRIPTION
Sweeps the em-dashes out of user-facing strings (dashboard, admin pages, legal copy, notification emails, API activity-log messages) so the product copy does not read as AI-written. Punctuation-only diff; standalone "—" empty-value placeholders and LLM prompt text are intentionally kept. Typecheck and production build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XWdBob8CS1dF8G6jrd2EWu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/148"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790037572&installation_model_id=431526&pr_number=148&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F148&signature=a299c37cee27445e5ba582288118c5870081492e9301d8dc367e55e420793303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->