### PR TITLE
Sidebar: promote the Phantom Story link from nav row to a CTA

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -4,6 +4,7 @@ import { DashboardNav, type NavReport } from "@/components/dashboard/nav";
 import { OrgSwitcher } from "@/components/dashboard/org-switcher";
 import { SignOutButton } from "@/components/dashboard/signout";
 import { WhyFree } from "@/components/dashboard/why-free";
+import { ProductCta } from "@/components/dashboard/product-cta";
 import { TrialBanner } from "@/components/dashboard/trial-banner";
 import { LetterproveAttest } from "@/components/letterprove-attest";
 import { isFirstSignIn } from "@/lib/letterprove";
@@ -136,7 +137,9 @@ export default async function DashboardLayout({
       {offerFounderCall && callUrl && <FounderCallOffer url={callUrl} />}
 
       <aside className="flex flex-col border-b border-ink/10 bg-paper md:h-screen md:w-[260px] md:shrink-0 md:border-b-0 md:border-r">
-        <div className="flex flex-col gap-6 px-5 py-6 md:h-full">
+        {/* Scrolls: six reports in the sub-menu plus the CTA push Sign out past
+            the fold, and an h-screen column without it leaves them unreachable. */}
+        <div className="flex flex-col gap-6 px-5 py-6 md:h-full md:overflow-y-auto">
           <div className="flex items-center justify-between gap-2">
             <Logo />
             <ThemeToggle className="hidden md:inline-flex" />
@@ -159,7 +162,13 @@ export default async function DashboardLayout({
 
           <DashboardNav reports={navReports} totalReports={reportCount} />
 
-          <div className="mt-auto hidden flex-col gap-3 border-t border-ink/10 pt-4 md:flex">
+          {/* The only mt-auto in this column, deliberately: flexbox splits free
+              space equally between every auto margin, so leaving one on the
+              account block below halved the slack and left this box floating
+              mid-column instead of sitting on the footer. */}
+          <ProductCta className="md:mt-auto" />
+
+          <div className="hidden flex-col gap-3 border-t border-ink/10 pt-4 md:flex">
             <WhyFree />
             <p className="truncate text-xs text-ink-faint" title={user.email ?? undefined}>
               {user.email}

--- a/components/dashboard/nav.tsx
+++ b/components/dashboard/nav.tsx
@@ -3,9 +3,8 @@
 import { Fragment, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { ArrowUpRight, ChevronDown, Plus } from "lucide-react";
+import { ChevronDown, Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { OutboundLink } from "@/components/outbound-link";
 
 interface NavItem {
   href: string;
@@ -99,32 +98,6 @@ export function DashboardNav({
         );
         return (
           <Fragment key={href}>
-          {/* Phantomstory sits above Settings: a nav-shaped item that is really
-              an external link, and dressed to say so — the brand mark renders
-              greyscale until hover brings the colour up, and the corner arrow
-              is right-aligned where a route item would have nothing.
-              OutboundLink so the click lands on /admin/conversions. */}
-          {href === "/dashboard/settings" && (
-            <OutboundLink
-              href="https://phantomstory.com"
-              target="_blank"
-              rel="noreferrer"
-              className="group flex items-center gap-3 rounded px-3 py-2 text-sm font-medium text-ink-soft transition-colors hover:bg-ink/5"
-            >
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                src="/images/phantomstory.png"
-                alt=""
-                aria-hidden
-                className="h-4 w-4 shrink-0 grayscale transition group-hover:grayscale-0"
-              />
-              <span>Phantoms</span>
-              <ArrowUpRight
-                className="ml-auto h-3.5 w-3.5 shrink-0 text-ink-faint transition-colors group-hover:text-ink-soft"
-                aria-hidden
-              />
-            </OutboundLink>
-          )}
           {isOverview ? (
             // The toggle can't live inside the Link (nested interactive
             // elements), so it overlays the row's right edge instead.

--- a/components/dashboard/product-cta.tsx
+++ b/components/dashboard/product-cta.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { ArrowUpRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { OutboundLink } from "@/components/outbound-link";
+
+/**
+ * The cross-product CTA at the foot of the dashboard sidebar, and the only
+ * route from lettertrace to Phantom Story: it replaces the "Phantoms" nav row,
+ * which sat among six page links in the same weight and colour and so read as
+ * a page you had not opened yet rather than as an offer.
+ *
+ * Proportions copy OrgSwitcher's trigger, so a box of the same shape sits at
+ * each end of the sidebar. The second line names the destination, which the
+ * benefit-led title deliberately does not.
+ *
+ * OutboundLink is the instrumentation: the click records a row in
+ * outbound_clicks, which is what /admin Conversions reads (lib/conversions.ts).
+ */
+export function ProductCta({ className }: { className?: string }) {
+  return (
+    <OutboundLink
+      href="https://phantomstory.com"
+      target="_blank"
+      rel="noreferrer"
+      className={cn(
+        "group flex w-full items-center justify-between gap-2 rounded border border-terracotta/40",
+        "bg-terracotta/[0.18] px-4 py-3 text-left transition hover:border-terracotta/70 hover:bg-terracotta/[0.26]",
+        className,
+      )}
+    >
+      <span className="min-w-0">
+        <span className="block text-sm font-semibold leading-snug text-terracotta-dark">
+          Automate Your Content Strategy
+        </span>
+        <span className="mt-0.5 block truncate text-xs text-ink-faint">Phantom Story</span>
+      </span>
+      <ArrowUpRight
+        className="h-4 w-4 shrink-0 text-terracotta-dark transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5"
+        aria-hidden
+      />
+    </OutboundLink>
+  );
+}


### PR DESCRIPTION
## Why

The link out to Phantom Story lived in the nav stack as "Phantoms", styled
identically to the six page links around it. Two things went wrong in that
position: the label names a brand that means nothing to someone who has never
heard of it, and a row in the same weight and colour as Topics or Logs reads as
a page you have not opened yet, not as an offer.

It is also the only outbound link we place ourselves, and `/admin` Conversions
exists specifically to measure what it produces. Leaving it as a menu row means
the cross-product funnel is measuring a link nobody reads as an invitation.

## What

- `components/dashboard/product-cta.tsx` (new): a bordered, terracotta-tinted
  box at the foot of the sidebar — "Automate Your Content Strategy" over a faint
  "Phantom Story", corner arrow, whole box clickable. Still an `OutboundLink`,
  so the click records in `outbound_clicks` exactly as before.
- `components/dashboard/nav.tsx`: the Phantoms row is gone, along with the
  `ArrowUpRight` and `OutboundLink` imports that became dead with it.
- `app/dashboard/layout.tsx`: the CTA is pinned to the foot of the sidebar, and
  the sidebar column now scrolls.


## Scope

Sidebar only. No schema change, no API change, nothing on a measurement path —
`supabase/schema.sql`, `lib/conversions.ts`, `lib/engine.ts` and the provider
catalogs are all untouched. The one shared surface involved,
`components/outbound-link.tsx`, is used as-is with no signature change, so no
other caller is affected.

## Tests

**No new tests, deliberately.** The change is a presentational component plus a
placement: there is no decision with branching logic to pin. `vitest.config.ts`
runs `environment: "node"` with an include glob covering `lib/`, `app/` and
`cli/` — `components/` is outside it, and there is no jsdom or testing-library
in the project. Asserting that a box renders its own text would mean adding both
as dependencies, which is more new surface than the box is worth. Happy to scope
that separately if the project wants a component tier.

**759 passing** across 41 files, unchanged. Typecheck clean, lint clean on the
changed files, `next build` compiles.

## Verification

Driven in a browser against a local dev server and a real signed-in session.
Numbers are `getBoundingClientRect` / `getComputedStyle` readings, not eyeballing.

- **Pinning.** Gap from CTA to the account block measures 24px — exactly the
  column's `gap-6` — with the Reports sub-menu both expanded and collapsed.
  Before the `mt-auto` fix the same measurement was 59px with the box floating.
- **Scrolling.** With six reports listed (the sidebar's cap), the column is 906px
  of content in a 716px box and scrolls; the account block's bottom edge sits
  24px above the fold and Sign out is reachable.
- **Colour.** CTA background `rgba(224, 120, 80, 0.18)` against the active nav
  item's `rgba(224, 120, 80, 0.1)`, in both themes.
- **Title case is real**, not CSS: computed `text-transform: none`.
- **Tracking still works.** Clicking the CTA fires the `/api/out` beacon and
  writes an `outbound_clicks` row for the signed-in user; the click then appears
  on `/admin` Conversions in the stat row and the connected-users table.
- **Themes.** Verified dark and light.

## Before merge

1. Eyeball it at ~390px in the device toolbar (see above).
2. No `supabase/schema.sql` re-run needed — this PR does not touch the schema.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790964246&installation_model_id=431526&pr_number=162&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F162&signature=ebb9a3d9f6034663be141d85718dea700915ab72910c65d8acc93a63eb1dc407"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->