### PR TITLE
(Fix): Line the logo up with the brand name field, not the label above it

### DIFF
--- a/app/dashboard/onboarding.tsx
+++ b/app/dashboard/onboarding.tsx
@@ -399,7 +399,12 @@ export function Onboarding() {
                   <img
                     src={imageUrl}
                     alt=""
-                    className="h-12 w-12 shrink-0 rounded border border-ink/10 bg-paper object-contain"
+                    // Sized and offset to sit flush against the name field
+                    // rather than the label above it: mt clears the Label
+                    // (text-sm 20px line-height + mb-1.5 6px = 26px), and the
+                    // box matches the Input's own height (py-2.5 twice + 20px
+                    // line-height + 2px border = 42px).
+                    className="mt-[26px] h-[42px] w-[42px] shrink-0 rounded border border-ink/10 bg-paper object-contain"
                     // Hotlinked from the customer's own domain, so it can 404
                     // or be blocked. Hiding beats a broken-image icon as the
                     // first thing they see of their own brand.


### PR DESCRIPTION
## What

`app/dashboard/onboarding.tsx` — the logo's `className`:

- `mt-[26px]` offsets past the Label above it (`text-sm` 20px line-height + `mb-1.5` 6px = 26px).
- `h-[42px] w-[42px]` replaces the arbitrary `h-12 w-12`, matching the Input's own rendered height (`py-2.5` twice + 20px line-height + 2px border = 42px).

## Verification

Live, via `getBoundingClientRect()` on the rendered elements: logo and input now share the same `top` and `bottom` to the pixel (delta 0 on both edges). Screenshotted against nytimes.com (thin logo) and a second site to confirm no regression when the image is wider or shorter than 42px — `object-contain` keeps it centered inside the fixed box either way.

## Scope

One file, one class-string change. No behavior, no new dependency, no test needed — it's a static Tailwind class on an `<img>` with no logic branch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791203494&installation_model_id=431526&pr_number=171&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F171&signature=a96f76bbee35a8e4c3b07e3eef11d390be45a2dd0765f8c154729fd90e63d3ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->