### PR TITLE
CLI 0.1.3: Windows sign-in URL no longer split by cmd.exe (#115)

### DIFF
--- a/app/api/oauth/authorize/route.ts
+++ b/app/api/oauth/authorize/route.ts
@@ -37,7 +37,20 @@ export async function GET(request: Request) {
   const clientId = p.get("client_id") ?? "";
   const redirectUri = p.get("redirect_uri") ?? "";
 
-  const client = await getClient(service, clientId);
+  if (!clientId) {
+    // The only known way to arrive here from our own CLI is a shell that
+    // truncated the sign-in URL at its first "&" (Windows cmd.exe, CLI <= 0.1.2).
+    return oauthErrorPage(
+      "This sign-in link is missing its client_id, which usually means your terminal cut the URL short. " +
+        "Update the Lettertrace CLI (npm install -g lettertrace@latest) or paste the full URL it printed.",
+    );
+  }
+  let client;
+  try {
+    client = await getClient(service, clientId);
+  } catch {
+    return oauthErrorPage("Lettertrace could not look up this OAuth client right now. Try again in a moment.", 500);
+  }
   if (!client) return oauthErrorPage("Unknown OAuth client.");
   if (!redirectUri || !redirectUriAllowed(client, redirectUri)) {
     return oauthErrorPage("The redirect URI is not registered for this client.");

--- a/cli/oauth.mjs
+++ b/cli/oauth.mjs
@@ -27,10 +27,41 @@ export class NeedsLogin extends Error {
   }
 }
 
+/**
+ * The program + argv that opens `url` in the default browser on `platform`.
+ * Exported (pure) so the Windows branch can be unit-tested from any OS.
+ *
+ * Windows is the delicate one. `cmd /c start "" <url>` is the classic recipe,
+ * but Node only quotes an argument that contains whitespace, so cmd.exe saw the
+ * raw query string and split it on every `&` — the browser opened
+ * `/api/oauth/authorize?response_type=code` and nothing else, which the server
+ * reported as "Unknown OAuth client" (#115). Going through PowerShell with a
+ * base64-encoded script means no shell ever parses the URL: single quotes are
+ * fully literal in PowerShell, and -EncodedCommand sidesteps every quoting rule
+ * of the command line itself.
+ */
+export function browserLaunch(url, platform = process.platform) {
+  if (platform === "darwin") return { cmd: "open", args: [url] };
+  if (platform === "win32") {
+    const script = `Start-Process '${url.replace(/'/g, "''")}'`;
+    const root = process.env.SystemRoot || process.env.SYSTEMROOT || "C:\\Windows";
+    return {
+      cmd: `${root}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`,
+      args: [
+        "-NoProfile",
+        "-NonInteractive",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-EncodedCommand",
+        Buffer.from(script, "utf16le").toString("base64"),
+      ],
+    };
+  }
+  return { cmd: "xdg-open", args: [url] };
+}
+
 function openBrowser(url) {
-  const cmd =
-    process.platform === "darwin" ? "open" : process.platform === "win32" ? "cmd" : "xdg-open";
-  const args = process.platform === "win32" ? ["/c", "start", "", url] : [url];
+  const { cmd, args } = browserLaunch(url);
   try {
     const child = spawn(cmd, args, { stdio: "ignore", detached: true });
     child.on("error", () => {});

--- a/cli/oauth.test.ts
+++ b/cli/oauth.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { browserLaunch as browserLaunchRaw } from "./oauth.mjs";
+
+type Launch = { cmd: string; args: string[] };
+const browserLaunch = browserLaunchRaw as (url: string, platform?: string) => Launch;
+
+// The authorize URL the CLI opens: many "&"-joined parameters and percent
+// escapes — everything cmd.exe mangles.
+const URL_ =
+  "https://lettertrace.com/api/oauth/authorize?response_type=code&client_id=lt_cli" +
+  "&redirect_uri=http%3A%2F%2F127.0.0.1%3A51234%2Fcallback&scope=projects%3Aread+runs%3Aread" +
+  "&state=abc&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM&code_challenge_method=S256&resource=v1";
+
+describe("browserLaunch", () => {
+  it("never routes a Windows launch through cmd.exe (#115)", () => {
+    const { cmd, args } = browserLaunch(URL_, "win32");
+    expect(cmd.toLowerCase()).toMatch(/powershell\.exe$/);
+    expect(cmd.toLowerCase()).not.toContain("cmd");
+    expect(args).not.toContain("start");
+    // The URL itself must not appear as a bare argv entry a shell could split.
+    expect(args).not.toContain(URL_);
+  });
+
+  it("hands PowerShell the whole URL, intact, as a literal string", () => {
+    const { args } = browserLaunch(URL_, "win32");
+    const encoded = args[args.indexOf("-EncodedCommand") + 1];
+    const script = Buffer.from(encoded, "base64").toString("utf16le");
+    expect(script).toBe(`Start-Process '${URL_}'`);
+    // Every parameter survives, including the ones after the first "&".
+    for (const key of ["client_id=lt_cli", "redirect_uri=", "code_challenge=", "resource=v1"]) {
+      expect(script).toContain(key);
+    }
+  });
+
+  it("escapes a single quote so the PowerShell string cannot be terminated early", () => {
+    const { args } = browserLaunch("https://x.test/?q=it's", "win32");
+    const script = Buffer.from(args[args.length - 1], "base64").toString("utf16le");
+    expect(script).toBe("Start-Process 'https://x.test/?q=it''s'");
+  });
+
+  it("uses the platform opener directly on macOS and Linux", () => {
+    expect(browserLaunch(URL_, "darwin")).toEqual({ cmd: "open", args: [URL_] });
+    expect(browserLaunch(URL_, "linux")).toEqual({ cmd: "xdg-open", args: [URL_] });
+  });
+});

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lettertrace",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Command-line client for a Lettertrace deployment: monitor how your brand shows up in AI assistant answers.",
   "license": "MIT",
   "author": "The Letter Company",

--- a/lib/oauth.test.ts
+++ b/lib/oauth.test.ts
@@ -3,6 +3,7 @@ import { beforeAll, describe, expect, it, vi } from "vitest";
 import {
   authenticateClient,
   dataScopesOf,
+  getClient,
   exchangeAuthorizationCode,
   exchangeRefreshToken,
   OAuthError,
@@ -321,5 +322,32 @@ describe("authenticateClient", () => {
     await expect(
       authenticateClient(client, { bodyClientId: "nope", authHeader: null }),
     ).rejects.toBeInstanceOf(OAuthError);
+  });
+});
+
+describe("getClient", () => {
+  const fake = (result: { data?: unknown; error?: { message: string } | null }) =>
+    ({
+      from: () => ({
+        select: () => ({
+          eq: () => ({ maybeSingle: () => Promise.resolve({ data: null, error: null, ...result }) }),
+        }),
+      }),
+    }) as never;
+
+  it("returns null for a missing row and for an empty id", async () => {
+    expect(await getClient(fake({ data: null }), "nope")).toBeNull();
+    expect(await getClient(fake({ data: cliClient }), "")).toBeNull();
+  });
+
+  it("returns the row when present", async () => {
+    expect(await getClient(fake({ data: cliClient }), "lt_cli")).toEqual(cliClient);
+  });
+
+  it("throws on a query error instead of reporting an unknown client (#115)", async () => {
+    await expect(getClient(fake({ error: { message: "boom" } }), "lt_cli")).rejects.toMatchObject({
+      code: "server_error",
+      status: 500,
+    });
   });
 });

--- a/lib/oauth.ts
+++ b/lib/oauth.ts
@@ -278,11 +278,14 @@ export async function getClient(
   clientId: string,
 ): Promise<OAuthClient | null> {
   if (!clientId) return null;
-  const { data } = await supabase
+  const { data, error } = await supabase
     .from("oauth_clients")
     .select(CLIENT_COLUMNS)
     .eq("client_id", clientId)
     .maybeSingle();
+  // A failed query is not "no such client". Swallowing it here once sent a
+  // user off to re-seed a client row that had been present all along (#115).
+  if (error) throw new OAuthError("server_error", 500, error.message);
   return (data as OAuthClient | null) ?? null;
 }
 


### PR DESCRIPTION
Fixes #115.

## What was wrong
On Windows, `lettertrace login` opened the browser via `cmd /c start "" <url>`. Node only quotes arguments containing whitespace, so cmd.exe split the authorize URL on every `&`. The browser received `/api/oauth/authorize?response_type=code` alone, and the server answered "Unknown OAuth client" because no client_id arrived.

The issue's diagnosis (lt_cli not seeded) was not the cause: the row has existed since Jul 28 and eleven other users authorized on Aug 12 from macOS, Android, and Linux. Zero successful `lt_cli` authorizations came from Windows before Aug 21.

## Changes
- `cli/oauth.mjs`: Windows launches through PowerShell `-EncodedCommand Start-Process '<url>'`. No shell parses the URL. `browserLaunch()` exported and tested (`cli/oauth.test.ts`).
- `lib/oauth.ts`: `getClient()` throws `server_error` on a query failure instead of returning null, so a database problem can no longer masquerade as an unknown client.
- `app/api/oauth/authorize/route.ts`: an empty `client_id` gets its own message telling the user the link was truncated and to update the CLI or paste the full URL.
- `cli/package.json`: 0.1.3. Note 0.1.2 was bumped in git on Aug 3 but never published; npm still serves 0.1.1.

## Not in this PR
Publishing to npm (needs `npm login` on the publishing machine). Run `cd cli && npm publish` after merge.

## Verification
- `vitest run`: all suites pass, including 4 new launcher tests and 3 new `getClient` tests.
- `tsc --noEmit` and `next lint` clean.
- Not exercised on a real Windows machine; the test asserts the decoded PowerShell script contains the URL byte-for-byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoCCmuP6SFrqzUgh4oLfxM

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790961528&installation_model_id=431526&pr_number=158&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F158&signature=64043fe5d09e67db4ab400ff758f299786ebdd8824a5994c2a992d5a9a14a1aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->