### PR TITLE
Post every new issue to Slack, with the repo it landed in

### DIFF
--- a/.github/scripts/issue-to-slack.sh
+++ b/.github/scripts/issue-to-slack.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Post one GitHub issue event to a Slack incoming webhook as a Block Kit message.
+#
+# Every value arrives through the environment, never as a shell argument, so an
+# issue title like `$(rm -rf /)` or one full of quotes is data to jq and nothing
+# else. Slack mrkdwn treats & < > as markup, so they are escaped before the
+# text is sent; the issue URL is the only thing that goes out unescaped.
+#
+# Required env:
+#   SLACK_WEBHOOK_URL   the channel's incoming-webhook URL
+#   REPO                owner/name
+#   ISSUE_NUMBER, ISSUE_TITLE, ISSUE_URL, ISSUE_BODY
+#   AUTHOR, AUTHOR_URL
+#   ACTION              opened | reopened
+# Optional:
+#   LABELS              comma-separated label names
+set -euo pipefail
+
+: "${SLACK_WEBHOOK_URL:?missing}" "${REPO:?missing}" "${ISSUE_NUMBER:?missing}" \
+  "${ISSUE_TITLE:?missing}" "${ISSUE_URL:?missing}" "${AUTHOR:?missing}" "${ACTION:?missing}"
+
+payload=$(jq -n \
+  --arg repo "$REPO" \
+  --arg number "$ISSUE_NUMBER" \
+  --arg title "$ISSUE_TITLE" \
+  --arg url "$ISSUE_URL" \
+  --arg body "${ISSUE_BODY:-}" \
+  --arg author "$AUTHOR" \
+  --arg author_url "${AUTHOR_URL:-}" \
+  --arg labels "${LABELS:-}" \
+  --arg action "$ACTION" '
+  def esc: gsub("&"; "&amp;") | gsub("<"; "&lt;") | gsub(">"; "&gt;");
+  # First 300 characters of the body, whitespace collapsed, as a quote block.
+  def excerpt:
+    ($body | gsub("\r"; "") | gsub("\\s+"; " ") | ltrimstr(" ") | .[0:300]) as $t
+    | if ($t | length) == 0 then "" elif ($body | length) > 300 then "> \($t | esc)…" else "> \($t | esc)" end;
+  (if $action == "reopened" then "Issue reopened" else "New issue" end) as $verb
+  | ($labels | split(",") | map(select(length > 0)) | map("`\(. | esc)`") | join(" ")) as $labeltext
+  | {
+      text: "\($verb) in \($repo | esc): #\($number) \($title | esc)",
+      blocks: ([
+        { type: "header", text: { type: "plain_text", text: "\($verb) · \($repo)", emoji: false } },
+        { type: "section", text: { type: "mrkdwn",
+            text: ("*<\($url)|#\($number) \($title | esc)>*\nby <\($author_url)|\($author | esc)>" + (if $labeltext == "" then "" else "  ·  \($labeltext)" end)) } },
+        (if excerpt == "" then empty else { type: "section", text: { type: "mrkdwn", text: excerpt } } end),
+        { type: "context", elements: [ { type: "mrkdwn", text: "<https://github.com/\($repo)/issues|All issues in \($repo | esc)>" } ] }
+      ])
+    }')
+
+# Slack answers a bare "ok" on success; anything else (invalid_payload,
+# no_service, channel_not_found) is a real failure and should fail the job.
+response=$(curl --silent --show-error --max-time 15 \
+  -H 'content-type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL")
+if [ "$response" != "ok" ]; then
+  echo "Slack rejected the message: $response" >&2
+  exit 1
+fi
+echo "Posted #$ISSUE_NUMBER from $REPO to Slack."

--- a/.github/workflows/issue-to-slack.yml
+++ b/.github/workflows/issue-to-slack.yml
@@ -1,0 +1,63 @@
+# Tell Slack when someone files an issue, and say which repo it landed in.
+#
+# Until this existed, an issue on any of our repos reached us only if a human
+# happened to open GitHub — #115 sat for three weeks that way. This posts every
+# opened or reopened issue to the Slack channel behind SLACK_ISSUES_WEBHOOK_URL.
+#
+# It is written once, here, and shared: this file is both this repo's own
+# trigger AND a reusable workflow every other letterstory repo can call with a
+# ten-line file. To wire up another repo, add .github/workflows/issues.yml:
+#
+#   name: Issue to Slack
+#   on:
+#     issues:
+#       types: [opened, reopened]
+#   jobs:
+#     notify:
+#       uses: letterstory/lettertrace/.github/workflows/issue-to-slack.yml@master
+#       secrets: inherit
+#
+# `secrets: inherit` hands through the org-level SLACK_ISSUES_WEBHOOK_URL, so a
+# new repo needs no secret of its own. This repo is public, which is what lets
+# private repos call the workflow and check out the script it runs.
+name: Issue to Slack
+
+on:
+  issues:
+    types: [opened, reopened]
+  workflow_call:
+    secrets:
+      SLACK_ISSUES_WEBHOOK_URL:
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # Always the script from THIS repo, whichever repo the issue is in.
+      - uses: actions/checkout@v4
+        with:
+          repository: letterstory/lettertrace
+          ref: master
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+
+      # Event fields go through env, never into the command line: an issue title
+      # is attacker-controlled text and must never be interpolated into a shell.
+      - name: Post to Slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ISSUES_WEBHOOK_URL }}
+          REPO: ${{ github.repository }}
+          ACTION: ${{ github.event.action }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          AUTHOR: ${{ github.event.issue.user.login }}
+          AUTHOR_URL: ${{ github.event.issue.user.html_url }}
+          LABELS: ${{ join(github.event.issue.labels.*.name, ',') }}
+        run: bash .github/scripts/issue-to-slack.sh


### PR DESCRIPTION
Issue #115 sat for three weeks because nothing told anyone it existed. This posts every opened or reopened issue to a Slack channel, naming the repo.

## Design
- **One file, shared.** `.github/workflows/issue-to-slack.yml` is both this repo's trigger and a reusable `workflow_call` workflow. Any other letterstory repo adopts it with the ten-line caller in the file's header comment plus `secrets: inherit`. This repo being public is what lets private repos call it and check out the script.
- **Payload built by jq from env vars**, never shell interpolation, so an issue title is data. Escapes `& < >` for Slack mrkdwn.
- **Fails loudly.** A rejected webhook or missing secret fails the job with Slack's error text.

## What the message looks like
Header: `New issue · letterstory/lettertrace`. Then a linked `#115 title` line with author and labels, a 300-character excerpt of the body, and a link to the repo's issue list.

## Before it can post
An org-level Actions secret named `SLACK_ISSUES_WEBHOOK_URL` (an incoming-webhook URL for the target channel), visible to all repos. Needs an org admin. Until it exists, the workflow runs and fails on each new issue, which is visible but harmless.

## Verification
Tested locally against a fake webhook server: issue #115's real payload renders correctly; a title of `$(touch /tmp/pwned) <script>&"quotes"` is escaped and executes nothing; a 404 from the webhook exits non-zero. YAML parses. Not yet exercised on a real runner, since the secret does not exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoCCmuP6SFrqzUgh4oLfxM

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790963441&installation_model_id=431526&pr_number=159&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F159&signature=d07b6d02ccf35239253ac6df45e81359f9ff5b60ef6ec212c267cfa24dda8cf2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->