### PR TITLE
Suggestions: hand the resolved route to the model call, and log the failures

### DIFF
--- a/app/api/competitors/suggest/route.ts
+++ b/app/api/competitors/suggest/route.ts
@@ -60,6 +60,10 @@ export async function POST(request: Request) {
       provider: key.provider,
       model: key.model,
       apiKey: key.apiKey!,
+      // A router credential (the Concentrate-funded free tier) only works
+      // through its gateway; resolveKey says which. Dropping this sent the
+      // router key straight to the provider, which refused it as invalid.
+      route: key.route,
       brandName: project.brand_name,
       brandDomain: project.brand_domains[0] ?? null,
       description: project.description,

--- a/app/api/onboarding/onboarding-suggest.test.ts
+++ b/app/api/onboarding/onboarding-suggest.test.ts
@@ -30,7 +30,8 @@ vi.mock("@/lib/trial", () => ({
   recordTrialSpend: vi.fn(),
 }));
 vi.mock("@/lib/pricing", () => ({ spendMicros: () => 0 }));
-vi.mock("@/lib/activity", () => ({ logDashboard: vi.fn() }));
+const logDashboard = vi.fn();
+vi.mock("@/lib/activity", () => ({ logDashboard: (...a: unknown[]) => logDashboard(...a) }));
 
 const { POST } = await import("@/app/api/onboarding/suggest/route");
 
@@ -235,5 +236,95 @@ describe("POST /api/onboarding/suggest — a model that outruns the route", () =
 
     expect(body.reason).toBeUndefined();
     expect(body.topics).toHaveLength(1);
+  });
+});
+
+// The free tier in production is funded through a Concentrate ROUTER key.
+// resolveKey returns that key together with `route` (which gateway to call);
+// this route used to drop the route and send the router key straight to
+// Anthropic, which refused it as an invalid key — every trial user's
+// onboarding then arrived with the identity filled in and no topics, and the
+// feed showed nothing at all, since only successes were logged.
+describe("POST /api/onboarding/suggest — router-funded trial", () => {
+  const ROUTED_TRIAL_KEY = {
+    source: "trial",
+    apiKey: "sk-cn-operator",
+    provider: "anthropic",
+    model: "claude-haiku-4-5",
+    route: { router: "concentrate", baseUrl: null },
+  };
+
+  it("hands the resolved route to the model call, not just the key", async () => {
+    resolveKey.mockResolvedValue(ROUTED_TRIAL_KEY);
+    const res = await POST(req({ domain: "acme.com" }));
+    expect((await res.json()).topics).toHaveLength(1);
+    expect(suggestFromSite).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: "sk-cn-operator",
+        model: "claude-haiku-4-5",
+        route: { router: "concentrate", baseUrl: null },
+      }),
+    );
+  });
+
+  it("still passes no route for a direct key", async () => {
+    await POST(req({ domain: "acme.com" }));
+    const call = suggestFromSite.mock.calls[0][0] as { route?: unknown };
+    expect(call.route).toBeUndefined();
+  });
+});
+
+describe("POST /api/onboarding/suggest — failures leave a trace", () => {
+  it("logs a model failure with the error text, and still answers 200 with the identity", async () => {
+    suggestFromSite.mockRejectedValue(new Error("Invalid API key."));
+    const res = await POST(req({ domain: "acme.com" }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ reason: "ai_failed", brandName: "Acme", topics: [] });
+    expect(logDashboard).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "user-1" }),
+      expect.anything(),
+      expect.objectContaining({
+        action: "onboarding.suggest_failed",
+        status: "failure",
+        metadata: expect.objectContaining({ reason: "ai_failed", error: "Error: Invalid API key.", domain: "acme.com" }),
+      }),
+    );
+  });
+
+  it("logs a spent trial and a missing key by their reason", async () => {
+    resolveKey.mockResolvedValue({ source: "exhausted", provider: "anthropic", model: "m" });
+    await POST(req({ domain: "acme.com" }));
+    expect(logDashboard).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ metadata: expect.objectContaining({ reason: "trial_exhausted" }) }),
+    );
+    resolveKey.mockResolvedValue({ source: "none", provider: "anthropic", model: "m" });
+    await POST(req({ domain: "acme.com" }));
+    expect(logDashboard).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ metadata: expect.objectContaining({ reason: "no_key" }) }),
+    );
+  });
+
+  it("logs an unreadable site with the scraper's own error", async () => {
+    scrapeDomain.mockResolvedValue({ ok: false, error: "Site returned 503." });
+    await POST(req({ domain: "acme.com" }));
+    expect(logDashboard).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ metadata: expect.objectContaining({ reason: "scrape_failed", error: "Site returned 503." }) }),
+    );
+  });
+
+  it("never lets a logging failure change the response", async () => {
+    suggestFromSite.mockRejectedValue(new Error("boom"));
+    logDashboard.mockRejectedValue(new Error("activity table down"));
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = await POST(req({ domain: "acme.com" }));
+    expect(res.status).toBe(200);
+    expect((await res.json()).reason).toBe("ai_failed");
+    err.mockRestore();
   });
 });

--- a/app/api/onboarding/suggest/route.ts
+++ b/app/api/onboarding/suggest/route.ts
@@ -46,6 +46,32 @@ async function withDeadline<T>(work: Promise<T>, ms: number): Promise<T | null> 
   }
 }
 
+/**
+ * Record why a suggestion did NOT happen. Every failure below answers 200 with
+ * a `reason` so the wizard can keep the identity it already has, which also
+ * meant none of them left a trace: a broken free tier looked, from the feed,
+ * exactly like nobody onboarding. Best-effort, never blocks the response.
+ */
+async function logSuggestFailure(
+  user: { id: string; email?: string | null },
+  request: Request,
+  domain: string,
+  reason: string,
+  detail?: string | null,
+): Promise<void> {
+  try {
+    await logDashboard(user, request, {
+      category: "onboarding",
+      action: "onboarding.suggest_failed",
+      status: "failure",
+      summary: `Could not suggest topics for ${domain}: ${reason}${detail ? ` (${detail})` : ""}`,
+      metadata: { domain, reason, ...(detail ? { error: detail } : {}) },
+    });
+  } catch (err) {
+    console.error("[onboarding] suggest failure log failed:", err instanceof Error ? err.message : String(err));
+  }
+}
+
 // POST /api/onboarding/suggest { domain }
 // Reads the site and returns everything screen 2 needs: who the brand is (name,
 // description, icon) and what to monitor (topics with questions, competitors).
@@ -82,6 +108,7 @@ export async function POST(request: Request) {
   // filled in. Reporting "no key" for a site we could not read would also point
   // them at Settings when the thing they can actually fix is the URL.
   if (!scrape.ok || !scrape.text) {
+    await logSuggestFailure(user, request, domain, "scrape_failed", scrape.error);
     return NextResponse.json({
       scraped: false,
       brandName: "",
@@ -105,6 +132,12 @@ export async function POST(request: Request) {
 
   const key = await resolveKey(supabase, user.id, pickDefaultProvider());
   if (!key.apiKey) {
+    await logSuggestFailure(
+      user,
+      request,
+      domain,
+      key.source === "exhausted" ? "trial_exhausted" : "no_key",
+    );
     return NextResponse.json({
       ...identity,
       scraped: false,
@@ -120,12 +153,17 @@ export async function POST(request: Request) {
         provider: key.provider,
         model: key.model,
         apiKey: key.apiKey,
+        // The credential may be a router key (the Concentrate-funded free tier
+        // is one), and a router key sent straight to the provider is just an
+        // invalid key. resolveKey says where the call has to go; pass it on.
+        route: key.route,
         brandName,
         siteText: scrape.text,
       }),
       SUGGEST_DEADLINE_MS,
     );
     if (!suggestion) {
+      await logSuggestFailure(user, request, domain, "ai_timeout", `${SUGGEST_DEADLINE_MS}ms`);
       return NextResponse.json({
         ...identity,
         scraped: false,
@@ -167,6 +205,7 @@ export async function POST(request: Request) {
       competitors: suggestion.competitors,
     });
   } catch (e) {
+    await logSuggestFailure(user, request, domain, "ai_failed", humanError(e));
     return NextResponse.json({
       ...identity,
       scraped: false,

--- a/app/api/project/reanalyze/route.ts
+++ b/app/api/project/reanalyze/route.ts
@@ -82,6 +82,10 @@ export async function POST(request: Request) {
       provider: key.provider,
       model: key.model,
       apiKey: key.apiKey!,
+      // A router credential (the Concentrate-funded free tier) only works
+      // through its gateway; resolveKey says which. Dropping this sent the
+      // router key straight to the provider, which refused it as invalid.
+      route: key.route,
       brandName: project.brand_name,
       siteText,
       description: project.description,

--- a/app/api/suggestion-routes-route.test.ts
+++ b/app/api/suggestion-routes-route.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// The three sibling suggestion routes share the onboarding suggest route's
+// bug: each resolved a key through resolveKey — which, for the Concentrate-
+// funded free tier, is a ROUTER key plus a `route` saying which gateway to
+// call — and then handed the model call the key alone. A router key sent
+// straight to the provider is an invalid key, so every trial user's
+// re-analyze, competitor suggestion and question generation failed while
+// anyone holding their own key was fine. These pin that the route travels.
+
+const PROJECT = {
+  id: "proj-1",
+  user_id: "user-1",
+  name: "Acme",
+  brand_name: "Acme",
+  brand_aliases: [],
+  brand_domains: ["acme.com"],
+  description: "Payments for the internet",
+  default_provider: "anthropic",
+  default_model: "claude-sonnet-4-6",
+};
+
+const ROUTED_TRIAL_KEY = {
+  source: "trial",
+  apiKey: "sk-cn-operator",
+  provider: "anthropic",
+  model: "claude-haiku-4-5",
+  route: { router: "concentrate", baseUrl: null },
+};
+
+// A query builder that answers every table read with an empty list (no tracked
+// topics or competitors) except the one row the topics route looks up, and
+// records inserts so generated prompts come back as if saved.
+const TOPIC = { id: "topic-1", project_id: "proj-1", name: "Payments", description: null };
+function fakeSupabase() {
+  const build = (table: string) => {
+    const b: Record<string, unknown> = {};
+    for (const m of ["select", "eq", "insert"]) b[m] = () => b;
+    b.maybeSingle = async () => ({ data: table === "topics" ? TOPIC : null });
+    b.then = (ok: (v: unknown) => unknown) =>
+      Promise.resolve({ data: table === "prompts" ? [{ id: "p1" }] : [], error: null }).then(ok);
+    return b;
+  };
+  return {
+    auth: { getUser: async () => ({ data: { user: { id: "user-1", email: "a@b.com" } } }) },
+    from: (table: string) => build(table),
+  };
+}
+
+vi.mock("@/lib/supabase/server", () => ({ createClient: () => fakeSupabase() }));
+vi.mock("@/lib/data", () => ({ getProject: vi.fn(async () => PROJECT) }));
+vi.mock("@/lib/scrape", () => ({
+  scrapeDomain: vi.fn(async () => ({ ok: true, text: "Acme builds payment infrastructure." })),
+}));
+const resolveKey = vi.fn();
+vi.mock("@/lib/trial", () => ({
+  resolveKey: (...a: unknown[]) => resolveKey(...a),
+  recordTrialUsage: vi.fn(),
+  recordTrialSpend: vi.fn(),
+}));
+vi.mock("@/lib/pricing", () => ({ spendMicros: () => 0 }));
+vi.mock("@/lib/activity", () => ({ logDashboard: vi.fn() }));
+const suggestFromSite = vi.fn();
+const suggestCompetitors = vi.fn();
+const generateVariations = vi.fn();
+vi.mock("@/lib/llm", () => ({
+  suggestFromSite: (o: unknown) => suggestFromSite(o),
+  suggestCompetitors: (o: unknown) => suggestCompetitors(o),
+  generateVariations: (o: unknown) => generateVariations(o),
+  humanError: (e: unknown) => String(e),
+}));
+
+const reanalyze = await import("@/app/api/project/reanalyze/route");
+const competitors = await import("@/app/api/competitors/suggest/route");
+const generate = await import("@/app/api/topics/[id]/generate/route");
+
+const req = (path: string, body: unknown = {}) =>
+  new Request(`http://localhost${path}`, { method: "POST", body: JSON.stringify(body) });
+
+const routed = expect.objectContaining({
+  apiKey: "sk-cn-operator",
+  model: "claude-haiku-4-5",
+  route: { router: "concentrate", baseUrl: null },
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resolveKey.mockResolvedValue(ROUTED_TRIAL_KEY);
+  suggestFromSite.mockResolvedValue({ description: "d", topics: [{ name: "Fraud", prompts: ["q"] }], competitors: [], tokens: 10 });
+  suggestCompetitors.mockResolvedValue({ suggestions: [{ name: "Adyen", aliases: [], domain: "adyen.com" }], tokens: 10 });
+  generateVariations.mockResolvedValue({ variations: [{ text: "best payments api?", specificity: "general" }], tokens: 10 });
+});
+
+describe("suggestion routes hand the resolved route to the model call", () => {
+  it("POST /api/project/reanalyze", async () => {
+    const res = await reanalyze.POST(req("/api/project/reanalyze"));
+    expect(res.status).toBe(200);
+    expect(suggestFromSite).toHaveBeenCalledWith(routed);
+  });
+
+  it("POST /api/competitors/suggest", async () => {
+    const res = await competitors.POST(req("/api/competitors/suggest"));
+    expect(res.status).toBe(200);
+    expect(suggestCompetitors).toHaveBeenCalledWith(routed);
+  });
+
+  it("POST /api/topics/:id/generate", async () => {
+    const res = await generate.POST(req("/api/topics/topic-1/generate", { count: 3 }), {
+      params: { id: "topic-1" },
+    });
+    expect(res.status).toBe(200);
+    expect(generateVariations).toHaveBeenCalledWith(routed);
+  });
+
+  it("passes no route for a direct key", async () => {
+    resolveKey.mockResolvedValue({ source: "own", apiKey: "sk-ant", provider: "anthropic", model: "claude-sonnet-4-6" });
+    await competitors.POST(req("/api/competitors/suggest"));
+    expect((suggestCompetitors.mock.calls[0][0] as { route?: unknown }).route).toBeUndefined();
+  });
+});

--- a/app/api/topics/[id]/generate/route.ts
+++ b/app/api/topics/[id]/generate/route.ts
@@ -76,6 +76,10 @@ export async function POST(
       provider: key.provider,
       model: key.model,
       apiKey: key.apiKey!,
+      // A router credential (the Concentrate-funded free tier) only works
+      // through its gateway; resolveKey says which. Dropping this sent the
+      // router key straight to the provider, which refused it as invalid.
+      route: key.route,
       topicName: topic.name,
       topicDescription: topic.description,
       // The Settings blurb has promised this field "helps generate better


### PR DESCRIPTION
## The bug Kabir hit

Onboarding nytimes.com arrived on screen 2 with the name, description and logo filled in but no topics or competitors, and the generic "We read your site but couldn't draft topics for it" note. Not user error, and not what #169/#171 changed.

## Root cause

Production funds the free tier through a Concentrate **router** key (`TRIAL_CONCENTRATE_API_KEY`, set 22 days ago). For suggestion calls `resolveKey` returns that key together with `route` (which gateway the call must go through). All four suggestion routes passed the model call the key alone, so the router key went straight to Anthropic, which rejected it as an invalid key. The onboarding route catches that as `ai_failed` and the wizard shows the generic note. Anyone holding their own provider key was unaffected, which is why it went unnoticed.

Reproduced against nytimes.com with the exact trial credential shape:

| Call | Result |
|---|---|
| Without `route` (production today) | "Invalid API key" in 143 ms |
| With `route` | 4 topics, 5 competitors (WSJ, Washington Post, BBC, Reuters, AP) in 7.8 s |

## Fix

- All four routes pass `route: key.route` to the model call: onboarding suggest, project re-analyze, competitor suggest, topic question generation.
- The onboarding suggest route logs every failure path (`scrape_failed`, `no_key`, `trial_exhausted`, `ai_timeout`, `ai_failed`) as `onboarding.suggest_failed` with the reason and error text. Those paths answer 200 with a `reason` so the wizard keeps the identity, which meant a broken free tier looked, from the feed, exactly like nobody onboarding. Logging is best-effort and never changes the response.

## Tests

- Suggest route: the route travels for a router-funded trial key, no route for a direct key, and each failure path leaves the right log without altering the response.
- New `suggestion-routes-route.test.ts` pins the same pass-through on the three sibling routes.
- 977 tests, `tsc`, lint, and `next build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sa4k6crcCiPet7kf76cBdZ

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791494036&installation_model_id=431526&pr_number=175&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F175&signature=e42715fd6946bd4c180b782d922d05d739f55e5891037c5774e3c10565ed7559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->