### PR TITLE
Add sitemap.xml + robots.txt (index /blog)

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,20 @@
+import type { MetadataRoute } from "next";
+
+// robots.txt for lettertrace.com. Points crawlers at the sitemap (so /blog gets
+// discovered) and keeps them out of the authenticated app + machine surfaces —
+// those only ever return auth redirects to a bot, so there's nothing to index.
+const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL ?? "https://lettertrace.com").replace(/\/+$/, "");
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/api/", "/dashboard", "/admin", "/oauth", "/auth/", "/login", "/activate", "/invite/"],
+      },
+    ],
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,44 @@
+import type { MetadataRoute } from "next";
+import { isBlogConfigured, listPosts } from "@/lib/blog";
+
+// Public sitemap for lettertrace.com — the marketing surface plus every published
+// blog post. Search + AI engines fetch this to discover and re-crawl content, so
+// it's the backbone of getting /blog indexed.
+//
+// Only the PUBLIC pages belong here — never the authenticated app (/dashboard,
+// /login, /oauth, …) or token-gated routes (/invite/[token]). Blog URLs are added
+// only when the CMS blog is wired (isBlogConfigured), so a fork / self-host that
+// isn't serving the blog doesn't advertise 404ing /blog URLs.
+
+const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL ?? "https://lettertrace.com").replace(/\/+$/, "");
+
+// Refresh hourly so newly published posts appear without a redeploy (matches the
+// blog's own ISR tag/time-based revalidate in lib/blog.ts).
+export const revalidate = 3600;
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const now = new Date();
+  const entries: MetadataRoute.Sitemap = [
+    { url: `${SITE_URL}/`, lastModified: now, changeFrequency: "weekly", priority: 1 },
+    { url: `${SITE_URL}/privacy`, lastModified: now, changeFrequency: "yearly", priority: 0.3 },
+    { url: `${SITE_URL}/terms`, lastModified: now, changeFrequency: "yearly", priority: 0.3 },
+  ];
+
+  if (!isBlogConfigured()) return entries;
+
+  entries.push({ url: `${SITE_URL}/blog`, lastModified: now, changeFrequency: "daily", priority: 0.8 });
+
+  const posts = await listPosts();
+  for (const post of posts) {
+    if (!post.slug) continue;
+    const modified = post.updated_at ?? post.published_at;
+    entries.push({
+      url: `${SITE_URL}/blog/${post.slug}`,
+      lastModified: modified ? new Date(modified) : now,
+      changeFrequency: "weekly",
+      priority: 0.7,
+    });
+  }
+
+  return entries;
+}


### PR DESCRIPTION
## What

Adds `app/sitemap.ts` and `app/robots.ts` to lettertrace.com.

`https://lettertrace.com/sitemap.xml` was 404ing, which meant (1) Google/AI crawlers had no manifest to discover `/blog` posts from, and (2) the Enhance flow's internal-links stage had no sitemap to crawl for link targets.

## Sitemap

- Public marketing pages (`/`, `/privacy`, `/terms`) always; `/blog` + every published post only when the CMS blog is wired (`isBlogConfigured()`), so a fork / self-host never lists 404ing `/blog` URLs.
- Blog posts pulled from the CMS via `lib/blog.ts`, hourly ISR (`revalidate = 3600`) so new posts appear without a redeploy.
- Excludes the authenticated app + token-gated routes.

## Robots

Points crawlers at the sitemap and disallows `/api`, `/dashboard`, `/admin`, `/oauth`, `/auth`, `/login`, `/activate`, `/invite` (all auth-gated — nothing to index).

## Verify

`tsc` clean, `next build` passes; `/sitemap.xml` and `/robots.txt` both register as routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791147245&installation_model_id=431526&pr_number=170&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F170&signature=d6fca4cf33e43f36a3b451964d1b7088b7dc8caa51786ad998cef6e24a11f1a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->