### PR TITLE
Admin: sign-ups, returning users, and the API-key activation rung

### DIFF
--- a/app/admin/conversions/page.tsx
+++ b/app/admin/conversions/page.tsx
@@ -6,7 +6,7 @@ import { requireAdmin } from "@/lib/admin";
 import { conversionsReport, isPeriod, type Period, type RatePoint } from "@/lib/conversions";
 import type { EmailClass } from "@/lib/growth";
 import { Badge, Card, SectionHeading, StatCard } from "@/components/ui";
-import { timeAgo } from "@/lib/utils";
+import { duration, timeAgo } from "@/lib/utils";
 import { PeriodSelect } from "./period-select";
 import { PERIOD_OPTIONS } from "./periods";
 
@@ -144,8 +144,12 @@ export default async function ConversionsPage({ searchParams }: { searchParams: 
         </Card>
       )}
 
-      {/* ---- Row 1: the numbers --------------------------------------------- */}
-      <div className="grid grid-cols-2 gap-4 lg:grid-cols-5">
+      {/* ---- Row 1: the connected rung --------------------------------------- */}
+      <section className="space-y-3">
+        <h3 className="text-sm font-medium uppercase tracking-wider text-ink-faint">
+          Connected · clicked out to another Letter product
+        </h3>
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
         <StatCard
           label="Connected rate"
           value={stats.rate === null ? "—" : `${stats.rate}%`}
@@ -171,16 +175,6 @@ export default async function ConversionsPage({ searchParams }: { searchParams: 
               : `${periodLabel} · ${stats.clicksAllTime.toLocaleString()} all time`
           }
           accent="butter"
-        />
-        <StatCard
-          label="Added API keys"
-          value={keyed.users.toLocaleString()}
-          hint={
-            period === "all"
-              ? `${keyed.rate === null ? "—" : `${keyed.rate}%`} of ${stats.totalUsers.toLocaleString()} signups brought their own`
-              : `first key in ${periodLabel} · ${keyed.allTime.toLocaleString()} all time, ${keyed.rate === null ? "—" : `${keyed.rate}%`} of signups`
-          }
-          accent="terracotta"
         />
         <StatCard
           label="Top destination"
@@ -215,7 +209,51 @@ export default async function ConversionsPage({ searchParams }: { searchParams: 
           }
           accent="sand"
         />
-      </div>
+        </div>
+      </section>
+
+      {/* ---- Row 1b: the activation rung -------------------------------------
+          A rung up from a click: the trial runs on the operator's shared keys,
+          so pasting your own is where an account stops costing us money. The
+          rate is deliberately all-time on both sides — activation is a stock,
+          "how many of everyone who ever signed up now have a key", and
+          dividing this period's converters by every signup ever would read as
+          a rate that collapses whenever the window narrows. */}
+      <section className="space-y-3">
+        <h3 className="text-sm font-medium uppercase tracking-wider text-ink-faint">
+          Activated · connected their own API key
+        </h3>
+        <div className="grid grid-cols-2 gap-4 lg:grid-cols-3">
+          <StatCard
+            label="API-key activation"
+            value={keyed.rate === null ? "—" : `${keyed.rate}%`}
+            hint={`${keyed.allTime.toLocaleString()} of ${stats.totalUsers.toLocaleString()} accounts have connected at least one key · all time`}
+            accent="terracotta"
+          />
+          <StatCard
+            label="Added API keys"
+            value={keyed.users.toLocaleString()}
+            hint={
+              period === "all"
+                ? "accounts, counted once on their first key"
+                : `first key in ${periodLabel} · ${keyed.allTime.toLocaleString()} all time`
+            }
+            accent="teal"
+          />
+          <StatCard
+            label="Time to first key"
+            value={duration(keyed.medianMs ?? keyed.medianAllTimeMs)}
+            hint={
+              keyed.medianMs === null
+                ? keyed.medianAllTimeMs === null
+                  ? "nobody has connected a key yet"
+                  : `median signup → first key · all time (nobody activated in ${periodLabel})`
+                : `median signup → first key, ${keyed.users.toLocaleString()} account${keyed.users === 1 ? "" : "s"} · ${periodLabel} · ${duration(keyed.medianAllTimeMs)} all time`
+            }
+            accent="butter"
+          />
+        </div>
+      </section>
 
       {/* ---- Row 2: the rate over time ---------------------------------------- */}
       <Card>
@@ -324,9 +362,10 @@ export default async function ConversionsPage({ searchParams }: { searchParams: 
         Connected means &ldquo;clicked one of our outbound product links while signed
         in&rdquo; — visits that start anywhere else are invisible here, and clicking is not
         signing up or paying, which will be measured separately. Links are counted when wrapped
-        in OutboundLink; today that is the Phantoms item in the dashboard nav. Added API keys
-        counts an account once, on its first provider or router key: the trial runs on our
-        shared keys, so pasting your own is the rung where an account stops costing us money.{" "}
+        in OutboundLink; today that is the Phantoms item in the dashboard nav. Activation counts
+        an account once, on its first provider or router key, and time to first key is a median
+        over the accounts that connected one — it says nothing about the ones that never did,
+        which is what the activation rate is for.{" "}
         <Link href="/admin/growth" className="underline">
           Back to growth
         </Link>

--- a/app/admin/conversions/page.tsx
+++ b/app/admin/conversions/page.tsx
@@ -24,7 +24,7 @@ export const metadata = { robots: { index: false, follow: false } };
  * pays for a product — get their own words when we can measure them, which is
  * why nothing on this page says "converted" about a mere click.
  *
- * Deliberately small for now: one row of numbers, one table.
+ * Deliberately small for now: one row of numbers, one chart, one table.
  */
 
 const CLASS_TONE: Record<EmailClass, "teal" | "sand" | "terracotta"> = {
@@ -122,7 +122,7 @@ export default async function ConversionsPage({ searchParams }: { searchParams: 
 
   const period = periodFrom(searchParams);
   const periodLabel = PERIOD_OPTIONS.find((o) => o.value === period)!.label.toLowerCase();
-  const { stats, series, connected, degraded } = await conversionsReport(period);
+  const { stats, keyed, series, connected, degraded } = await conversionsReport(period);
   const latest = series.filter((p) => p.rate !== null).at(-1);
   const peak = series.reduce((a, b) => ((b.rate ?? -1) > (a?.rate ?? -1) ? b : a), latest);
   const today = new Date().toISOString().slice(0, 10);
@@ -131,7 +131,7 @@ export default async function ConversionsPage({ searchParams }: { searchParams: 
     <div className="space-y-10">
       <SectionHeading
         title="Conversions"
-        description="Who goes from lettertrace to another Letter Company product. Today this measures connected users — clicked one of our outbound links; signups and paying customers become their own rungs once we can measure them. Emails are in the clear: this is a cross-sell list."
+        description="The rungs an account climbs: connected — clicked one of our outbound links — and keyed, where they paste their own API key and stop running on our shared trial. Signups on the other products and paying customers get their own rungs once we can measure them. Emails are in the clear: this is a cross-sell list."
         action={<PeriodSelect value={period} />}
       />
 
@@ -145,7 +145,7 @@ export default async function ConversionsPage({ searchParams }: { searchParams: 
       )}
 
       {/* ---- Row 1: the numbers --------------------------------------------- */}
-      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-5">
         <StatCard
           label="Connected rate"
           value={stats.rate === null ? "—" : `${stats.rate}%`}
@@ -171,6 +171,16 @@ export default async function ConversionsPage({ searchParams }: { searchParams: 
               : `${periodLabel} · ${stats.clicksAllTime.toLocaleString()} all time`
           }
           accent="butter"
+        />
+        <StatCard
+          label="Added API keys"
+          value={keyed.users.toLocaleString()}
+          hint={
+            period === "all"
+              ? `${keyed.rate === null ? "—" : `${keyed.rate}%`} of ${stats.totalUsers.toLocaleString()} signups brought their own`
+              : `first key in ${periodLabel} · ${keyed.allTime.toLocaleString()} all time, ${keyed.rate === null ? "—" : `${keyed.rate}%`} of signups`
+          }
+          accent="terracotta"
         />
         <StatCard
           label="Top destination"
@@ -314,7 +324,9 @@ export default async function ConversionsPage({ searchParams }: { searchParams: 
         Connected means &ldquo;clicked one of our outbound product links while signed
         in&rdquo; — visits that start anywhere else are invisible here, and clicking is not
         signing up or paying, which will be measured separately. Links are counted when wrapped
-        in OutboundLink; today that is the Phantoms item in the dashboard nav.{" "}
+        in OutboundLink; today that is the Phantoms item in the dashboard nav. Added API keys
+        counts an account once, on its first provider or router key: the trial runs on our
+        shared keys, so pasting your own is the rung where an account stops costing us money.{" "}
         <Link href="/admin/growth" className="underline">
           Back to growth
         </Link>

--- a/app/admin/growth/page.tsx
+++ b/app/admin/growth/page.tsx
@@ -97,7 +97,7 @@ export default async function GrowthPage({ searchParams }: { searchParams: SP })
   if (!admin) notFound();
 
   const report = await growthReport();
-  const { activity } = report;
+  const { activity, signups, retention } = report;
   const filter = leadFilterFrom(searchParams);
   const leads = report.leads.filter(filter.pick);
   const leadCounts = new Map(LEAD_FILTERS.map((f) => [f.key, report.leads.filter(f.pick).length]));
@@ -120,8 +120,11 @@ export default async function GrowthPage({ searchParams }: { searchParams: SP })
         </Card>
       )}
 
-      {/* ---- Row 1: the numbers --------------------------------------------- */}
-      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+      {/* ---- Row 1: the numbers ---------------------------------------------
+          Six cards on a three-wide grid: the activity windows across the top,
+          and the three ratios that judge them underneath — how many arrived,
+          how many came back, how concentrated the usage is. */}
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-3">
         <StatCard
           label="Daily active"
           value={activity.daily.users.toLocaleString()}
@@ -141,9 +144,25 @@ export default async function GrowthPage({ searchParams }: { searchParams: SP })
           accent="butter"
         />
         <StatCard
+          label="New sign-ups"
+          value={signups.monthly.toLocaleString()}
+          hint={`rolling 30d · ${signups.weekly.toLocaleString()} in 7d · ${signups.daily.toLocaleString()} in 24h`}
+          accent="terracotta"
+        />
+        <StatCard
+          label="Returning users"
+          value={retention.rate === null ? "—" : `${retention.rate}%`}
+          hint={
+            retention.active === 0
+              ? "nobody has run in 30d"
+              : `${retention.returning.toLocaleString()} of ${retention.active.toLocaleString()} active users ran on 2+ days · 30d`
+          }
+          accent="mint"
+        />
+        <StatCard
           label="Stickiness"
           value={activity.stickiness === null ? "—" : `${activity.stickiness}%`}
-          hint={`DAU / MAU · ${report.totalUsers.toLocaleString()} signups total`}
+          hint={`DAU / MAU · ${signups.total.toLocaleString()} signups total`}
           accent="sand"
         />
       </div>
@@ -350,8 +369,11 @@ export default async function GrowthPage({ searchParams }: { searchParams: SP })
       </section>
 
       <p className="text-xs text-ink-faint">
-        Active means “fired a run”, not “signed in”. Email classes: work = company domain,
-        personal = consumer providers, burner = disposable inboxes.{" "}
+        Active means “fired a run”, not “signed in”, and returning means “ran on two or
+        more separate days” — five runs in one afternoon is one evaluation session, not a
+        return. New sign-ups is the one figure counted off accounts rather than runs: the gap
+        between it and daily active is the activation problem. Email classes: work = company
+        domain, personal = consumer providers, burner = disposable inboxes.{" "}
         <Link href="/admin" className="underline">
           Back to operations
         </Link>

--- a/lib/conversions.test.ts
+++ b/lib/conversions.test.ts
@@ -5,6 +5,7 @@ import {
   normalizeProductUrl,
   periodStart,
   productOf,
+  median,
   shapeConversionStats,
   shapeConnectedUsers,
   shapeKeyedStats,
@@ -267,28 +268,85 @@ describe("shapeKeyedStats", () => {
     { user_id: "u2", created_at: iso(5) },
     { user_id: "u3", created_at: iso(0, 2) },
   ];
+  // u1 took 10 days, u2 took 2 days, u3 took 1 hour. 47 more signups with no
+  // key, so the denominator is 50.
+  const keyed: GrowthProfileRow[] = [
+    { id: "u1", email: "a@x.com", created_at: iso(50) },
+    { id: "u2", email: "b@x.com", created_at: iso(7) },
+    { id: "u3", email: "c@x.com", created_at: iso(0, 3) },
+  ];
+  const profiles: GrowthProfileRow[] = [
+    ...keyed,
+    ...Array.from({ length: 47 }, (_, i) => ({
+      id: `n${i}`,
+      email: null,
+      created_at: iso(10),
+    })),
+  ];
 
   it("counts a user by their first key, once", () => {
-    expect(shapeKeyedStats(keys, 50, NOW - 30 * DAY_MS)).toEqual({
-      users: 2,
-      allTime: 3,
-      rate: 6,
-    });
+    const stats = shapeKeyedStats(keys, profiles, NOW - 30 * DAY_MS);
+    expect(stats.users).toBe(2);
+    expect(stats.allTime).toBe(3);
   });
 
   it("counts everyone for an all-time period", () => {
-    expect(shapeKeyedStats(keys, 50, null)).toEqual({ users: 3, allTime: 3, rate: 6 });
+    expect(shapeKeyedStats(keys, profiles, null).users).toBe(3);
+  });
+
+  it("keeps the activation rate all-time on both sides of the fraction", () => {
+    // 3 of 50 accounts have a key, whatever window is being viewed.
+    expect(shapeKeyedStats(keys, profiles, NOW - 30 * DAY_MS).rate).toBe(6);
+    expect(shapeKeyedStats(keys, profiles, null).rate).toBe(6);
   });
 
   it("keeps one decimal so an early rate does not round to zero", () => {
-    expect(shapeKeyedStats([{ user_id: "u1", created_at: iso(1) }], 2000, null).rate).toBe(0.1);
+    const many = Array.from({ length: 2000 }, (_, i) => ({
+      id: `n${i}`,
+      email: null,
+      created_at: iso(5),
+    }));
+    expect(shapeKeyedStats([{ user_id: "n0", created_at: iso(1) }], many, null).rate).toBe(0.1);
+  });
+
+  it("medians the signup-to-first-key gap over the period cohort", () => {
+    // In the last 30 days: u2 (2 days) and u3 (1 hour). Two values, so the
+    // median averages them.
+    const stats = shapeKeyedStats(keys, profiles, NOW - 30 * DAY_MS);
+    expect(stats.medianMs).toBe(Math.round((2 * DAY_MS + 3_600_000) / 2));
+    // All time adds u1's 10 days, making three values with 2 days in the middle.
+    expect(stats.medianAllTimeMs).toBe(2 * DAY_MS);
+  });
+
+  it("nulls the period median when nobody activated in it, keeping the all-time one", () => {
+    const stats = shapeKeyedStats(keys, profiles, NOW + DAY_MS);
+    expect(stats.users).toBe(0);
+    expect(stats.medianMs).toBeNull();
+    expect(stats.medianAllTimeMs).toBe(2 * DAY_MS);
+  });
+
+  it("still counts a key whose owner has no profile row, but draws no gap from it", () => {
+    const orphan: KeyRow[] = [{ user_id: "gone", created_at: iso(1) }];
+    const stats = shapeKeyedStats(orphan, profiles, null);
+    expect(stats.allTime).toBe(1);
+    expect(stats.medianMs).toBeNull();
   });
 
   it("skips unparseable timestamps and nulls the rate with no users", () => {
-    expect(shapeKeyedStats([{ user_id: "u1", created_at: "nope" }], 0, null)).toEqual({
+    expect(shapeKeyedStats([{ user_id: "u1", created_at: "nope" }], [], null)).toEqual({
       users: 0,
       allTime: 0,
       rate: null,
+      medianMs: null,
+      medianAllTimeMs: null,
     });
+  });
+});
+
+describe("median", () => {
+  it("takes the middle of an odd count and averages the two middles of an even one", () => {
+    expect(median([5, 1, 3])).toBe(3);
+    expect(median([4, 1, 3, 2])).toBe(3);
+    expect(median([])).toBeNull();
   });
 });

--- a/lib/conversions.test.ts
+++ b/lib/conversions.test.ts
@@ -7,7 +7,9 @@ import {
   productOf,
   shapeConversionStats,
   shapeConnectedUsers,
+  shapeKeyedStats,
   shapeRateSeries,
+  type KeyRow,
   type OutboundClickRow,
 } from "./conversions";
 import type { GrowthProfileRow } from "./growth";
@@ -253,5 +255,40 @@ describe("shapeConnectedUsers", () => {
       expect(c.email).toBeNull();
       expect(c.emailClass).toBe("personal");
     }
+  });
+});
+
+describe("shapeKeyedStats", () => {
+  const keys: KeyRow[] = [
+    // u1 converted 40 days ago and added a second key inside the window; the
+    // period must still credit them to the older date, not count them twice.
+    { user_id: "u1", created_at: iso(40) },
+    { user_id: "u1", created_at: iso(3) },
+    { user_id: "u2", created_at: iso(5) },
+    { user_id: "u3", created_at: iso(0, 2) },
+  ];
+
+  it("counts a user by their first key, once", () => {
+    expect(shapeKeyedStats(keys, 50, NOW - 30 * DAY_MS)).toEqual({
+      users: 2,
+      allTime: 3,
+      rate: 6,
+    });
+  });
+
+  it("counts everyone for an all-time period", () => {
+    expect(shapeKeyedStats(keys, 50, null)).toEqual({ users: 3, allTime: 3, rate: 6 });
+  });
+
+  it("keeps one decimal so an early rate does not round to zero", () => {
+    expect(shapeKeyedStats([{ user_id: "u1", created_at: iso(1) }], 2000, null).rate).toBe(0.1);
+  });
+
+  it("skips unparseable timestamps and nulls the rate with no users", () => {
+    expect(shapeKeyedStats([{ user_id: "u1", created_at: "nope" }], 0, null)).toEqual({
+      users: 0,
+      allTime: 0,
+      rate: null,
+    });
   });
 });

--- a/lib/conversions.ts
+++ b/lib/conversions.ts
@@ -186,8 +186,27 @@ export interface KeyedStats {
   /** Users with at least one key, ever. */
   allTime: number;
   /** allTime / totalUsers as a percentage with one decimal, null until there is
-   *  anyone to divide by. Same one-decimal reasoning as the connected rate. */
+   *  anyone to divide by. Same one-decimal reasoning as the connected rate.
+   *  Deliberately all-time on both sides: activation is a STOCK — the share of
+   *  everyone who ever signed up that now has a key — and dividing a period's
+   *  converters by every signup ever would read as a collapsing rate. */
   rate: number | null;
+  /** Median milliseconds from signing up to connecting the first key, over the
+   *  users whose first key landed in the period. Null when that cohort is
+   *  empty, or when none of them can be matched to a signup time. */
+  medianMs: number | null;
+  /** The same median over everyone who ever connected a key — the stable
+   *  number, since a narrow period's median rests on very few people. */
+  medianAllTimeMs: number | null;
+}
+
+/** The middle value, averaging the two middles on an even count. Its own
+ *  function so the two medians above can't drift apart. */
+export function median(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = sorted.length >> 1;
+  return sorted.length % 2 === 1 ? sorted[mid] : Math.round((sorted[mid - 1] + sorted[mid]) / 2);
 }
 
 /**
@@ -204,7 +223,7 @@ export interface KeyedStats {
  */
 export function shapeKeyedStats(
   keys: KeyRow[],
-  totalUsers: number,
+  profiles: GrowthProfileRow[],
   since: number | null,
 ): KeyedStats {
   const firstByUser = new Map<string, number>();
@@ -215,13 +234,35 @@ export function shapeKeyedStats(
     if (prev === undefined || t < prev) firstByUser.set(key.user_id, t);
   }
 
+  const signedUpAt = new Map<string, number>();
+  for (const profile of profiles) {
+    const t = Date.parse(profile.created_at);
+    if (Number.isFinite(t)) signedUpAt.set(profile.id, t);
+  }
+
   let inPeriod = 0;
-  for (const t of firstByUser.values()) if (since === null || t >= since) inPeriod += 1;
+  const gapsInPeriod: number[] = [];
+  const gapsAllTime: number[] = [];
+  for (const [userId, firstKeyAt] of firstByUser) {
+    const started = signedUpAt.get(userId);
+    // A key whose owner has no profile row (deleted account, or a profile the
+    // cap cut off) still counts as a key — it just can't contribute a gap.
+    // Negative gaps can't happen from a real signup, so they'd be clock skew:
+    // dropped rather than pulled toward zero.
+    const gap = started === undefined ? null : firstKeyAt - started;
+    if (gap !== null && gap >= 0) gapsAllTime.push(gap);
+    if (since === null || firstKeyAt >= since) {
+      inPeriod += 1;
+      if (gap !== null && gap >= 0) gapsInPeriod.push(gap);
+    }
+  }
 
   return {
     users: inPeriod,
     allTime: firstByUser.size,
-    rate: totalUsers > 0 ? Math.round((firstByUser.size / totalUsers) * 1000) / 10 : null,
+    rate: profiles.length > 0 ? Math.round((firstByUser.size / profiles.length) * 1000) / 10 : null,
+    medianMs: median(gapsInPeriod),
+    medianAllTimeMs: median(gapsAllTime),
   };
 }
 
@@ -406,7 +447,7 @@ export async function conversionsReport(
 
   return {
     stats: shapeConversionStats(clicks, profiles.length, since),
-    keyed: shapeKeyedStats(keys, profiles.length, since),
+    keyed: shapeKeyedStats(keys, profiles, since),
     series: shapeRateSeries(clicks, profiles, since, now),
     // The table reads through the same window: destinations, counts and
     // first/latest are period-scoped, so it always agrees with the cards.

--- a/lib/conversions.ts
+++ b/lib/conversions.ts
@@ -75,6 +75,14 @@ export interface OutboundClickRow {
   clicked_at: string;
 }
 
+/** A BYOK credential row, from provider_keys OR router_keys — the two tables
+ *  are separate because a router is not an answer engine (see the schema), but
+ *  for "did this account bring its own key?" they are the same event. */
+export interface KeyRow {
+  user_id: string;
+  created_at: string;
+}
+
 // ---------------------------------------------------------------------------
 // Periods
 // ---------------------------------------------------------------------------
@@ -165,6 +173,55 @@ export function shapeConversionStats(
     connectedAllTime: allUsers.size,
     clicksAllTime: clicks.length,
     topProduct: top ? { product: top[0], clicks: top[1] } : null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Brought their own keys
+// ---------------------------------------------------------------------------
+
+export interface KeyedStats {
+  /** Users whose FIRST key landed inside the period — the conversion event. */
+  users: number;
+  /** Users with at least one key, ever. */
+  allTime: number;
+  /** allTime / totalUsers as a percentage with one decimal, null until there is
+   *  anyone to divide by. Same one-decimal reasoning as the connected rate. */
+  rate: number | null;
+}
+
+/**
+ * How many accounts added their own API keys.
+ *
+ * A rung above CONNECTED and below paying: the trial runs on the operator's
+ * shared keys, so pasting your own key is the moment an account stops costing
+ * us money and starts intending to keep using the product.
+ *
+ * Period-scoping counts each user by their FIRST key, not by every key they
+ * add — someone who pastes Anthropic in July and OpenAI in August converted
+ * once, in July, and should not show up again in August's number. The all-time
+ * stock comes back alongside so a narrow period keeps its context.
+ */
+export function shapeKeyedStats(
+  keys: KeyRow[],
+  totalUsers: number,
+  since: number | null,
+): KeyedStats {
+  const firstByUser = new Map<string, number>();
+  for (const key of keys) {
+    const t = Date.parse(key.created_at);
+    if (!Number.isFinite(t)) continue;
+    const prev = firstByUser.get(key.user_id);
+    if (prev === undefined || t < prev) firstByUser.set(key.user_id, t);
+  }
+
+  let inPeriod = 0;
+  for (const t of firstByUser.values()) if (since === null || t >= since) inPeriod += 1;
+
+  return {
+    users: inPeriod,
+    allTime: firstByUser.size,
+    rate: totalUsers > 0 ? Math.round((firstByUser.size / totalUsers) * 1000) / 10 : null,
   };
 }
 
@@ -303,6 +360,7 @@ export function shapeConnectedUsers(
 
 export interface ConversionsReport {
   stats: ConversionStats;
+  keyed: KeyedStats;
   series: RatePoint[];
   connected: ConnectedUser[];
   /** Set when a query failed — the page says "incomplete", never fake zero. */
@@ -319,24 +377,36 @@ export async function conversionsReport(
 ): Promise<ConversionsReport> {
   const svc = createServiceClient();
 
-  const [clicksQ, profilesQ] = await Promise.all([
+  // All keys, all time: the period filter applies to a user's FIRST key, which
+  // can only be found by looking at every row they have.
+  const [clicksQ, profilesQ, providerKeysQ, routerKeysQ] = await Promise.all([
     svc
       .from("outbound_clicks")
       .select("user_id, url, clicked_at")
       .order("clicked_at", { ascending: false })
       .limit(ROWS_CAP),
     svc.from("profiles").select("id, email, created_at").limit(ROWS_CAP),
+    svc.from("provider_keys").select("user_id, created_at").limit(ROWS_CAP),
+    svc.from("router_keys").select("user_id, created_at").limit(ROWS_CAP),
   ]);
 
-  const failed = [clicksQ.error && "outbound_clicks", profilesQ.error && "profiles"].filter(
-    Boolean,
-  );
+  const failed = [
+    clicksQ.error && "outbound_clicks",
+    profilesQ.error && "profiles",
+    providerKeysQ.error && "provider_keys",
+    routerKeysQ.error && "router_keys",
+  ].filter(Boolean);
   const clicks = (clicksQ.data ?? []) as OutboundClickRow[];
   const profiles = (profilesQ.data ?? []) as GrowthProfileRow[];
+  const keys = [
+    ...((providerKeysQ.data ?? []) as KeyRow[]),
+    ...((routerKeysQ.data ?? []) as KeyRow[]),
+  ];
   const since = periodStart(period, now);
 
   return {
     stats: shapeConversionStats(clicks, profiles.length, since),
+    keyed: shapeKeyedStats(keys, profiles.length, since),
     series: shapeRateSeries(clicks, profiles, since, now),
     // The table reads through the same window: destinations, counts and
     // first/latest are period-scoped, so it always agrees with the cards.

--- a/lib/growth.test.ts
+++ b/lib/growth.test.ts
@@ -5,6 +5,8 @@ import {
   shapeActivity,
   shapeLeads,
   shapeRecentRuns,
+  shapeRetention,
+  shapeSignups,
   shapeTopAccounts,
   type GrowthProfileRow,
   type GrowthProjectRow,
@@ -216,5 +218,66 @@ describe("shapeLeads", () => {
   it("drops accounts without an email — they cannot be contacted", () => {
     const profiles: GrowthProfileRow[] = [{ id: "u9", email: null, created_at: iso(1) }];
     expect(shapeLeads([], [], profiles, NOW)).toHaveLength(0);
+  });
+});
+
+describe("shapeSignups", () => {
+  it("counts profiles per rolling window, plus the all-time total", () => {
+    const profiles: GrowthProfileRow[] = [
+      { id: "a", email: "a@x.com", created_at: iso(0, 2) },
+      { id: "b", email: "b@x.com", created_at: iso(3) },
+      { id: "c", email: "c@x.com", created_at: iso(20) },
+      { id: "d", email: "d@x.com", created_at: iso(90) },
+    ];
+    expect(shapeSignups(profiles, NOW)).toEqual({
+      daily: 1,
+      weekly: 2,
+      monthly: 3,
+      total: 4,
+    });
+  });
+
+  it("ignores unparseable and future timestamps in the windows", () => {
+    const profiles: GrowthProfileRow[] = [
+      { id: "a", email: null, created_at: "not a date" },
+      { id: "b", email: null, created_at: new Date(NOW + DAY_MS).toISOString() },
+    ];
+    // Still both real accounts, so total counts them — the windows do not.
+    expect(shapeSignups(profiles, NOW)).toEqual({ daily: 0, weekly: 0, monthly: 0, total: 2 });
+  });
+});
+
+describe("shapeRetention", () => {
+  const owner = new Map([
+    ["proj-a", "u1"],
+    ["proj-b", "u2"],
+    ["proj-c", "u2"],
+  ]);
+
+  it("counts a user as returning only on a second distinct UTC day", () => {
+    const runs = [
+      // u1: three runs, all the same day — one session, not a return.
+      run({ project_id: "proj-a", created_at: iso(2, 1) }),
+      run({ project_id: "proj-a", created_at: iso(2, 2) }),
+      run({ project_id: "proj-a", created_at: iso(2, 3) }),
+      // u2: two days, across two different projects — returned.
+      run({ project_id: "proj-b", created_at: iso(5) }),
+      run({ project_id: "proj-c", created_at: iso(9) }),
+    ];
+    expect(shapeRetention(runs, owner, NOW)).toEqual({ active: 2, returning: 1, rate: 50 });
+  });
+
+  it("drops runs outside the 30d window and runs with no owner", () => {
+    const runs = [
+      run({ project_id: "proj-a", created_at: iso(1) }),
+      run({ project_id: "proj-a", created_at: iso(40) }),
+      run({ project_id: "proj-gone", created_at: iso(1) }),
+      run({ project_id: "proj-gone", created_at: iso(2) }),
+    ];
+    expect(shapeRetention(runs, owner, NOW)).toEqual({ active: 1, returning: 0, rate: 0 });
+  });
+
+  it("returns a null rate rather than 0% when nobody is active", () => {
+    expect(shapeRetention([], owner, NOW)).toEqual({ active: 0, returning: 0, rate: null });
   });
 });

--- a/lib/growth.ts
+++ b/lib/growth.ts
@@ -253,6 +253,88 @@ export function shapeActivity(
 }
 
 // ---------------------------------------------------------------------------
+// Signups
+// ---------------------------------------------------------------------------
+
+export interface Signups {
+  /** New profiles in the rolling 24h / 7d / 30d, same windows as activity. */
+  daily: number;
+  weekly: number;
+  monthly: number;
+  /** Every profile ever — the denominator the other pages divide by. */
+  total: number;
+}
+
+/** New accounts per rolling window. Counted off profiles.created_at, which the
+ *  signup trigger stamps, so this is "made an account", not "ran anything" —
+ *  the one number on this page that is deliberately NOT measured in runs,
+ *  because the gap between it and daily active IS the activation problem. */
+export function shapeSignups(profiles: GrowthProfileRow[], now: number): Signups {
+  const cutoffs = { daily: now - DAY_MS, weekly: now - 7 * DAY_MS, monthly: now - 30 * DAY_MS };
+  const counts = { daily: 0, weekly: 0, monthly: 0 };
+  for (const profile of profiles) {
+    const t = Date.parse(profile.created_at);
+    if (!Number.isFinite(t) || t > now) continue;
+    for (const key of ["daily", "weekly", "monthly"] as const) {
+      if (t >= cutoffs[key]) counts[key] += 1;
+    }
+  }
+  return { ...counts, total: profiles.length };
+}
+
+// ---------------------------------------------------------------------------
+// Returning users
+// ---------------------------------------------------------------------------
+
+export interface Retention {
+  /** Distinct users with at least one run in the last 30 days. */
+  active: number;
+  /** Of those, the ones who came back: runs on two or more distinct UTC days. */
+  returning: number;
+  /** returning / active as a whole percentage, null with nobody active. */
+  rate: number | null;
+}
+
+/** The share of active users who came back on a second day.
+ *
+ *  "Returning" needs a return TO something, and for a visibility tracker that
+ *  something is a run — so a returning user is one who fired runs on two or
+ *  more distinct UTC days inside the 30d window, not one who merely signed in
+ *  twice. Distinct days rather than run count on purpose: five runs in one
+ *  afternoon is a single evaluation session, and the question here is whether
+ *  anyone came back the next day.
+ *
+ *  Scheduled runs count, and that is deliberate: a user whose weekly schedule
+ *  keeps firing is retained even when they never open the app. */
+export function shapeRetention(
+  runs: GrowthRunRow[],
+  projectOwner: Map<string, string>,
+  now: number,
+): Retention {
+  const cutoff = now - 30 * DAY_MS;
+  const daysByUser = new Map<string, Set<string>>();
+
+  for (const run of runs) {
+    const t = Date.parse(run.created_at);
+    const owner = projectOwner.get(run.project_id);
+    if (!owner || !Number.isFinite(t) || t < cutoff || t > now) continue;
+    const days = daysByUser.get(owner) ?? new Set<string>();
+    days.add(utcDay(run.created_at));
+    daysByUser.set(owner, days);
+  }
+
+  const active = daysByUser.size;
+  let returning = 0;
+  for (const days of daysByUser.values()) if (days.size >= 2) returning += 1;
+
+  return {
+    active,
+    returning,
+    rate: active > 0 ? Math.round((returning / active) * 100) : null,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Most active accounts
 // ---------------------------------------------------------------------------
 
@@ -437,6 +519,8 @@ export function shapeLeads(
 
 export interface GrowthReport {
   activity: Activity;
+  signups: Signups;
+  retention: Retention;
   topAccounts: TopAccount[];
   recentRuns: RecentRun[];
   leads: Lead[];
@@ -493,6 +577,8 @@ export async function growthReport(now = Date.now()): Promise<GrowthReport> {
 
   return {
     activity: shapeActivity(runs, projectOwner, now),
+    signups: shapeSignups(profiles, now),
+    retention: shapeRetention(runs, projectOwner, now),
     topAccounts: shapeTopAccounts(runs, projects, profiles),
     recentRuns: shapeRecentRuns(runs, projects, profiles),
     leads: shapeLeads(runs, projects, profiles, now),

--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { article, resolveRedirectBase, safePath } from "@/lib/utils";
+import { article, duration, resolveRedirectBase, safePath } from "@/lib/utils";
 
 describe("resolveRedirectBase", () => {
   const PROD = "https://lettertrace.com";
@@ -95,5 +95,27 @@ describe("article", () => {
   it("ignores case and leading space", () => {
     expect(article("  openai")).toBe("an");
     expect(article("GOOGLE")).toBe("a");
+  });
+});
+
+describe("duration", () => {
+  it("picks one unit and rounds to it", () => {
+    expect(duration(30_000)).toBe("<1m");
+    expect(duration(9 * 60_000)).toBe("9m");
+    expect(duration(3 * 3_600_000)).toBe("3h");
+    expect(duration(5 * 86_400_000)).toBe("5d");
+    expect(duration(120 * 86_400_000)).toBe("4mo");
+  });
+
+  it("crosses over at 48h and 60d rather than at the unit boundary", () => {
+    // 36 hours is more legibly "36h" than "2d"; 47 days than "2mo".
+    expect(duration(36 * 3_600_000)).toBe("36h");
+    expect(duration(47 * 86_400_000)).toBe("47d");
+  });
+
+  it("renders an em dash for nothing to measure", () => {
+    expect(duration(null)).toBe("—");
+    expect(duration(-1)).toBe("—");
+    expect(duration(Number.NaN)).toBe("—");
   });
 });

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -26,6 +26,26 @@ export function timeAgo(iso: string | null): string {
   return new Date(iso).toLocaleDateString();
 }
 
+/**
+ * A span of time as a rounded, single-unit phrase: "3d", "14h", "6m".
+ *
+ * For durations that are ANSWERS rather than timestamps — how long something
+ * took — where timeAgo's "ago" would be wrong and a second decimal would be
+ * false precision. One unit only: a median of "2d 7h 14m" reads as a
+ * measurement of something it isn't.
+ */
+export function duration(ms: number | null): string {
+  if (ms === null || !Number.isFinite(ms) || ms < 0) return "—";
+  if (ms < 60_000) return "<1m";
+  const mins = Math.round(ms / 60_000);
+  if (mins < 60) return `${mins}m`;
+  const hrs = Math.round(mins / 60);
+  if (hrs < 48) return `${hrs}h`;
+  const days = Math.round(hrs / 24);
+  if (days < 60) return `${days}d`;
+  return `${Math.round(days / 30)}mo`;
+}
+
 function isLoopback(url: string): boolean {
   try {
     const host = new URL(url).hostname.toLowerCase();


### PR DESCRIPTION
Five numbers the admin dashboard was missing.

## Growth

The stat row was four cards of *is anyone using this* and nothing about where those users came from or whether they came back. Two more, so the row goes six wide on a three-column grid — activity windows on top, the ratios that judge them underneath.

**New sign-ups** — profiles created in the rolling 24h / 7d / 30d. The one figure on the page counted off accounts rather than runs, deliberately: the gap between it and daily active *is* the activation problem.

**Returning users** — of the users who ran in the last 30 days, the share who ran on two or more distinct UTC days. Distinct days rather than run count, because five runs in one afternoon is a single evaluation session and the question here is whether anyone came back the next day. Scheduled runs count: a weekly schedule that keeps firing is retention even when nobody opens the app.

## Conversions

Seven cards in one strip would read as an undifferentiated pile, so the row splits into two labelled rungs — the page has been measuring two different things all along.

**Connected** · clicked out to another Letter product — the four cards that were already there, unchanged.

**Activated** · connected their own API key — the rung between a click and a payment. The trial runs on the operator's shared keys, so pasting your own is the moment an account stops costing us money.

| Card | What it is |
|---|---|
| **API-key activation** | Share of *all* accounts that have ever connected at least one provider or router key. |
| **Added API keys** | Accounts that activated in the selected period, counted once on their **first** key. |
| **Time to first key** | Median gap from signup to first key for that cohort, with the all-time median alongside. |

Two judgment calls worth reviewing:

- **Activation rate is all-time on both sides of the fraction.** It's a stock, not a flow. Scoping the numerator to the period while the denominator stays "every signup ever" would show a rate that collapses whenever you narrow the window — a chart lying about a number that didn't move.
- **The median is over accounts that activated**, so it says nothing about the ones that never did. That's what the rate is for, and the footnote says so. A narrow period's median rests on very few people, hence the all-time companion in the hint.

Edge cases: a key whose owner has no profile row still counts as a key but contributes no gap; negative gaps would be clock skew, so they drop rather than pull the median toward zero.

## Shape

Same contract as the rest of `lib/growth.ts` and `lib/conversions.ts`: the shapers are pure and unit-tested, the loaders only fetch rows. A failed `provider_keys` or `router_keys` query joins the existing degraded banner rather than reading as a truthful zero. New `utils.duration()` formats a span as one rounded unit, crossing over at 48h and 60d rather than at the unit boundary — 36 hours reads better as "36h" than "2d".

25 new tests; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C2WtdEpikMDqzwv7or1m6E