### PR TITLE
Report the lettertrace landing into the company funnel

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,6 +17,7 @@ import { Badge, Button, Card } from "@/components/ui";
 import { Logo } from "@/components/logo";
 import { ThemeToggle } from "@/components/theme";
 import { InstallCli } from "@/components/install-cli";
+import { LetterCoTelemetry } from "@/components/letterco-telemetry";
 import {
   FOUNDER_CALL_LANDING_SOURCE,
   founderCallUrl,
@@ -162,6 +163,7 @@ export default function LandingPage() {
 
   return (
     <div id="top" className="min-h-screen bg-paper text-ink">
+      <LetterCoTelemetry />
       {/* Nav */}
       <header className="sticky top-0 z-40 border-b border-ink/10 bg-paper/80 backdrop-blur">
         <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-5">

--- a/components/letterco-telemetry.tsx
+++ b/components/letterco-telemetry.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useEffect } from "react";
+import posthog from "posthog-js";
+
+/**
+ * Company-funnel telemetry — deliberately separate from PostHogAnalytics,
+ * which is lettertrace's own product-analytics project and stays untouched.
+ *
+ * This boots a second, named PostHog instance pointed at the company-wide
+ * funnel project (shared with the app and the marketing sites; the token is a
+ * public ingest key) and captures exactly one marketing pageview tagged
+ * marketing_site: "lettertrace" — the row key on the staff Telemetry tab at
+ * app.letterstory.com/fleet. Mount it ONLY on public marketing pages, never
+ * in the app layout: authed product usage must not count as marketing
+ * traffic. Event names follow the letterstory repo's docs/analytics-events.md.
+ */
+const LETTERCO_KEY = "phc_zVtjM42jzNFtDtNFfohun7qct7pg9Zs9Z9kYyZEnsw3z";
+
+// One capture per page load (StrictMode double-mounts effects in dev).
+let fired = false;
+
+export function LetterCoTelemetry() {
+  useEffect(() => {
+    if (fired) return;
+    fired = true;
+    const letterco = posthog.init(
+      LETTERCO_KEY,
+      {
+        api_host: "https://us.i.posthog.com",
+        capture_pageview: false,
+        autocapture: false,
+        disable_session_recording: true,
+      },
+      "letterco"
+    );
+    letterco?.capture("$pageview", { marketing_site: "lettertrace" });
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
Adds a second, named PostHog instance on the **public landing page only** that reports one marketing pageview (`marketing_site: "lettertrace"`) into the company-wide funnel project, so lettertrace appears as its own row on the staff Telemetry tab (app.letterstory.com/fleet).

Deliberately scoped:
- `PostHogAnalytics` (lettertrace's own product-analytics project) is untouched — the two instances coexist via posthog-js named instances.
- Mounted only in `LandingPage`, never the app layout, so authed product usage can't count as marketing traffic.
- Autocapture and session recording are off for the funnel instance; it emits exactly one event per landing load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vbkvdd8EYw3A8ds11FDAgm

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790874462&installation_model_id=431526&pr_number=157&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F157&signature=53fa6a01778fd2e730be9df264f2c87c68c95e695c1376d769a25371a80c66be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->