### PR TITLE
Sidebar: Runs merges into Overview as a Reports sub-menu

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { Logo } from "@/components/logo";
-import { DashboardNav } from "@/components/dashboard/nav";
+import { DashboardNav, type NavReport } from "@/components/dashboard/nav";
 import { OrgSwitcher } from "@/components/dashboard/org-switcher";
 import { SignOutButton } from "@/components/dashboard/signout";
 import { WhyFree } from "@/components/dashboard/why-free";
@@ -19,6 +19,7 @@ import { getUnseenRun } from "@/lib/results-seen";
 import { trialEnabled, trialRunLimit, getTrialRunsUsed } from "@/lib/trial";
 import { modelLabel } from "@/lib/models";
 import { timeAgo } from "@/lib/utils";
+import type { Run } from "@/lib/types";
 
 export const dynamic = "force-dynamic";
 
@@ -97,6 +98,31 @@ export default async function DashboardLayout({
   // happened to be on when the run landed.
   const unseenRun = project ? await getUnseenRun(supabase, project) : null;
 
+  // Recent reports for the sidebar's Overview sub-menu. Completed only — those
+  // are the ones with a results page behind them; the runs page still shows
+  // running/failed rows. Formatted here so the nav stays a pure client render.
+  let navReports: NavReport[] = [];
+  let reportCount = 0;
+  if (project) {
+    const { data: reportRows, count } = await supabase
+      .from("runs")
+      .select("id, provider, model, created_at", { count: "exact" })
+      .eq("project_id", project.id)
+      .eq("status", "completed")
+      .order("created_at", { ascending: false })
+      .limit(6);
+    reportCount = count ?? 0;
+    navReports = (
+      (reportRows ?? []) as Pick<Run, "id" | "provider" | "model" | "created_at">[]
+    ).map((r) => ({
+      id: r.id,
+      // Relative, not calendar dates — "the one from last week" is how the
+      // list gets scanned; the model tells same-day reports apart.
+      when: timeAgo(r.created_at),
+      model: modelLabel(r.provider, r.model),
+    }));
+  }
+
   return (
     <div className="min-h-screen bg-paper md:flex">
       {/* Usage attestation. Mounted here rather than in the root layout because
@@ -131,7 +157,7 @@ export default async function DashboardLayout({
             </div>
           )}
 
-          <DashboardNav />
+          <DashboardNav reports={navReports} totalReports={reportCount} />
 
           <div className="mt-auto hidden flex-col gap-3 border-t border-ink/10 pt-4 md:flex">
             <WhyFree />

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -108,7 +108,7 @@ export default async function DashboardPage() {
       action={
         runs.length > 0 ? (
           <Button href="/dashboard/runs" variant="secondary" size="sm">
-            View all runs
+            View all reports
           </Button>
         ) : undefined
       }
@@ -143,7 +143,7 @@ export default async function DashboardPage() {
       },
       {
         done: false,
-        title: "Run your first monitor",
+        title: "Run your first report",
         description: "Query the models with your key and see who gets mentioned.",
         href: "/dashboard/runs",
         icon: Play,
@@ -744,14 +744,14 @@ export default async function DashboardPage() {
       {/* Latest run caption */}
       <div className="flex flex-wrap items-center justify-between gap-3 rounded border border-ink/10 bg-paper-shade/50 px-5 py-4">
         <p className="text-sm text-ink-faint">
-          Latest run:{" "}
+          Latest report:{" "}
           <span className="font-medium text-ink">
             {modelLabel(latestRun.provider, latestRun.model)}
           </span>{" "}
           · {totalResponses} answers · {timeAgo(latestRun.created_at)}
         </p>
         <Button href="/dashboard/runs" variant="secondary" size="sm">
-          View all runs
+          View all reports
         </Button>
       </div>
     </div>

--- a/app/dashboard/runs/[id]/page.tsx
+++ b/app/dashboard/runs/[id]/page.tsx
@@ -62,8 +62,8 @@ export default async function RunDetailPage({ params }: { params: { id: string }
   if (!project) {
     return (
       <div className="space-y-8">
-        <SectionHeading title="Run" />
-        <EmptyState title="No project yet" description="Create your project to view runs." />
+        <SectionHeading title="Report" />
+        <EmptyState title="No project yet" description="Create your project to view reports." />
       </div>
     );
   }
@@ -217,10 +217,10 @@ export default async function RunDetailPage({ params }: { params: { id: string }
           href="/dashboard/runs"
           className="inline-flex items-center gap-1 text-sm text-ink-faint hover:text-ink"
         >
-          <ArrowLeft className="h-4 w-4" /> Back to runs
+          <ArrowLeft className="h-4 w-4" /> Back to reports
         </a>
         <SectionHeading
-          title="Run results"
+          title="Report"
           description={`${modelLabel(run.provider, run.model)} · ${run.completed_count} / ${run.prompt_count} answers · ${timeAgo(run.created_at)}`}
           action={<Badge tone={STATUS_TONE[run.status]}>{run.status}</Badge>}
         />

--- a/app/dashboard/runs/page.tsx
+++ b/app/dashboard/runs/page.tsx
@@ -48,10 +48,10 @@ export default async function RunsPage() {
   if (!project) {
     return (
       <div className="space-y-8">
-        <SectionHeading title="Runs" />
+        <SectionHeading title="Reports" />
         <EmptyState
           title="No project yet"
-          description="Create your project first, then you can run your first brand monitor."
+          description="Create your project first, then you can run your first report."
           action={
             <Button href="/dashboard/settings">
               Create a project <ArrowRight className="h-4 w-4" />
@@ -131,7 +131,7 @@ export default async function RunsPage() {
   return (
     <div className="space-y-8">
       <SectionHeading
-        title="Runs"
+        title="Reports"
         // Describes the NEXT run, and says so. The old copy claimed what
         // "each run" asks, sitting above a list of completed runs that named a
         // different model — see nextRunMessage.
@@ -168,8 +168,8 @@ export default async function RunsPage() {
       {runs.length === 0 ? (
         <EmptyState
           icon={<PlayCircle className="h-8 w-8" />}
-          title="No runs yet"
-          description="Run your first monitor to see where your brand shows up in AI answers."
+          title="No reports yet"
+          description="Run your first report to see where your brand shows up in AI answers."
         />
       ) : (
         <div className="space-y-3">

--- a/app/dashboard/runs/run-now.tsx
+++ b/app/dashboard/runs/run-now.tsx
@@ -52,7 +52,7 @@ export function RunNow({
           minute", which roughly doubled the button's width the moment it was
           clicked — the spinner already says a wait is underway. */}
       <Button onClick={run} loading={loading} loadingText="Running…" disabled={disabled}>
-        <Play className="h-4 w-4" /> Run monitor now
+        <Play className="h-4 w-4" /> Run report now
       </Button>
 
       {keySource === "exhausted" && (

--- a/app/dashboard/runs/schedule-control.tsx
+++ b/app/dashboard/runs/schedule-control.tsx
@@ -65,10 +65,10 @@ export function ScheduleControl({
         <div className="flex min-w-0 items-start gap-3">
           <CalendarClock className="mt-0.5 h-5 w-5 shrink-0 text-ink-faint" />
           <div className="min-w-0 space-y-0.5">
-            <p className="text-sm font-medium text-ink">Automatic runs</p>
+            <p className="text-sm font-medium text-ink">Scheduled reports</p>
             {!scheduled && (
               <p className="text-xs text-ink-faint">
-                Run your prompts on a schedule (around 8:00 UTC) instead of by
+                Run a report on a schedule (around 8:00 UTC) instead of by
                 hand, and build a trend over time.
               </p>
             )}

--- a/components/dashboard/charts.tsx
+++ b/components/dashboard/charts.tsx
@@ -94,7 +94,7 @@ export function TrendChart({
 }) {
   const t = useChartTheme();
   if (!data || data.length === 0) {
-    return <Placeholder label="No runs to chart yet" height={280} />;
+    return <Placeholder label="No reports to chart yet" height={280} />;
   }
   return (
     <ResponsiveContainer width="100%" height={280}>
@@ -166,7 +166,7 @@ export function EngineTrendChart({
 }) {
   const t = useChartTheme();
   if (!data || data.length === 0 || series.length === 0) {
-    return <Placeholder label="No runs to chart yet" height={280} />;
+    return <Placeholder label="No reports to chart yet" height={280} />;
   }
   const labelOf = new Map(series.map((s) => [s.key, s.label]));
   return (

--- a/components/dashboard/nav.tsx
+++ b/components/dashboard/nav.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { Fragment } from "react";
+import { Fragment, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { ArrowUpRight } from "lucide-react";
+import { ArrowUpRight, ChevronDown, Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { OutboundLink } from "@/components/outbound-link";
 
@@ -12,19 +12,44 @@ interface NavItem {
   label: string;
   /** Base name of the icon in /public/images/icons (Default + active variants). */
   icon: string;
+  /** Rendered only in the wrapped phone row; at md+ the item's content lives
+      in the Reports sub-menu under Overview instead. */
+  mobileOnly?: boolean;
+}
+
+/** A completed run, pre-formatted by the layout for the sidebar. */
+export interface NavReport {
+  id: string;
+  /** Relative age ("6d ago") — recency is what people scan the list by. */
+  when: string;
+  model: string;
 }
 
 const NAV_ITEMS: NavItem[] = [
   { href: "/dashboard", label: "Overview", icon: "Overview" },
   { href: "/dashboard/topics", label: "Topics", icon: "Topics" },
   { href: "/dashboard/competitors", label: "Competitors", icon: "Competitors" },
-  { href: "/dashboard/runs", label: "Runs", icon: "Runs" },
+  // Reports lives under Overview at md+ (see the sub-menu below); this item
+  // exists so the section is still reachable from the phone row, where a
+  // nested list inside a wrapping flex-row would be unreadable.
+  { href: "/dashboard/runs", label: "Reports", icon: "Runs", mobileOnly: true },
   { href: "/dashboard/logs", label: "Logs", icon: "Logs" },
   { href: "/dashboard/settings", label: "Settings", icon: "Settings" },
 ];
 
-export function DashboardNav() {
+export function DashboardNav({
+  reports,
+  totalReports,
+}: {
+  reports: NavReport[];
+  totalReports: number;
+}) {
   const pathname = usePathname();
+  // Open by default: the sub-menu is the pitch — "reports are a thing you run
+  // repeatedly" — so it shouldn't hide behind a click. The nav survives route
+  // changes (the dashboard layout never remounts), so a collapse sticks for
+  // the visit.
+  const [reportsOpen, setReportsOpen] = useState(true);
 
   return (
     // Six labelled items in one un-wrapping row overflowed the viewport on a
@@ -32,11 +57,46 @@ export function DashboardNav() {
     // labels and needs no scrolling; the column layout at md+ must not wrap, or
     // the fixed-height sidebar would spill items into a second column.
     <nav className="flex flex-row flex-wrap gap-1 md:flex-col md:flex-nowrap">
-      {NAV_ITEMS.map(({ href, label, icon }) => {
+      {NAV_ITEMS.map(({ href, label, icon, mobileOnly }) => {
+        const isOverview = href === "/dashboard";
         const active =
-          href === "/dashboard"
+          isOverview
             ? pathname === "/dashboard"
             : pathname.startsWith(href);
+        const link = (
+          <Link
+            href={href}
+            className={cn(
+              "group flex items-center gap-3 rounded px-3 py-2 text-sm font-medium transition-colors",
+              active
+                ? "bg-terracotta/10 text-terracotta-dark"
+                : "text-ink-soft hover:bg-ink/5",
+              mobileOnly && "md:hidden",
+            )}
+          >
+            <span className="relative h-4 w-4 shrink-0" aria-hidden>
+              {/* Default state: shown when not active, hidden on hover. */}
+              <img
+                src={`/images/icons/${icon}-Default.svg`}
+                alt=""
+                className={cn(
+                  "absolute inset-0 h-full w-full",
+                  active ? "hidden" : "block group-hover:hidden",
+                )}
+              />
+              {/* Active state: full opacity when active, 50% opacity on hover. */}
+              <img
+                src={`/images/icons/${icon}.svg`}
+                alt=""
+                className={cn(
+                  "absolute inset-0 h-full w-full",
+                  active ? "opacity-100" : "opacity-0 group-hover:opacity-50",
+                )}
+              />
+            </span>
+            <span>{label}</span>
+          </Link>
+        );
         return (
           <Fragment key={href}>
           {/* Phantomstory sits above Settings: a nav-shaped item that is really
@@ -65,37 +125,84 @@ export function DashboardNav() {
               />
             </OutboundLink>
           )}
-          <Link
-            href={href}
-            className={cn(
-              "group flex items-center gap-3 rounded px-3 py-2 text-sm font-medium transition-colors",
-              active
-                ? "bg-terracotta/10 text-terracotta-dark"
-                : "text-ink-soft hover:bg-ink/5",
-            )}
-          >
-            <span className="relative h-4 w-4 shrink-0" aria-hidden>
-              {/* Default state: shown when not active, hidden on hover. */}
-              <img
-                src={`/images/icons/${icon}-Default.svg`}
-                alt=""
+          {isOverview ? (
+            // The toggle can't live inside the Link (nested interactive
+            // elements), so it overlays the row's right edge instead.
+            <div className="relative w-full">
+              {link}
+              <button
+                type="button"
+                onClick={() => setReportsOpen((o) => !o)}
+                aria-label={reportsOpen ? "Collapse reports" : "Expand reports"}
+                aria-expanded={reportsOpen}
+                className="absolute right-2 top-1/2 hidden -translate-y-1/2 rounded p-1 text-ink-faint transition-colors hover:bg-ink/10 hover:text-ink md:block"
+              >
+                <ChevronDown
+                  className={cn(
+                    "h-3.5 w-3.5 transition-transform",
+                    !reportsOpen && "-rotate-90",
+                  )}
+                />
+              </button>
+            </div>
+          ) : (
+            link
+          )}
+          {/* Reports under Overview: the Overview page is the standing summary
+              across time; each report is a one-off snapshot feeding it. Nesting
+              them says that — and keeps "run another one" a single click from
+              anywhere. The left border hangs from the Overview icon's center. */}
+          {isOverview && reportsOpen && (
+            <div className="mb-1 ml-5 hidden flex-col gap-0.5 border-l border-ink/10 pl-3 md:flex">
+              <Link
+                href="/dashboard/runs"
                 className={cn(
-                  "absolute inset-0 h-full w-full",
-                  active ? "hidden" : "block group-hover:hidden",
+                  "flex items-center gap-2 rounded px-2 py-1.5 text-[13px] font-medium transition-colors",
+                  pathname === "/dashboard/runs"
+                    ? "bg-terracotta/10 text-terracotta-dark"
+                    : "text-ink-soft hover:bg-ink/5",
                 )}
-              />
-              {/* Active state: full opacity when active, 50% opacity on hover. */}
-              <img
-                src={`/images/icons/${icon}.svg`}
-                alt=""
-                className={cn(
-                  "absolute inset-0 h-full w-full",
-                  active ? "opacity-100" : "opacity-0 group-hover:opacity-50",
-                )}
-              />
-            </span>
-            <span>{label}</span>
-          </Link>
+              >
+                <Plus className="h-3.5 w-3.5 shrink-0" aria-hidden />
+                <span>Create New Report</span>
+              </Link>
+              {reports.map((report) => {
+                const reportActive = pathname === `/dashboard/runs/${report.id}`;
+                return (
+                  <Link
+                    key={report.id}
+                    href={`/dashboard/runs/${report.id}`}
+                    className={cn(
+                      "flex items-center rounded px-2 py-1.5 text-[13px] transition-colors",
+                      reportActive
+                        ? "bg-terracotta/10 text-terracotta-dark"
+                        : "text-ink-soft hover:bg-ink/5",
+                    )}
+                  >
+                    <span className="truncate">
+                      {report.when}
+                      <span
+                        className={cn(
+                          "ml-1.5",
+                          reportActive ? "opacity-70" : "text-ink-faint",
+                        )}
+                      >
+                        {report.model}
+                      </span>
+                    </span>
+                  </Link>
+                );
+              })}
+              {totalReports > reports.length && (
+                <Link
+                  href="/dashboard/runs"
+                  className="rounded px-2 py-1.5 text-[13px] text-ink-faint transition-colors hover:bg-ink/5 hover:text-ink-soft"
+                >
+                  All reports ({totalReports})
+                </Link>
+              )}
+            </div>
+          )}
           </Fragment>
         );
       })}

--- a/components/dashboard/run-ready-banner.tsx
+++ b/components/dashboard/run-ready-banner.tsx
@@ -82,7 +82,7 @@ export function RunReadyBanner({
           </span>
           <div>
             <p className="text-sm font-medium text-ink">
-              {failed ? "Your latest run failed" : "Your run finished, results are ready"}
+              {failed ? "Your latest report failed" : "Your report is ready"}
             </p>
             <p className="mt-0.5 text-xs text-ink-faint">
               {failed


### PR DESCRIPTION
Casey's menu simplification, with Kabir's naming feedback applied.

## What changed
- **Runs is gone as a top-level nav item.** Under Overview a collapsible sub-menu (open by default) holds **Create New Report**, the recent completed reports as `6d ago · Claude Haiku 4.5` rows, and an `All reports (N)` overflow link. Completed runs only — the ones with a results page behind them.
- On phones the nav's wrapping row gets a flat **Reports** chip instead of the nested list.
- The noun renames across the UI: page titles Reports/Report, "Back to reports", "View all reports", "Latest report:", "Run report now", "Run your first report", "Your report is ready", "Scheduled reports".

## Deliberately unchanged
- Routes stay at `/dashboard/runs`; API/DB keep "runs".
- `lib/trial`'s shared messages ("Your next run asks…", "free runs") keep "run" — it survives as the verb, and those strings feed API errors and are pinned by tests.

## Why
Fewer things to click, and the sidebar itself now says reports are a repeatable thing: run one, change something, run another, watch Overview move.

Verified headlessly on a populated account (screenshots in Slack): sub-menu states, active highlights, mobile row, Reports page. 759 tests, tsc, lint, and production build all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WuT43AgbLRhTniU8aVqDXJ

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790385642&installation_model_id=431526&pr_number=155&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F155&signature=65ce69ac20c802a49b153bf09653d161eeb932c7ec0e1d2124d4dca6f6be5cd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->