### PR TITLE
Add a Blog link to the landing nav and footer

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,6 +18,7 @@ import { Logo } from "@/components/logo";
 import { ThemeToggle } from "@/components/theme";
 import { InstallCli } from "@/components/install-cli";
 import { LetterCoTelemetry } from "@/components/letterco-telemetry";
+import { isBlogConfigured } from "@/lib/blog";
 import {
   FOUNDER_CALL_LANDING_SOURCE,
   founderCallUrl,
@@ -160,6 +161,9 @@ export default function LandingPage() {
   // not send its visitors to *our* founder's calendar. Unset means the section
   // does not exist.
   const bookingUrl = founderCallUrl();
+  // /blog is inert on forks / self-host (no CMS key + collection), so only
+  // surface the Blog link when the blog is actually configured.
+  const blogConfigured = isBlogConfigured();
 
   return (
     <div id="top" className="min-h-screen bg-paper text-ink">
@@ -174,6 +178,9 @@ export default function LandingPage() {
             <a href="#how" className="transition hover:text-ink">How it works</a>
             <a href="#features" className="transition hover:text-ink">Features</a>
             <a href="#open-source" className="transition hover:text-ink">Open source</a>
+            {blogConfigured ? (
+              <a href="/blog" className="transition hover:text-ink">Blog</a>
+            ) : null}
           </nav>
           <div className="flex items-center gap-2">
             <a
@@ -423,6 +430,7 @@ export default function LandingPage() {
               { label: "How it works", href: "#how" },
               { label: "Features", href: "#features" },
               { label: "Open source", href: "#open-source" },
+              ...(blogConfigured ? [{ label: "Blog", href: "/blog" }] : []),
             ]}
           />
           <FooterCol


### PR DESCRIPTION
## What

Adds a **Blog** link to the marketing landing page (`app/page.tsx`), surfacing the existing `/blog` CMS blog:

- **Desktop:** last item on the top-line nav, after "Open source".
- **Mobile:** the top nav is `hidden md:flex`, so it's added under the **Product** footer column (the mobile-reachable home for those links).

## Open-source-aware

Gated on `isBlogConfigured()` — the same check `/blog` itself uses to `notFound()` on forks/self-host with no CMS key + collection. So the link only appears where the blog actually resolves, and stays hidden on self-hosted deployments (mirrors how the founder-call offer is gated via `founderCallUrl()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791481778&installation_model_id=431526&pr_number=174&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F174&signature=2fca5b82ae3a4a4fdf48b19306b88cc322b73187b95ac91b0cb1d00341c8abdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->