### PR TITLE
Conversions: the rate chart shows each day on its own, not a running total

### DIFF
--- a/app/admin/conversions/page.tsx
+++ b/app/admin/conversions/page.tsx
@@ -44,11 +44,12 @@ function ColumnHeader({ children, className }: { children: React.ReactNode; clas
 }
 
 /**
- * The connected rate as it stood at each day's end — cumulative within the
- * period, over the signups that existed then, so the right edge always equals
- * the headline card. Same construction as Growth's RunSparkline: inline SVG,
- * numbers in <title> tooltips, colors through style because CSS var() only
- * resolves in styles. One series, so the title is the legend.
+ * Each day's connected rate on its own — that day's clickers over the signups
+ * that existed by then — so a quiet day sits on the baseline and a busy one
+ * stands out, instead of every day folding into a total that can only climb.
+ * Same construction as Growth's RunSparkline: inline SVG, numbers in <title>
+ * tooltips, colors through style because CSS var() only resolves in styles.
+ * One series, so the title is the legend.
  */
 function RateChart({ series }: { series: RatePoint[] }) {
   const points = series.filter((p) => p.rate !== null) as (RatePoint & { rate: number })[];
@@ -101,7 +102,7 @@ function RateChart({ series }: { series: RatePoint[] }) {
           height={H}
           fill="transparent"
         >
-          <title>{`${p.day} · ${p.rate}% connected (${p.connected} of ${p.signups} signups) · ${p.clicks} click${p.clicks === 1 ? "" : "s"} this day`}</title>
+          <title>{`${p.day} · ${p.rate}% connected (${p.connected} of ${p.signups} signups clicked this day) · ${p.clicks} click${p.clicks === 1 ? "" : "s"}`}</title>
         </rect>
       ))}
     </svg>
@@ -124,6 +125,7 @@ export default async function ConversionsPage({ searchParams }: { searchParams: 
   const { stats, series, connected, degraded } = await conversionsReport(period);
   const latest = series.filter((p) => p.rate !== null).at(-1);
   const peak = series.reduce((a, b) => ((b.rate ?? -1) > (a?.rate ?? -1) ? b : a), latest);
+  const today = new Date().toISOString().slice(0, 10);
 
   return (
     <div className="space-y-10">
@@ -223,8 +225,10 @@ export default async function ConversionsPage({ searchParams }: { searchParams: 
                 <RateChart series={series} />
               </div>
               <p className="mt-3 text-xs tabular-nums text-ink-faint">
-                now {latest.rate}%{peak && peak.day !== latest.day ? ` · peak ${peak.rate}% on ${peak.day}` : ""} · cumulative
-                within the period, over signups as of each day · hover for daily numbers
+                {latest.day === today ? "today" : latest.day} {latest.rate}%
+                {peak && peak.day !== latest.day ? ` · peak ${peak.rate}% on ${peak.day}` : ""} · each
+                day on its own: users who clicked that day, over signups as of that day · hover for
+                daily numbers
               </p>
             </>
           )}

--- a/lib/conversions.test.ts
+++ b/lib/conversions.test.ts
@@ -153,10 +153,11 @@ describe("shapeConversionStats", () => {
 });
 
 describe("shapeRateSeries", () => {
-  it("builds one point per day with a cumulative rate over signups as of that day", () => {
+  it("builds one point per day with that day's rate over signups as of that day", () => {
     // u2 signed up 20d ago, u3 3d ago (PROFILES); period covers last 7 days.
     const clicks = [
       click({ user_id: "u2", clicked_at: iso(5) }),
+      click({ user_id: "u2", clicked_at: iso(5, 2) }),
       click({ user_id: "u2", clicked_at: iso(2) }),
       click({ user_id: "u3", clicked_at: iso(2) }),
     ];
@@ -164,27 +165,43 @@ describe("shapeRateSeries", () => {
     expect(series).toHaveLength(8); // 7 full days back plus today
 
     const day5 = series.find((p) => p.day === iso(5).slice(0, 10))!;
-    // By 5d ago: u1/u2/u4 signed up (u3 hadn't yet), u2 connected.
+    // 5d ago: u1/u2/u4 had signed up (u3 hadn't yet); u2 clicked twice, one user.
     expect(day5.connected).toBe(1);
     expect(day5.signups).toBe(3);
-    expect(day5.rate).toBe(33.3);
-    expect(day5.clicks).toBe(1);
+    expect(day5.rate).toBe(33.33);
+    expect(day5.clicks).toBe(2);
 
-    const last = series.at(-1)!;
-    expect(last.connected).toBe(2);
-    expect(last.signups).toBe(4);
-    expect(last.rate).toBe(50);
+    const day2 = series.find((p) => p.day === iso(2).slice(0, 10))!;
+    // 2d ago: all four signed up; u2 and u3 clicked — u2's earlier day doesn't carry over.
+    expect(day2.connected).toBe(2);
+    expect(day2.signups).toBe(4);
+    expect(day2.rate).toBe(50);
   });
 
-  it("matches the headline stat at its right edge", () => {
-    const clicks = [
-      click({ user_id: "u1", clicked_at: iso(6) }),
-      click({ user_id: "u2", clicked_at: iso(1) }),
-    ];
-    const since = NOW - 7 * DAY_MS;
-    const series = shapeRateSeries(clicks, PROFILES, since, NOW);
-    const stats = shapeConversionStats(clicks, PROFILES.length, since);
-    expect(series.at(-1)!.rate).toBe(stats.rate);
+  it("puts a quiet day at zero rather than carrying the last rate forward", () => {
+    const clicks = [click({ user_id: "u2", clicked_at: iso(5) })];
+    const series = shapeRateSeries(clicks, PROFILES, NOW - 7 * DAY_MS, NOW);
+    const day4 = series.find((p) => p.day === iso(4).slice(0, 10))!;
+    expect(day4.connected).toBe(0);
+    expect(day4.rate).toBe(0);
+    expect(series.at(-1)!.rate).toBe(0);
+  });
+
+  it("keeps two decimals so one clicker in a big base is not rounded to zero", () => {
+    const profiles: GrowthProfileRow[] = Array.from({ length: 2000 }, (_, i) => ({
+      id: `p${i}`,
+      email: null,
+      created_at: iso(30),
+    }));
+    const series = shapeRateSeries([click({ user_id: "p1", clicked_at: iso(1) })], profiles, NOW - 7 * DAY_MS, NOW);
+    expect(series.find((p) => p.day === iso(1).slice(0, 10))!.rate).toBe(0.05);
+  });
+
+  it("is null on days before anyone had signed up", () => {
+    const profiles: GrowthProfileRow[] = [{ id: "u1", email: null, created_at: iso(2) }];
+    const series = shapeRateSeries([click({ clicked_at: iso(1) })], profiles, NOW - 7 * DAY_MS, NOW);
+    expect(series.find((p) => p.day === iso(5).slice(0, 10))!.rate).toBeNull();
+    expect(series.find((p) => p.day === iso(1).slice(0, 10))!.rate).toBe(100);
   });
 
   it("starts at the first click for all-time, and is empty with no clicks", () => {
@@ -200,7 +217,8 @@ describe("shapeRateSeries", () => {
       click({ user_id: "u2", clicked_at: iso(1) }),
     ];
     const series = shapeRateSeries(clicks, PROFILES, NOW - 7 * DAY_MS, NOW);
-    expect(series.at(-1)!.connected).toBe(1);
+    expect(series.find((p) => p.day === iso(1).slice(0, 10))!.connected).toBe(1);
+    expect(series.reduce((n, p) => n + p.clicks, 0)).toBe(1);
   });
 });
 

--- a/lib/conversions.ts
+++ b/lib/conversions.ts
@@ -175,21 +175,25 @@ export function shapeConversionStats(
 export interface RatePoint {
   /** UTC date, YYYY-MM-DD. */
   day: string;
-  /** Cumulative-within-period connected rate as of this day's end: distinct
-   *  users who clicked between the period start and this day, over signups
-   *  that existed by this day. Null while there are no signups to divide by. */
+  /** This day's connected rate: distinct users who clicked on this day, over
+   *  signups that existed by this day's end. The headline card's construction
+   *  with a one-day window, so a day is 0 when nobody clicked and null only
+   *  while there is no one to divide by. Two decimals rather than the card's
+   *  one: a single day's share of the whole user base is small by nature, and
+   *  1 in 2,000 has to read as 0.05%, not 0%. */
   rate: number | null;
-  /** Cumulative connected users behind that rate. */
+  /** Distinct users who clicked on this day. */
   connected: number;
   /** Clicks on this day alone. */
   clicks: number;
+  /** Signups as of this day's end. */
   signups: number;
 }
 
 /** One point per UTC day from the period start (or the first click, for
- *  all-time) through today. The denominator is signups AS OF each day, not
- *  today's — so the curve is the rate as it actually stood, and its last
- *  point equals the headline card. */
+ *  all-time) through today. Each point stands on its own — that day's
+ *  clickers over that day's user base — so the curve shows which days
+ *  actually moved people, not a total that can only climb. */
 export function shapeRateSeries(
   clicks: OutboundClickRow[],
   profiles: GrowthProfileRow[],
@@ -211,7 +215,6 @@ export function shapeRateSeries(
 
   const startDay = new Date(firstDay).toISOString().slice(0, 10);
   const series: RatePoint[] = [];
-  const connected = new Set<string>();
   let clickIdx = 0;
   let signupIdx = 0;
 
@@ -221,6 +224,7 @@ export function shapeRateSeries(
     dayStart += DAY_MS
   ) {
     const dayEnd = dayStart + DAY_MS;
+    const connected = new Set<string>();
     let dayClicks = 0;
     while (clickIdx < inPeriod.length && inPeriod[clickIdx].t < dayEnd) {
       connected.add(inPeriod[clickIdx].user_id);
@@ -231,7 +235,7 @@ export function shapeRateSeries(
 
     series.push({
       day: new Date(dayStart).toISOString().slice(0, 10),
-      rate: signupIdx > 0 ? Math.round((connected.size / signupIdx) * 1000) / 10 : null,
+      rate: signupIdx > 0 ? Math.round((connected.size / signupIdx) * 10_000) / 100 : null,
       connected: connected.size,
       clicks: dayClicks,
       signups: signupIdx,


### PR DESCRIPTION
## What

The "Connected rate over time" chart on `/admin/conversions` was cumulative within the period: connected users accumulated day over day, so the line could only climb and a busy day looked the same as a quiet one a week later.

Each point is now **that day's rate on its own**: distinct users who clicked that day, over signups as of that day. It is the headline card's construction with a one-day window, so the two stay comparable.

- Quiet days sit at 0; a day is null only before anyone had signed up.
- Two decimals instead of the card's one. A single day's share of the whole base is small by nature (one clicker is about 0.2% today), so one decimal would flatten most days.
- Caption reads "today X% · peak Y% on <day> · each day on its own: users who clicked that day, over signups as of that day · hover for daily numbers". Hover says "N of M signups clicked this day".

## Verification

- `vitest`: 22 pass. Replaced the cumulative and "matches the headline at the right edge" tests with per-day reset, zero on quiet days, two-decimal rounding, and pre-signup null.
- `tsc --noEmit` and `eslint` clean.
- Ran the report loader read-only against the database for the last 30 days: daily rates land between 0.21% and 1.04% on the eight days with clicks, peak on Sep 1; headline card unchanged at 3.7%.

Prettier flags these files but they were already unformatted at HEAD; left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PAiviErMoUxZizg6r7k7M

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790970552&installation_model_id=431526&pr_number=163&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F163&signature=252996e10b1869c140b6b564a09a180c82f614ae23f6515e485abab5a2199c89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->