### PR TITLE
Conversions: period dropdown, connected-rate chart, period-scoped page

### DIFF
--- a/app/admin/conversions/page.tsx
+++ b/app/admin/conversions/page.tsx
@@ -3,10 +3,12 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import { ArrowUpRight } from "lucide-react";
 import { requireAdmin } from "@/lib/admin";
-import { conversionsReport } from "@/lib/conversions";
+import { conversionsReport, isPeriod, type Period, type RatePoint } from "@/lib/conversions";
 import type { EmailClass } from "@/lib/growth";
 import { Badge, Card, SectionHeading, StatCard } from "@/components/ui";
 import { timeAgo } from "@/lib/utils";
+import { PeriodSelect } from "./period-select";
+import { PERIOD_OPTIONS } from "./periods";
 
 export const dynamic = "force-dynamic";
 export const metadata = { robots: { index: false, follow: false } };
@@ -41,17 +43,94 @@ function ColumnHeader({ children, className }: { children: React.ReactNode; clas
   );
 }
 
-export default async function ConversionsPage() {
+/**
+ * The connected rate as it stood at each day's end — cumulative within the
+ * period, over the signups that existed then, so the right edge always equals
+ * the headline card. Same construction as Growth's RunSparkline: inline SVG,
+ * numbers in <title> tooltips, colors through style because CSS var() only
+ * resolves in styles. One series, so the title is the legend.
+ */
+function RateChart({ series }: { series: RatePoint[] }) {
+  const points = series.filter((p) => p.rate !== null) as (RatePoint & { rate: number })[];
+  if (points.length === 0) return null;
+
+  const W = 600;
+  const H = 110;
+  const PAD_TOP = 8;
+  const max = Math.max(0.1, ...points.map((p) => p.rate));
+  const x = (i: number) => (points.length === 1 ? W / 2 : (i / (points.length - 1)) * W);
+  const y = (rate: number) => H - 4 - (rate / max) * (H - 4 - PAD_TOP);
+  // One point can't make a line, so it becomes a flat one edge to edge — and
+  // the fill reuses these same coordinates so it always sits under the line.
+  const linePoints =
+    points.length === 1
+      ? [`0,${y(points[0].rate).toFixed(1)}`, `${W},${y(points[0].rate).toFixed(1)}`]
+      : points.map((p, i) => `${x(i).toFixed(1)},${y(p.rate).toFixed(1)}`);
+  const line = linePoints.join(" ");
+  const bandW = W / points.length;
+
+  return (
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      preserveAspectRatio="none"
+      className="h-36 w-full"
+      role="img"
+      aria-label="Connected rate over time"
+    >
+      {/* Baseline at 0% — the one recessive gridline this needs. */}
+      <line x1={0} y1={H - 4} x2={W} y2={H - 4} style={{ stroke: "rgb(var(--c-ink) / 0.12)", strokeWidth: 1 }} vectorEffect="non-scaling-stroke" />
+      <polygon
+        points={`0,${H - 4} ${line} ${W},${H - 4}`}
+        style={{ fill: "rgb(var(--c-mint-bright) / 0.12)" }}
+      />
+      <polyline
+        points={line}
+        style={{ fill: "none", stroke: "rgb(var(--c-mint-bright))", strokeWidth: 2 }}
+        strokeLinejoin="round"
+        strokeLinecap="round"
+        vectorEffect="non-scaling-stroke"
+      />
+      {/* Invisible per-day bands: hit targets wider than the marks, carrying
+          the native tooltip with the numbers for that day. */}
+      {points.map((p, i) => (
+        <rect
+          key={p.day}
+          x={x(i) - bandW / 2}
+          y={0}
+          width={bandW}
+          height={H}
+          fill="transparent"
+        >
+          <title>{`${p.day} · ${p.rate}% connected (${p.connected} of ${p.signups} signups) · ${p.clicks} click${p.clicks === 1 ? "" : "s"} this day`}</title>
+        </rect>
+      ))}
+    </svg>
+  );
+}
+
+type SP = Record<string, string | string[] | undefined>;
+
+function periodFrom(searchParams: SP): Period {
+  const raw = Array.isArray(searchParams.p) ? searchParams.p[0] : searchParams.p;
+  return isPeriod(raw) ? raw : "30d";
+}
+
+export default async function ConversionsPage({ searchParams }: { searchParams: SP }) {
   const admin = await requireAdmin();
   if (!admin) notFound();
 
-  const { stats, connected, degraded } = await conversionsReport();
+  const period = periodFrom(searchParams);
+  const periodLabel = PERIOD_OPTIONS.find((o) => o.value === period)!.label.toLowerCase();
+  const { stats, series, connected, degraded } = await conversionsReport(period);
+  const latest = series.filter((p) => p.rate !== null).at(-1);
+  const peak = series.reduce((a, b) => ((b.rate ?? -1) > (a?.rate ?? -1) ? b : a), latest);
 
   return (
     <div className="space-y-10">
       <SectionHeading
         title="Conversions"
         description="Who goes from lettertrace to another Letter Company product. Today this measures connected users — clicked one of our outbound links; signups and paying customers become their own rungs once we can measure them. Emails are in the clear: this is a cross-sell list."
+        action={<PeriodSelect value={period} />}
       />
 
       {degraded && (
@@ -68,19 +147,27 @@ export default async function ConversionsPage() {
         <StatCard
           label="Connected rate"
           value={stats.rate === null ? "—" : `${stats.rate}%`}
-          hint={`${stats.connectedUsers.toLocaleString()} of ${stats.totalUsers.toLocaleString()} signups clicked a Letter product`}
+          hint={`${stats.connectedUsers.toLocaleString()} of ${stats.totalUsers.toLocaleString()} signups clicked a Letter product · ${periodLabel}`}
           accent="mint"
         />
         <StatCard
           label="Connected users"
           value={stats.connectedUsers.toLocaleString()}
-          hint="distinct users, all time"
+          hint={
+            period === "all"
+              ? "distinct users, all time"
+              : `distinct users, ${periodLabel} · ${stats.connectedAllTime.toLocaleString()} all time`
+          }
           accent="teal"
         />
         <StatCard
           label="Clicks"
-          value={stats.clicks30d.toLocaleString()}
-          hint={`rolling 30d · ${stats.clicks7d.toLocaleString()} in 7d · ${stats.clicksTotal.toLocaleString()} ever`}
+          value={stats.clicks.toLocaleString()}
+          hint={
+            period === "all"
+              ? "all time"
+              : `${periodLabel} · ${stats.clicksAllTime.toLocaleString()} all time`
+          }
           accent="butter"
         />
         <StatCard
@@ -111,28 +198,54 @@ export default async function ConversionsPage() {
           }
           hint={
             stats.topProduct
-              ? `${stats.topProduct.clicks.toLocaleString()} click${stats.topProduct.clicks === 1 ? "" : "s"}`
-              : "no clicks recorded yet"
+              ? `${stats.topProduct.clicks.toLocaleString()} click${stats.topProduct.clicks === 1 ? "" : "s"} · ${periodLabel}`
+              : `no clicks ${period === "all" ? "recorded yet" : "in this period"}`
           }
           accent="sand"
         />
       </div>
 
-      {/* ---- Row 2: who's connected ------------------------------------------ */}
+      {/* ---- Row 2: the rate over time ---------------------------------------- */}
+      <Card>
+        <div className="flex flex-col px-5 pb-4 pt-5">
+          <div className="flex items-baseline justify-between gap-3">
+            <h3 className="text-sm font-semibold text-ink">Connected rate over time</h3>
+            <span className="text-xs text-ink-faint">{periodLabel}</span>
+          </div>
+          {series.length === 0 || !latest ? (
+            <p className="py-8 text-sm text-ink-faint">
+              No clicks {period === "all" ? "recorded yet" : "in this period"}, so there is no
+              rate to draw.
+            </p>
+          ) : (
+            <>
+              <div className="mt-3">
+                <RateChart series={series} />
+              </div>
+              <p className="mt-3 text-xs tabular-nums text-ink-faint">
+                now {latest.rate}%{peak && peak.day !== latest.day ? ` · peak ${peak.rate}% on ${peak.day}` : ""} · cumulative
+                within the period, over signups as of each day · hover for daily numbers
+              </p>
+            </>
+          )}
+        </div>
+      </Card>
+
+      {/* ---- Row 3: who's connected ------------------------------------------ */}
       <section className="space-y-3">
         <div>
           <h3 className="text-lg font-semibold text-ink">Connected users</h3>
           <p className="mt-1 max-w-3xl text-sm text-ink-faint">
-            Everyone who clicked out to a Letter Company product, most recent first, with where
-            they went.
+            Everyone who clicked out to a Letter Company product in this period ({periodLabel}),
+            most recent first, with where they went.
           </p>
         </div>
         <Card>
           {connected.length === 0 ? (
             <p className="px-5 py-8 text-sm text-ink-faint">
-              Nobody has clicked out yet. Tracking only exists from the day it shipped, so an
-              empty list right after a deploy means &ldquo;too early&rdquo;, not
-              &ldquo;never&rdquo;.
+              Nobody clicked out {period === "all" ? "yet" : "in this period"}. Tracking only
+              exists from the day it shipped, so an empty list right after a deploy means
+              &ldquo;too early&rdquo;, not &ldquo;never&rdquo;.
             </p>
           ) : (
             <>

--- a/app/admin/conversions/period-select.tsx
+++ b/app/admin/conversions/period-select.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import type { Period } from "@/lib/conversions";
+import { PERIOD_OPTIONS } from "./periods";
+
+/**
+ * The page-level time filter. It writes the period into the URL (?p=) rather
+ * than holding state, so the server component re-renders every number, the
+ * chart and the table from the same window — and a reloaded or shared URL
+ * keeps its period. Labels live in ./periods.ts, importable from both sides
+ * of the client boundary.
+ */
+export function PeriodSelect({ value }: { value: Period }) {
+  const router = useRouter();
+  return (
+    <select
+      value={value}
+      aria-label="Time period"
+      onChange={(event) => router.push(`/admin/conversions?p=${event.target.value}`)}
+      className="rounded border border-ink/10 bg-surface px-2.5 py-1.5 text-xs text-ink transition hover:border-ink/25 focus:outline-none focus:ring-1 focus:ring-ink/30"
+    >
+      {PERIOD_OPTIONS.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/app/admin/conversions/periods.ts
+++ b/app/admin/conversions/periods.ts
@@ -1,0 +1,13 @@
+import type { Period } from "@/lib/conversions";
+
+/** The dropdown's options, in a module with no "use client" directive: the
+ *  server page needs to .find() a label and a client module's exports are
+ *  opaque references on the server, while lib/conversions.ts pulls in the
+ *  service-role client and must stay out of the client bundle. This file is
+ *  importable from both sides. */
+export const PERIOD_OPTIONS: { value: Period; label: string }[] = [
+  { value: "7d", label: "Last 7 days" },
+  { value: "30d", label: "Last 30 days" },
+  { value: "ytd", label: "Year to date" },
+  { value: "all", label: "All time" },
+];

--- a/lib/conversions.test.ts
+++ b/lib/conversions.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
+  clicksSince,
+  isPeriod,
   normalizeProductUrl,
+  periodStart,
   productOf,
   shapeConversionStats,
   shapeConnectedUsers,
+  shapeRateSeries,
   type OutboundClickRow,
 } from "./conversions";
 import type { GrowthProfileRow } from "./growth";
@@ -72,6 +76,29 @@ describe("productOf", () => {
   });
 });
 
+describe("periods", () => {
+  it("validates period strings", () => {
+    expect(isPeriod("7d")).toBe(true);
+    expect(isPeriod("all")).toBe(true);
+    expect(isPeriod("90d")).toBe(false);
+    expect(isPeriod(undefined)).toBe(false);
+  });
+
+  it("opens 7d/30d as rolling windows, ytd at Jan 1 UTC, all as null", () => {
+    expect(periodStart("7d", NOW)).toBe(NOW - 7 * DAY_MS);
+    expect(periodStart("30d", NOW)).toBe(NOW - 30 * DAY_MS);
+    expect(periodStart("ytd", NOW)).toBe(Date.parse("2026-01-01T00:00:00.000Z"));
+    expect(periodStart("all", NOW)).toBeNull();
+  });
+
+  it("clicksSince keeps everything for null and filters otherwise", () => {
+    const clicks = [click({ clicked_at: iso(1) }), click({ clicked_at: iso(20) })];
+    expect(clicksSince(clicks, null)).toHaveLength(2);
+    expect(clicksSince(clicks, NOW - 7 * DAY_MS)).toHaveLength(1);
+    expect(clicksSince([click({ clicked_at: "not a date" })], NOW - 7 * DAY_MS)).toHaveLength(0);
+  });
+});
+
 describe("shapeConversionStats", () => {
   it("counts distinct connected and computes a one-decimal rate", () => {
     const clicks = [
@@ -79,47 +106,101 @@ describe("shapeConversionStats", () => {
       click({ user_id: "u1", clicked_at: iso(1) }),
       click({ user_id: "u2", url: "https://letterbrace.com/pricing" }),
     ];
-    const stats = shapeConversionStats(clicks, 4, NOW);
+    const stats = shapeConversionStats(clicks, 4, null);
     expect(stats.connectedUsers).toBe(2);
     expect(stats.totalUsers).toBe(4);
     expect(stats.rate).toBe(50);
-    expect(stats.clicksTotal).toBe(3);
+    expect(stats.clicks).toBe(3);
   });
 
   it("keeps sub-percent rates visible instead of rounding to zero", () => {
-    const stats = shapeConversionStats([click({})], 300, NOW);
+    const stats = shapeConversionStats([click({})], 300, null);
     expect(stats.rate).toBe(0.3);
   });
 
-  it("windows clicks at 7 and 30 days", () => {
+  it("scopes to the period while keeping all-time companions", () => {
     const clicks = [
-      click({ clicked_at: iso(0, 2) }),
-      click({ clicked_at: iso(10) }),
-      click({ clicked_at: iso(45) }),
+      click({ user_id: "u1", clicked_at: iso(0, 2) }),
+      click({ user_id: "u2", clicked_at: iso(10) }),
+      click({ user_id: "u3", clicked_at: iso(45) }),
     ];
-    const stats = shapeConversionStats(clicks, 10, NOW);
-    expect(stats.clicks7d).toBe(1);
-    expect(stats.clicks30d).toBe(2);
-    expect(stats.clicksTotal).toBe(3);
+    const stats = shapeConversionStats(clicks, 10, NOW - 7 * DAY_MS);
+    expect(stats.connectedUsers).toBe(1);
+    expect(stats.clicks).toBe(1);
+    expect(stats.rate).toBe(10);
+    expect(stats.connectedAllTime).toBe(3);
+    expect(stats.clicksAllTime).toBe(3);
   });
 
-  it("picks the most clicked product as top destination", () => {
+  it("picks the most clicked product in the period as top destination", () => {
     const clicks = [
       click({}),
       click({ clicked_at: iso(1) }),
-      click({ user_id: "u2", url: "https://letterbrace.com" }),
+      click({ user_id: "u2", url: "https://letterbrace.com", clicked_at: iso(45) }),
     ];
-    expect(shapeConversionStats(clicks, 10, NOW).topProduct).toEqual({
+    expect(shapeConversionStats(clicks, 10, NOW - 30 * DAY_MS).topProduct).toEqual({
       product: "phantomstory.com",
       clicks: 2,
     });
   });
 
   it("returns null rate and top product when there is nothing to divide", () => {
-    const stats = shapeConversionStats([], 0, NOW);
+    const stats = shapeConversionStats([], 0, null);
     expect(stats.rate).toBeNull();
     expect(stats.topProduct).toBeNull();
     expect(stats.connectedUsers).toBe(0);
+  });
+});
+
+describe("shapeRateSeries", () => {
+  it("builds one point per day with a cumulative rate over signups as of that day", () => {
+    // u2 signed up 20d ago, u3 3d ago (PROFILES); period covers last 7 days.
+    const clicks = [
+      click({ user_id: "u2", clicked_at: iso(5) }),
+      click({ user_id: "u2", clicked_at: iso(2) }),
+      click({ user_id: "u3", clicked_at: iso(2) }),
+    ];
+    const series = shapeRateSeries(clicks, PROFILES, NOW - 7 * DAY_MS, NOW);
+    expect(series).toHaveLength(8); // 7 full days back plus today
+
+    const day5 = series.find((p) => p.day === iso(5).slice(0, 10))!;
+    // By 5d ago: u1/u2/u4 signed up (u3 hadn't yet), u2 connected.
+    expect(day5.connected).toBe(1);
+    expect(day5.signups).toBe(3);
+    expect(day5.rate).toBe(33.3);
+    expect(day5.clicks).toBe(1);
+
+    const last = series.at(-1)!;
+    expect(last.connected).toBe(2);
+    expect(last.signups).toBe(4);
+    expect(last.rate).toBe(50);
+  });
+
+  it("matches the headline stat at its right edge", () => {
+    const clicks = [
+      click({ user_id: "u1", clicked_at: iso(6) }),
+      click({ user_id: "u2", clicked_at: iso(1) }),
+    ];
+    const since = NOW - 7 * DAY_MS;
+    const series = shapeRateSeries(clicks, PROFILES, since, NOW);
+    const stats = shapeConversionStats(clicks, PROFILES.length, since);
+    expect(series.at(-1)!.rate).toBe(stats.rate);
+  });
+
+  it("starts at the first click for all-time, and is empty with no clicks", () => {
+    const series = shapeRateSeries([click({ clicked_at: iso(3) })], PROFILES, null, NOW);
+    expect(series[0].day).toBe(iso(3).slice(0, 10));
+    expect(shapeRateSeries([], PROFILES, null, NOW)).toEqual([]);
+  });
+
+  it("ignores clicks from the future and unparseable timestamps", () => {
+    const clicks = [
+      click({ clicked_at: iso(-2) }),
+      click({ clicked_at: "not a date" }),
+      click({ user_id: "u2", clicked_at: iso(1) }),
+    ];
+    const series = shapeRateSeries(clicks, PROFILES, NOW - 7 * DAY_MS, NOW);
+    expect(series.at(-1)!.connected).toBe(1);
   });
 });
 

--- a/lib/conversions.ts
+++ b/lib/conversions.ts
@@ -76,43 +76,82 @@ export interface OutboundClickRow {
 }
 
 // ---------------------------------------------------------------------------
+// Periods
+// ---------------------------------------------------------------------------
+
+/** The page's one time filter: every number, the chart, and the table read the
+ *  same window, so the period is a page-level URL param rather than per-card
+ *  state. (The option labels live with the dropdown in period-select.tsx,
+ *  which is a client component and must not import this server module.) */
+export type Period = "7d" | "30d" | "ytd" | "all";
+
+export function isPeriod(value: unknown): value is Period {
+  return value === "7d" || value === "30d" || value === "ytd" || value === "all";
+}
+
+/** When the period opens, as a ms timestamp — null means all-time. YTD is
+ *  Jan 1 UTC, matching the UTC day-bucketing everywhere else on /admin. */
+export function periodStart(period: Period, now: number): number | null {
+  switch (period) {
+    case "7d":
+      return now - 7 * DAY_MS;
+    case "30d":
+      return now - 30 * DAY_MS;
+    case "ytd":
+      return Date.UTC(new Date(now).getUTCFullYear(), 0, 1);
+    case "all":
+      return null;
+  }
+}
+
+/** Clicks at or after `since` (null = everything). Unparseable timestamps drop
+ *  here rather than in every consumer. */
+export function clicksSince(clicks: OutboundClickRow[], since: number | null): OutboundClickRow[] {
+  if (since === null) return clicks;
+  return clicks.filter((c) => {
+    const t = Date.parse(c.clicked_at);
+    return Number.isFinite(t) && t >= since;
+  });
+}
+
+// ---------------------------------------------------------------------------
 // The headline numbers
 // ---------------------------------------------------------------------------
 
 export interface ConversionStats {
-  /** Distinct users with at least one recorded click, ever. */
+  /** Distinct users with at least one click inside the period. */
   connectedUsers: number;
   totalUsers: number;
   /** connectedUsers / totalUsers as a percentage with one decimal, null until
    *  there is anyone to divide by. One decimal because early on the honest
    *  number is 0.x% — a rounded 0% reads as "feature is broken". */
   rate: number | null;
-  clicks7d: number;
-  clicks30d: number;
-  clicksTotal: number;
-  /** Most-clicked product host, for the "where do they go" card. */
+  /** Clicks inside the period. */
+  clicks: number;
+  /** All-time companions, so a narrow period keeps its context in the hints. */
+  connectedAllTime: number;
+  clicksAllTime: number;
+  /** Most-clicked product host inside the period. */
   topProduct: { product: string; clicks: number } | null;
 }
 
 const DAY_MS = 86_400_000;
 
+/** Takes ALL clicks and scopes internally — the all-time companions come from
+ *  the same pass, so callers never juggle two filtered arrays. */
 export function shapeConversionStats(
   clicks: OutboundClickRow[],
   totalUsers: number,
-  now: number,
+  since: number | null,
 ): ConversionStats {
+  const inPeriod = clicksSince(clicks, since);
   const users = new Set<string>();
+  const allUsers = new Set<string>();
   const byProduct = new Map<string, number>();
-  let clicks7d = 0;
-  let clicks30d = 0;
 
-  for (const click of clicks) {
+  for (const click of clicks) allUsers.add(click.user_id);
+  for (const click of inPeriod) {
     users.add(click.user_id);
-    const t = Date.parse(click.clicked_at);
-    if (Number.isFinite(t) && t <= now) {
-      if (t >= now - 7 * DAY_MS) clicks7d += 1;
-      if (t >= now - 30 * DAY_MS) clicks30d += 1;
-    }
     const product = productOf(click.url);
     byProduct.set(product, (byProduct.get(product) ?? 0) + 1);
   }
@@ -122,11 +161,83 @@ export function shapeConversionStats(
     connectedUsers: users.size,
     totalUsers,
     rate: totalUsers > 0 ? Math.round((users.size / totalUsers) * 1000) / 10 : null,
-    clicks7d,
-    clicks30d,
-    clicksTotal: clicks.length,
+    clicks: inPeriod.length,
+    connectedAllTime: allUsers.size,
+    clicksAllTime: clicks.length,
     topProduct: top ? { product: top[0], clicks: top[1] } : null,
   };
+}
+
+// ---------------------------------------------------------------------------
+// The rate over time (the chart under the stat row)
+// ---------------------------------------------------------------------------
+
+export interface RatePoint {
+  /** UTC date, YYYY-MM-DD. */
+  day: string;
+  /** Cumulative-within-period connected rate as of this day's end: distinct
+   *  users who clicked between the period start and this day, over signups
+   *  that existed by this day. Null while there are no signups to divide by. */
+  rate: number | null;
+  /** Cumulative connected users behind that rate. */
+  connected: number;
+  /** Clicks on this day alone. */
+  clicks: number;
+  signups: number;
+}
+
+/** One point per UTC day from the period start (or the first click, for
+ *  all-time) through today. The denominator is signups AS OF each day, not
+ *  today's — so the curve is the rate as it actually stood, and its last
+ *  point equals the headline card. */
+export function shapeRateSeries(
+  clicks: OutboundClickRow[],
+  profiles: GrowthProfileRow[],
+  since: number | null,
+  now: number,
+): RatePoint[] {
+  const inPeriod = clicksSince(clicks, since)
+    .map((c) => ({ ...c, t: Date.parse(c.clicked_at) }))
+    .filter((c) => Number.isFinite(c.t) && c.t <= now)
+    .sort((a, b) => a.t - b.t);
+
+  const firstDay = since ?? inPeriod[0]?.t;
+  if (firstDay === undefined) return [];
+
+  const signupTimes = profiles
+    .map((p) => Date.parse(p.created_at))
+    .filter(Number.isFinite)
+    .sort((a, b) => a - b);
+
+  const startDay = new Date(firstDay).toISOString().slice(0, 10);
+  const series: RatePoint[] = [];
+  const connected = new Set<string>();
+  let clickIdx = 0;
+  let signupIdx = 0;
+
+  for (
+    let dayStart = Date.parse(`${startDay}T00:00:00.000Z`);
+    dayStart <= now;
+    dayStart += DAY_MS
+  ) {
+    const dayEnd = dayStart + DAY_MS;
+    let dayClicks = 0;
+    while (clickIdx < inPeriod.length && inPeriod[clickIdx].t < dayEnd) {
+      connected.add(inPeriod[clickIdx].user_id);
+      dayClicks += 1;
+      clickIdx += 1;
+    }
+    while (signupIdx < signupTimes.length && signupTimes[signupIdx] < dayEnd) signupIdx += 1;
+
+    series.push({
+      day: new Date(dayStart).toISOString().slice(0, 10),
+      rate: signupIdx > 0 ? Math.round((connected.size / signupIdx) * 1000) / 10 : null,
+      connected: connected.size,
+      clicks: dayClicks,
+      signups: signupIdx,
+    });
+  }
+  return series;
 }
 
 // ---------------------------------------------------------------------------
@@ -188,6 +299,7 @@ export function shapeConnectedUsers(
 
 export interface ConversionsReport {
   stats: ConversionStats;
+  series: RatePoint[];
   connected: ConnectedUser[];
   /** Set when a query failed — the page says "incomplete", never fake zero. */
   degraded: string | null;
@@ -197,7 +309,10 @@ export interface ConversionsReport {
  *  the day it isn't is the day this earns aggregation SQL. */
 const ROWS_CAP = 10_000;
 
-export async function conversionsReport(now = Date.now()): Promise<ConversionsReport> {
+export async function conversionsReport(
+  period: Period = "30d",
+  now = Date.now(),
+): Promise<ConversionsReport> {
   const svc = createServiceClient();
 
   const [clicksQ, profilesQ] = await Promise.all([
@@ -214,10 +329,14 @@ export async function conversionsReport(now = Date.now()): Promise<ConversionsRe
   );
   const clicks = (clicksQ.data ?? []) as OutboundClickRow[];
   const profiles = (profilesQ.data ?? []) as GrowthProfileRow[];
+  const since = periodStart(period, now);
 
   return {
-    stats: shapeConversionStats(clicks, profiles.length, now),
-    connected: shapeConnectedUsers(clicks, profiles),
+    stats: shapeConversionStats(clicks, profiles.length, since),
+    series: shapeRateSeries(clicks, profiles, since, now),
+    // The table reads through the same window: destinations, counts and
+    // first/latest are period-scoped, so it always agrees with the cards.
+    connected: shapeConnectedUsers(clicksSince(clicks, since), profiles),
     degraded: failed.length > 0 ? failed.join(", ") : null,
   };
 }


### PR DESCRIPTION
## What

Follow-up to #150. One time filter for the whole Conversions page, plus the trend chart under the stat row.

- **Period dropdown** (heading, top-right): Last 7 days / Last 30 days / Year to date / All time, default 30d. The period lives in the URL (`?p=`), so the stat cards, the chart, and the connected-users table always reflect the same window, and a shared or reloaded URL keeps its period. Narrow periods keep all-time context in the card hints.
- **"Connected rate over time"**: the rate as it stood at each day's end — cumulative within the period, over the signups that existed *that* day, so the curve is historically honest and its right edge always equals the headline card (there's a test asserting that). Same construction as Growth's sparkline: inline SVG, native tooltips with per-day rate/connected/signups/clicks, house mint, single series.
- `shapeConversionStats` scopes to a period internally and returns all-time companions; the table's destination counts and first/latest clicks are period-scoped too.

## Bugs caught by rendering before shipping

- Dropdown options exported from the `"use client"` module were opaque client references on the server (`.find()` threw) — they moved to a shared `periods.ts`.
- A single-day series drew a tent-shaped fill under a flat line — the fill now derives from the same coordinates as the line.

Verified with headless signed-in screenshots of both the 30d and all-time views against real data. 7 new tests (20 in the module).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HV7Dmoryjgnt66GTAm7Wab

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790195729&installation_model_id=431526&pr_number=151&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F151&signature=58a2210da31596d7bcd62960bb108415efb8d2fb6f587fbc43114c9649e58795"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->