### PR TITLE
Admin Conversions tab: who clicks out to other Letter Company products

### DIFF
--- a/app/admin/conversions/page.tsx
+++ b/app/admin/conversions/page.tsx
@@ -1,0 +1,207 @@
+import { Fragment } from "react";
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { ArrowUpRight } from "lucide-react";
+import { requireAdmin } from "@/lib/admin";
+import { conversionsReport } from "@/lib/conversions";
+import type { EmailClass } from "@/lib/growth";
+import { Badge, Card, SectionHeading, StatCard } from "@/components/ui";
+import { timeAgo } from "@/lib/utils";
+
+export const dynamic = "force-dynamic";
+export const metadata = { robots: { index: false, follow: false } };
+
+/**
+ * The cross-product page: who leaves lettertrace for another Letter Company
+ * product. Like Growth, emails are in the clear — a connected user is the
+ * warmest possible signal for the rest of the family, and this page exists to
+ * act on that. Same requireAdmin gate.
+ *
+ * "Conversions" is the umbrella, and CONNECTED is deliberately its weakest
+ * rung: clicked out to a product. The stronger rungs — signed up over there,
+ * pays for a product — get their own words when we can measure them, which is
+ * why nothing on this page says "converted" about a mere click.
+ *
+ * Deliberately small for now: one row of numbers, one table.
+ */
+
+const CLASS_TONE: Record<EmailClass, "teal" | "sand" | "terracotta"> = {
+  work: "teal",
+  personal: "sand",
+  burner: "terracotta",
+};
+
+function ColumnHeader({ children, className }: { children: React.ReactNode; className?: string }) {
+  return (
+    <span
+      className={`text-[10px] font-medium uppercase tracking-wider text-ink-faint ${className ?? ""}`}
+    >
+      {children}
+    </span>
+  );
+}
+
+export default async function ConversionsPage() {
+  const admin = await requireAdmin();
+  if (!admin) notFound();
+
+  const { stats, connected, degraded } = await conversionsReport();
+
+  return (
+    <div className="space-y-10">
+      <SectionHeading
+        title="Conversions"
+        description="Who goes from lettertrace to another Letter Company product. Today this measures connected users — clicked one of our outbound links; signups and paying customers become their own rungs once we can measure them. Emails are in the clear: this is a cross-sell list."
+      />
+
+      {degraded && (
+        <Card className="border-terracotta/40 bg-terracotta/[0.04]">
+          <p className="px-6 py-4 text-sm text-terracotta-dark">
+            Some figures could not be loaded ({degraded}). Treat the numbers below as incomplete
+            rather than as zero.
+          </p>
+        </Card>
+      )}
+
+      {/* ---- Row 1: the numbers --------------------------------------------- */}
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        <StatCard
+          label="Connected rate"
+          value={stats.rate === null ? "—" : `${stats.rate}%`}
+          hint={`${stats.connectedUsers.toLocaleString()} of ${stats.totalUsers.toLocaleString()} signups clicked a Letter product`}
+          accent="mint"
+        />
+        <StatCard
+          label="Connected users"
+          value={stats.connectedUsers.toLocaleString()}
+          hint="distinct users, all time"
+          accent="teal"
+        />
+        <StatCard
+          label="Clicks"
+          value={stats.clicks30d.toLocaleString()}
+          hint={`rolling 30d · ${stats.clicks7d.toLocaleString()} in 7d · ${stats.clicksTotal.toLocaleString()} ever`}
+          accent="butter"
+        />
+        <StatCard
+          label="Top destination"
+          value={
+            stats.topProduct ? (
+              /* A host, not a number: sized down a step and truncating so a
+                 long domain shrinks gracefully instead of escaping the card,
+                 and a real link out — the arrow marks it as one. */
+              <a
+                href={`https://${stats.topProduct.product}`}
+                target="_blank"
+                rel="noreferrer"
+                title={stats.topProduct.product}
+                className="group flex min-w-0 items-center gap-1"
+              >
+                <span className="truncate text-xl leading-relaxed underline-offset-4 group-hover:underline">
+                  {stats.topProduct.product}
+                </span>
+                <ArrowUpRight
+                  className="h-4 w-4 shrink-0 text-ink-faint transition-colors group-hover:text-ink"
+                  aria-hidden
+                />
+              </a>
+            ) : (
+              "—"
+            )
+          }
+          hint={
+            stats.topProduct
+              ? `${stats.topProduct.clicks.toLocaleString()} click${stats.topProduct.clicks === 1 ? "" : "s"}`
+              : "no clicks recorded yet"
+          }
+          accent="sand"
+        />
+      </div>
+
+      {/* ---- Row 2: who's connected ------------------------------------------ */}
+      <section className="space-y-3">
+        <div>
+          <h3 className="text-lg font-semibold text-ink">Connected users</h3>
+          <p className="mt-1 max-w-3xl text-sm text-ink-faint">
+            Everyone who clicked out to a Letter Company product, most recent first, with where
+            they went.
+          </p>
+        </div>
+        <Card>
+          {connected.length === 0 ? (
+            <p className="px-5 py-8 text-sm text-ink-faint">
+              Nobody has clicked out yet. Tracking only exists from the day it shipped, so an
+              empty list right after a deploy means &ldquo;too early&rdquo;, not
+              &ldquo;never&rdquo;.
+            </p>
+          ) : (
+            <>
+              <div className="flex items-center gap-4 border-b border-ink/10 px-5 py-2">
+                <ColumnHeader className="flex-1">Email · destinations</ColumnHeader>
+                <ColumnHeader className="w-16 text-right">Class</ColumnHeader>
+                <ColumnHeader className="w-14 text-right">Clicks</ColumnHeader>
+                <ColumnHeader className="w-24 text-right">First</ColumnHeader>
+                <ColumnHeader className="w-24 text-right">Latest</ColumnHeader>
+              </div>
+              <div className="max-h-96 divide-y divide-ink/5 overflow-y-auto">
+                {connected.map((c) => (
+                  <div
+                    key={c.userId}
+                    className="flex items-center gap-4 px-5 py-2.5 transition hover:bg-ink/[0.02]"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate font-mono text-[13px] text-ink">
+                        {c.email ?? "(no email)"}
+                      </p>
+                      <p className="truncate text-xs text-ink-faint">
+                        {/* Each destination links to the URL actually clicked
+                            (path included), not just the product's front door. */}
+                        {c.destinations.map((d, i) => (
+                          <Fragment key={d.url}>
+                            {i > 0 && " · "}
+                            <a
+                              href={d.url}
+                              target="_blank"
+                              rel="noreferrer"
+                              title={d.url}
+                              className="underline-offset-2 hover:text-ink hover:underline"
+                            >
+                              {d.product}
+                            </a>
+                            {d.clicks > 1 && ` ×${d.clicks}`}
+                          </Fragment>
+                        ))}
+                      </p>
+                    </div>
+                    <span className="w-16 shrink-0 text-right">
+                      <Badge tone={CLASS_TONE[c.emailClass]}>{c.emailClass}</Badge>
+                    </span>
+                    <span className="w-14 shrink-0 text-right font-mono text-sm tabular-nums text-ink">
+                      {c.clicks.toLocaleString()}
+                    </span>
+                    <span className="w-24 shrink-0 text-right text-xs tabular-nums text-ink-faint">
+                      {timeAgo(c.firstClickAt)}
+                    </span>
+                    <span className="w-24 shrink-0 text-right text-xs tabular-nums text-ink-faint">
+                      {timeAgo(c.lastClickAt)}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
+        </Card>
+      </section>
+
+      <p className="text-xs text-ink-faint">
+        Connected means &ldquo;clicked one of our outbound product links while signed
+        in&rdquo; — visits that start anywhere else are invisible here, and clicking is not
+        signing up or paying, which will be measured separately. Links are counted when wrapped
+        in OutboundLink; today that is the Phantoms item in the dashboard nav.{" "}
+        <Link href="/admin/growth" className="underline">
+          Back to growth
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/app/admin/nav.tsx
+++ b/app/admin/nav.tsx
@@ -22,6 +22,11 @@ const TABS = [
       p.startsWith("/admin/runs") ||
       p.startsWith("/admin/accounts"),
   },
+  {
+    href: "/admin/conversions",
+    label: "Conversions",
+    match: (p: string) => p.startsWith("/admin/conversions"),
+  },
 ];
 
 export function AdminNav() {

--- a/app/api/out/route.ts
+++ b/app/api/out/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import { normalizeProductUrl } from "@/lib/conversions";
+
+export const dynamic = "force-dynamic";
+
+// POST /api/out — record a click on an outbound Letter Company product link.
+// Fired by components/outbound-link.tsx via sendBeacon as the browser leaves,
+// which shapes everything here: the sender never reads the response, so every
+// outcome (bad body, unknown host, insert failure) ends in an empty 2xx — the
+// only hard refusal is no session, because a row needs a user to belong to.
+//
+// The URL is normalized AND allow-listed by normalizeProductUrl before it is
+// stored: an authenticated caller poking this endpoint directly can at worst
+// record that they "clicked" a real Letter product URL — never fill the table
+// with arbitrary strings.
+export async function POST(request: Request) {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  let raw: unknown;
+  try {
+    raw = (await request.json()) as unknown;
+  } catch {
+    raw = null;
+  }
+  const candidate =
+    raw && typeof raw === "object" && "url" in raw ? (raw as { url: unknown }).url : null;
+  const url = typeof candidate === "string" ? normalizeProductUrl(candidate) : null;
+  if (!url) return new NextResponse(null, { status: 204 });
+
+  try {
+    await createServiceClient()
+      .from("outbound_clicks")
+      .insert({ user_id: user.id, url });
+  } catch {
+    // Telemetry never breaks (or delays) the navigation it is recording.
+  }
+  return new NextResponse(null, { status: 204 });
+}

--- a/components/dashboard/nav.tsx
+++ b/components/dashboard/nav.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { ArrowUpRight } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { OutboundLink } from "@/components/outbound-link";
 
 interface NavItem {
   href: string;
@@ -41,9 +42,10 @@ export function DashboardNav() {
           {/* Phantomstory sits above Settings: a nav-shaped item that is really
               an external link, and dressed to say so — the brand mark renders
               greyscale until hover brings the colour up, and the corner arrow
-              is right-aligned where a route item would have nothing. */}
+              is right-aligned where a route item would have nothing.
+              OutboundLink so the click lands on /admin/conversions. */}
           {href === "/dashboard/settings" && (
-            <a
+            <OutboundLink
               href="https://phantomstory.com"
               target="_blank"
               rel="noreferrer"
@@ -61,7 +63,7 @@ export function DashboardNav() {
                 className="ml-auto h-3.5 w-3.5 shrink-0 text-ink-faint transition-colors group-hover:text-ink-soft"
                 aria-hidden
               />
-            </a>
+            </OutboundLink>
           )}
           <Link
             href={href}

--- a/components/outbound-link.tsx
+++ b/components/outbound-link.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import type { AnchorHTMLAttributes } from "react";
+
+/**
+ * An <a> that records its click before the browser leaves for another Letter
+ * Company product. The row behind the /admin Conversions page.
+ *
+ * sendBeacon is the whole point: it hands the request to the browser and
+ * returns immediately, so the navigation is never delayed and the POST
+ * survives the page being torn down — a plain fetch here would be racing the
+ * unload. The fetch/keepalive branch covers environments without sendBeacon.
+ *
+ * Recording is fire-and-forget by design; a failed beacon must never break a
+ * link. The server drops URLs that aren't on the Letter product allow-list
+ * (lib/conversions.ts), so using this component IS the instrumentation — no
+ * per-link registration.
+ */
+export function OutboundLink({
+  href,
+  onClick,
+  children,
+  ...rest
+}: AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) {
+  return (
+    <a
+      href={href}
+      onClick={(event) => {
+        try {
+          const body = JSON.stringify({ url: href });
+          if (navigator.sendBeacon) {
+            navigator.sendBeacon("/api/out", new Blob([body], { type: "application/json" }));
+          } else {
+            void fetch("/api/out", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body,
+              keepalive: true,
+            }).catch(() => {});
+          }
+        } catch {
+          // Never let telemetry break the link.
+        }
+        onClick?.(event);
+      }}
+      {...rest}
+    >
+      {children}
+    </a>
+  );
+}

--- a/lib/conversions.test.ts
+++ b/lib/conversions.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeProductUrl,
+  productOf,
+  shapeConversionStats,
+  shapeConnectedUsers,
+  type OutboundClickRow,
+} from "./conversions";
+import type { GrowthProfileRow } from "./growth";
+
+const DAY_MS = 86_400_000;
+const NOW = Date.parse("2026-08-24T12:00:00.000Z");
+
+function iso(daysAgo: number, hoursAgo = 0): string {
+  return new Date(NOW - daysAgo * DAY_MS - hoursAgo * 3_600_000).toISOString();
+}
+
+function click(overrides: Partial<OutboundClickRow>): OutboundClickRow {
+  return {
+    user_id: "u1",
+    url: "https://phantomstory.com",
+    clicked_at: iso(0, 1),
+    ...overrides,
+  };
+}
+
+const PROFILES: GrowthProfileRow[] = [
+  { id: "u1", email: "jo@acme.io", created_at: iso(60) },
+  { id: "u2", email: "sam@gmail.com", created_at: iso(20) },
+  { id: "u3", email: "eval@mailinator.com", created_at: iso(3) },
+  { id: "u4", email: null, created_at: iso(10) },
+];
+
+describe("normalizeProductUrl", () => {
+  it("keeps origin + path, drops query and hash, trims trailing slashes", () => {
+    expect(normalizeProductUrl("https://phantomstory.com/?utm_source=lt#top")).toBe(
+      "https://phantomstory.com",
+    );
+    expect(normalizeProductUrl("https://letterbrace.com/pricing/?ref=lt")).toBe(
+      "https://letterbrace.com/pricing",
+    );
+  });
+
+  it("accepts subdomains of allow-listed hosts", () => {
+    expect(normalizeProductUrl("https://app.letterprove.com/start")).toBe(
+      "https://app.letterprove.com/start",
+    );
+  });
+
+  it("rejects hosts off the allow-list, including suffix look-alikes", () => {
+    expect(normalizeProductUrl("https://example.com")).toBeNull();
+    expect(normalizeProductUrl("https://evilphantomstory.com")).toBeNull();
+    expect(normalizeProductUrl("https://phantomstory.com.evil.io")).toBeNull();
+  });
+
+  it("rejects non-http(s) and unparseable input", () => {
+    expect(normalizeProductUrl("javascript:alert(1)")).toBeNull();
+    expect(normalizeProductUrl("not a url")).toBeNull();
+    expect(normalizeProductUrl(null)).toBeNull();
+    expect(normalizeProductUrl(undefined)).toBeNull();
+  });
+});
+
+describe("productOf", () => {
+  it("maps a URL to its allow-list host, subdomains included", () => {
+    expect(productOf("https://phantomstory.com/foo")).toBe("phantomstory.com");
+    expect(productOf("https://app.letterprove.com/start")).toBe("letterprove.com");
+  });
+
+  it("falls back to the hostname for an unexpected row", () => {
+    expect(productOf("https://example.com/x")).toBe("example.com");
+  });
+});
+
+describe("shapeConversionStats", () => {
+  it("counts distinct connected and computes a one-decimal rate", () => {
+    const clicks = [
+      click({ user_id: "u1" }),
+      click({ user_id: "u1", clicked_at: iso(1) }),
+      click({ user_id: "u2", url: "https://letterbrace.com/pricing" }),
+    ];
+    const stats = shapeConversionStats(clicks, 4, NOW);
+    expect(stats.connectedUsers).toBe(2);
+    expect(stats.totalUsers).toBe(4);
+    expect(stats.rate).toBe(50);
+    expect(stats.clicksTotal).toBe(3);
+  });
+
+  it("keeps sub-percent rates visible instead of rounding to zero", () => {
+    const stats = shapeConversionStats([click({})], 300, NOW);
+    expect(stats.rate).toBe(0.3);
+  });
+
+  it("windows clicks at 7 and 30 days", () => {
+    const clicks = [
+      click({ clicked_at: iso(0, 2) }),
+      click({ clicked_at: iso(10) }),
+      click({ clicked_at: iso(45) }),
+    ];
+    const stats = shapeConversionStats(clicks, 10, NOW);
+    expect(stats.clicks7d).toBe(1);
+    expect(stats.clicks30d).toBe(2);
+    expect(stats.clicksTotal).toBe(3);
+  });
+
+  it("picks the most clicked product as top destination", () => {
+    const clicks = [
+      click({}),
+      click({ clicked_at: iso(1) }),
+      click({ user_id: "u2", url: "https://letterbrace.com" }),
+    ];
+    expect(shapeConversionStats(clicks, 10, NOW).topProduct).toEqual({
+      product: "phantomstory.com",
+      clicks: 2,
+    });
+  });
+
+  it("returns null rate and top product when there is nothing to divide", () => {
+    const stats = shapeConversionStats([], 0, NOW);
+    expect(stats.rate).toBeNull();
+    expect(stats.topProduct).toBeNull();
+    expect(stats.connectedUsers).toBe(0);
+  });
+});
+
+describe("shapeConnectedUsers", () => {
+  it("groups clicks per user with destinations, first/last, most recent user first", () => {
+    const clicks = [
+      click({ user_id: "u1", clicked_at: iso(5) }),
+      click({ user_id: "u1", clicked_at: iso(1) }),
+      click({ user_id: "u1", url: "https://letterbrace.com/pricing", clicked_at: iso(3) }),
+      click({ user_id: "u2", clicked_at: iso(0, 1) }),
+    ];
+    const connected = shapeConnectedUsers(clicks, PROFILES);
+    expect(connected.map((c) => c.userId)).toEqual(["u2", "u1"]);
+
+    const u1 = connected[1];
+    expect(u1.email).toBe("jo@acme.io");
+    expect(u1.emailClass).toBe("work");
+    expect(u1.clicks).toBe(3);
+    expect(u1.firstClickAt).toBe(iso(5));
+    expect(u1.lastClickAt).toBe(iso(1));
+    expect(u1.destinations).toEqual([
+      { url: "https://phantomstory.com", product: "phantomstory.com", clicks: 2 },
+      { url: "https://letterbrace.com/pricing", product: "letterbrace.com", clicks: 1 },
+    ]);
+  });
+
+  it("keeps rows whose profile is missing or has no email", () => {
+    const clicks = [click({ user_id: "u4" }), click({ user_id: "gone" })];
+    const connected = shapeConnectedUsers(clicks, PROFILES);
+    expect(connected).toHaveLength(2);
+    for (const c of connected) {
+      expect(c.email).toBeNull();
+      expect(c.emailClass).toBe("personal");
+    }
+  });
+});

--- a/lib/conversions.ts
+++ b/lib/conversions.ts
@@ -1,0 +1,223 @@
+import { createServiceClient } from "@/lib/supabase/service";
+import { classifyEmail, type EmailClass, type GrowthProfileRow } from "./growth";
+
+/**
+ * Cross-product conversions: who leaves lettertrace for another Letter
+ * Company product, measured in clicks on the outbound links we place
+ * ourselves (today: the Phantoms item in the dashboard nav).
+ *
+ * The write path is components/outbound-link.tsx → POST /api/out → an
+ * outbound_clicks row; this module is the read path behind /admin/conversions.
+ * A user with at least one click, ever, is CONNECTED — the deliberately weak
+ * word, because clicking is the lowest rung of the conversion ladder and the
+ * higher rungs (signed up on the other product, pays for it) will need their
+ * own names when they become measurable. All-time IS the honest window: the
+ * table only exists from the day this shipped, and per-window click counts
+ * come alongside for trend.
+ *
+ * Everything below the loader is pure and unit-tested; the loader only
+ * fetches rows and hands them over — same contract as lib/growth.ts.
+ */
+
+// ---------------------------------------------------------------------------
+// Which URLs count
+// ---------------------------------------------------------------------------
+
+/** Letter Company product hosts. A click records only when its URL lands on
+ *  one of these (subdomains included) — this is the allow-list the /api/out
+ *  route enforces, so extending cross-promotion to a new product means adding
+ *  its host here and linking it with <OutboundLink>. */
+export const LETTER_PRODUCT_HOSTS = [
+  "phantomstory.com",
+  "letterbrace.com",
+  "letterstory.com",
+  "letterprove.com",
+  "letterspade.com",
+];
+
+/** origin + path with query/hash dropped and a trailing slash trimmed, or
+ *  null when the string isn't an http(s) URL on a Letter product host.
+ *  Doubles as the allow-list check: null means "do not record". */
+export function normalizeProductUrl(raw: string | null | undefined): string | null {
+  let url: URL;
+  try {
+    url = new URL(raw ?? "");
+  } catch {
+    return null;
+  }
+  if (url.protocol !== "https:" && url.protocol !== "http:") return null;
+  const host = url.hostname.toLowerCase();
+  const known = LETTER_PRODUCT_HOSTS.some((h) => host === h || host.endsWith(`.${h}`));
+  if (!known) return null;
+  const path = url.pathname.replace(/\/+$/, "");
+  return `${url.origin}${path}`;
+}
+
+/** The product a stored URL belongs to — the allow-list host, for grouping.
+ *  Falls back to the raw hostname so an unexpected row still displays. */
+export function productOf(url: string): string {
+  let host: string;
+  try {
+    host = new URL(url).hostname.toLowerCase();
+  } catch {
+    return url;
+  }
+  return LETTER_PRODUCT_HOSTS.find((h) => host === h || host.endsWith(`.${h}`)) ?? host;
+}
+
+// ---------------------------------------------------------------------------
+// Row shapes (what the loader fetches)
+// ---------------------------------------------------------------------------
+
+export interface OutboundClickRow {
+  user_id: string;
+  url: string;
+  clicked_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// The headline numbers
+// ---------------------------------------------------------------------------
+
+export interface ConversionStats {
+  /** Distinct users with at least one recorded click, ever. */
+  connectedUsers: number;
+  totalUsers: number;
+  /** connectedUsers / totalUsers as a percentage with one decimal, null until
+   *  there is anyone to divide by. One decimal because early on the honest
+   *  number is 0.x% — a rounded 0% reads as "feature is broken". */
+  rate: number | null;
+  clicks7d: number;
+  clicks30d: number;
+  clicksTotal: number;
+  /** Most-clicked product host, for the "where do they go" card. */
+  topProduct: { product: string; clicks: number } | null;
+}
+
+const DAY_MS = 86_400_000;
+
+export function shapeConversionStats(
+  clicks: OutboundClickRow[],
+  totalUsers: number,
+  now: number,
+): ConversionStats {
+  const users = new Set<string>();
+  const byProduct = new Map<string, number>();
+  let clicks7d = 0;
+  let clicks30d = 0;
+
+  for (const click of clicks) {
+    users.add(click.user_id);
+    const t = Date.parse(click.clicked_at);
+    if (Number.isFinite(t) && t <= now) {
+      if (t >= now - 7 * DAY_MS) clicks7d += 1;
+      if (t >= now - 30 * DAY_MS) clicks30d += 1;
+    }
+    const product = productOf(click.url);
+    byProduct.set(product, (byProduct.get(product) ?? 0) + 1);
+  }
+
+  const top = [...byProduct.entries()].sort((a, b) => b[1] - a[1])[0] ?? null;
+  return {
+    connectedUsers: users.size,
+    totalUsers,
+    rate: totalUsers > 0 ? Math.round((users.size / totalUsers) * 1000) / 10 : null,
+    clicks7d,
+    clicks30d,
+    clicksTotal: clicks.length,
+    topProduct: top ? { product: top[0], clicks: top[1] } : null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The connected list
+// ---------------------------------------------------------------------------
+
+export interface ConnectedUser {
+  userId: string;
+  /** Null when the profile is gone or never had an email — the row still
+   *  shows, because the click happened either way. */
+  email: string | null;
+  emailClass: EmailClass;
+  /** Distinct destinations this user clicked, most-clicked first. */
+  destinations: { url: string; product: string; clicks: number }[];
+  clicks: number;
+  firstClickAt: string;
+  lastClickAt: string;
+}
+
+/** One row per connected user, most recent click first. */
+export function shapeConnectedUsers(
+  clicks: OutboundClickRow[],
+  profiles: GrowthProfileRow[],
+): ConnectedUser[] {
+  const emailByUser = new Map(profiles.map((p) => [p.id, p.email]));
+
+  const byUser = new Map<string, { urls: Map<string, number>; first: string; last: string }>();
+  for (const click of clicks) {
+    const entry =
+      byUser.get(click.user_id) ??
+      { urls: new Map<string, number>(), first: click.clicked_at, last: click.clicked_at };
+    entry.urls.set(click.url, (entry.urls.get(click.url) ?? 0) + 1);
+    if (click.clicked_at < entry.first) entry.first = click.clicked_at;
+    if (click.clicked_at > entry.last) entry.last = click.clicked_at;
+    byUser.set(click.user_id, entry);
+  }
+
+  return [...byUser.entries()]
+    .map(([userId, entry]) => {
+      const email = emailByUser.get(userId) ?? null;
+      return {
+        userId,
+        email,
+        emailClass: classifyEmail(email),
+        destinations: [...entry.urls.entries()]
+          .map(([url, count]) => ({ url, product: productOf(url), clicks: count }))
+          .sort((a, b) => b.clicks - a.clicks || a.url.localeCompare(b.url)),
+        clicks: [...entry.urls.values()].reduce((a, b) => a + b, 0),
+        firstClickAt: entry.first,
+        lastClickAt: entry.last,
+      };
+    })
+    .sort((a, b) => b.lastClickAt.localeCompare(a.lastClickAt));
+}
+
+// ---------------------------------------------------------------------------
+// Loader
+// ---------------------------------------------------------------------------
+
+export interface ConversionsReport {
+  stats: ConversionStats;
+  connected: ConnectedUser[];
+  /** Set when a query failed — the page says "incomplete", never fake zero. */
+  degraded: string | null;
+}
+
+/** Same cap philosophy as growth.ts: comfortably above today's volume, and
+ *  the day it isn't is the day this earns aggregation SQL. */
+const ROWS_CAP = 10_000;
+
+export async function conversionsReport(now = Date.now()): Promise<ConversionsReport> {
+  const svc = createServiceClient();
+
+  const [clicksQ, profilesQ] = await Promise.all([
+    svc
+      .from("outbound_clicks")
+      .select("user_id, url, clicked_at")
+      .order("clicked_at", { ascending: false })
+      .limit(ROWS_CAP),
+    svc.from("profiles").select("id, email, created_at").limit(ROWS_CAP),
+  ]);
+
+  const failed = [clicksQ.error && "outbound_clicks", profilesQ.error && "profiles"].filter(
+    Boolean,
+  );
+  const clicks = (clicksQ.data ?? []) as OutboundClickRow[];
+  const profiles = (profilesQ.data ?? []) as GrowthProfileRow[];
+
+  return {
+    stats: shapeConversionStats(clicks, profiles.length, now),
+    connected: shapeConnectedUsers(clicks, profiles),
+    degraded: failed.length > 0 ? failed.join(", ") : null,
+  };
+}

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1243,3 +1243,29 @@ create policy "web_mentions_owner" on public.web_mentions
 drop policy if exists "search_keys_owner" on public.search_keys;
 create policy "search_keys_owner" on public.search_keys
   for all using (user_id = auth.uid()) with check (user_id = auth.uid());
+
+-- ---------- outbound_clicks (cross-product conversions) -------------------
+--
+-- One row per click on a link that leaves lettertrace for another Letter
+-- Company product (phantomstory, letterbrace, ...). Written server-side by
+-- POST /api/out after cookie auth, read only by the staff-gated /admin
+-- Conversions page — so, like ops_events, RLS is ON WITH NO POLICIES:
+-- default-deny for every cookie client, service role on both ends.
+--
+-- The URL is stored normalized (origin + path, no query/hash) and only for
+-- hosts on the Letter product allow-list (lib/conversions.ts), so the table
+-- can't be filled with junk by an authenticated caller poking the endpoint.
+-- Safe to re-run.
+create table if not exists public.outbound_clicks (
+  id         uuid primary key default gen_random_uuid(),
+  user_id    uuid not null references auth.users (id) on delete cascade,
+  url        text not null,
+  clicked_at timestamptz not null default now()
+);
+
+create index if not exists idx_outbound_clicks_user on public.outbound_clicks (user_id, clicked_at desc);
+create index if not exists idx_outbound_clicks_time on public.outbound_clicks (clicked_at desc);
+
+alter table public.outbound_clicks enable row level security;
+
+revoke insert, update, delete on table public.outbound_clicks from anon, authenticated;


### PR DESCRIPTION
## What

A third `/admin` tab (Operations | Growth | **Conversions**) answering: what percentage of lettertrace users go to another Letter Company product, and who are they.

- **Top row**: connected rate (distinct clickers ÷ total signups, one decimal so early numbers don't round to a misleading 0%), connected users, clicks over 7d/30d/ever, and the top destination as a real outbound link (truncates gracefully for long hosts).
- **Below**: one row per connected user — email in the clear (this is a cross-sell list), work/personal/burner badge, the exact URLs they clicked (linked, path included), first and latest click.

**Vocabulary**: "connected" = clicked one of our outbound links — deliberately the weakest rung of the conversion ladder, so "signed up on the other product" and "pays for it" can get their own words when they become measurable.

## The pipeline (nothing recorded these clicks before)

- `outbound_clicks` table — RLS on with no policies (ops_events-style): service role writes, staff-gated page reads, cookie clients can neither read nor forge. **Already applied to the live database and verified** (table, RLS, both indexes).
- `POST /api/out` — cookie-authed; normalizes the URL (origin + path, no query/hash) and allow-lists it against `LETTER_PRODUCT_HOSTS`, so an authenticated caller poking the endpoint can't fill the table with junk.
- `<OutboundLink>` — an `<a>` that `sendBeacon`s the click so navigation is never delayed and the POST survives page teardown. The dashboard's Phantoms → phantomstory.com link is the first user; future cross-product links just need the wrapper.

`lib/conversions.ts` follows the `growth.ts` contract: pure, unit-tested shape functions (13 new tests) under a loader that only fetches, with the same degraded-not-zero reporting.

## Notes

- Data starts at zero on deploy day; there is no retroactive click data.
- No new env vars — reuses the existing service-role key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HV7Dmoryjgnt66GTAm7Wab

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790192945&installation_model_id=431526&pr_number=150&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F150&signature=4210175fc8386dcb1c70af2dff6507265126a290dfea3aab791baef9b1d90e7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->