### PR TITLE
Operations: whose key a run failed on, and only ours count

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -115,11 +115,13 @@ export default async function AdminPage({ searchParams }: { searchParams: SP }) 
               <p className="text-sm text-ink-soft">
                 {live.stuck.length > 0 && `${live.stuck.length} run(s) stuck in flight. `}
                 {live.failures.length > 0 &&
-                  `${live.failures.length} distinct run failure${live.failures.length === 1 ? "" : "s"}. `}
+                  `${live.failures.length} distinct run failure${live.failures.length === 1 ? "" : "s"} on our key. `}
                 {!failing &&
                   (live.runs24h.total === 0
-                    ? `No runs in the last ${win.label}: nothing has failed, but nothing has been exercised either.`
-                    : `${live.runs24h.completed} of ${live.runs24h.completed + live.runs24h.failed} runs completed.`)}
+                    ? `No runs on our key in the last ${win.label}: nothing has failed, but nothing has been exercised either.`
+                    : `${live.runs24h.completed} of ${live.runs24h.completed + live.runs24h.failed} runs on our key completed.`)}
+                {live.theirs24h.failed > 0 &&
+                  ` ${live.theirs24h.failed} run${live.theirs24h.failed === 1 ? "" : "s"} failed on customers' own keys — their provider accounts, not counted here.`}
               </p>
               {live.degraded && (
                 <p className="text-sm text-terracotta-dark">
@@ -138,8 +140,8 @@ export default async function AdminPage({ searchParams }: { searchParams: SP }) 
           value={live.successRate === null ? "—" : `${live.successRate}%`}
           hint={
             live.successRate === null
-              ? "no runs settled"
-              : `${live.runs24h.completed} ok · ${live.runs24h.failed} failed`
+              ? `no runs on our key settled${live.theirs24h.failed > 0 ? ` · ${live.theirs24h.failed} failed on customer keys` : ""}`
+              : `${live.runs24h.completed} ok · ${live.runs24h.failed} failed on our key${live.theirs24h.failed > 0 ? ` · ${live.theirs24h.failed} on customer keys` : ""}`
           }
           accent={live.successRate !== null && live.successRate < 90 ? "terracotta" : "mint"}
         />
@@ -166,6 +168,7 @@ export default async function AdminPage({ searchParams }: { searchParams: SP }) 
       <Telemetry
         stuck={live.stuck}
         failures={live.failures}
+        theirFailures={live.theirFailures}
         problems={ops.problems}
         telemetryOn={ops.enabled}
       />
@@ -178,8 +181,8 @@ export default async function AdminPage({ searchParams }: { searchParams: SP }) 
             <span className="text-sm tabular-nums text-ink-faint">{live.engines.length}</span>
           </div>
           <p className="max-w-3xl text-sm text-ink-faint">
-            Where a failure sits. One engine failing while the rest succeed is a provider problem,
-            not ours.
+            Where a failure sits, on our key only. One engine failing while the rest succeed is a
+            provider problem, not ours.
           </p>
           <Card>
             <div className="max-h-72 divide-y divide-ink/5 overflow-y-auto">

--- a/app/admin/runs/[id]/page.tsx
+++ b/app/admin/runs/[id]/page.tsx
@@ -48,7 +48,7 @@ export default async function AdminRunPage({ params }: { params: { id: string } 
   const { data: run } = await svc
     .from("runs")
     .select(
-      "id, project_id, status, provider, model, prompt_count, completed_count, replicates, route, error, created_at, finished_at",
+      "id, project_id, status, provider, model, prompt_count, completed_count, replicates, route, key_source, error, created_at, finished_at",
     )
     .eq("id", params.id)
     .maybeSingle();
@@ -144,7 +144,7 @@ export default async function AdminRunPage({ params }: { params: { id: string } 
         <StatCard
           label="Engine"
           value={<span className="font-mono text-xl">{run.provider}</span>}
-          hint={`${run.model}${run.route ? ` · via ${run.route}` : ""}`}
+          hint={`${run.model}${run.route ? ` · via ${run.route}` : ""}${run.key_source === "own" ? " · their key" : run.key_source === "trial" ? " · our key" : ""}`}
           accent="teal"
         />
         <StatCard

--- a/app/admin/telemetry.tsx
+++ b/app/admin/telemetry.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { Activity, CheckCircle2, Clock, Search, XCircle } from "lucide-react";
+import { Activity, CheckCircle2, Clock, KeyRound, Search, XCircle } from "lucide-react";
 import { Badge, Card } from "@/components/ui";
 import type { StuckRun, FailureGroup } from "@/lib/ops-live";
 import type { Problem } from "@/lib/ops-report";
@@ -40,11 +40,14 @@ const matches = (needle: string, ...fields: (string | number | null | undefined)
 export function Telemetry({
   stuck,
   failures,
+  theirFailures = [],
   problems,
   telemetryOn,
 }: {
   stuck: StuckRun[];
   failures: FailureGroup[];
+  /** Failures on customers' own keys: listed, never alarmed. */
+  theirFailures?: FailureGroup[];
   problems: Problem[];
   telemetryOn: boolean;
 }) {
@@ -65,6 +68,13 @@ export function Telemetry({
         : failures.filter((f) => matches(needle, f.example, f.signature, f.engines.join(" "))),
     [failures, needle, filtering],
   );
+  const shownTheirs = useMemo(
+    () =>
+      !filtering
+        ? theirFailures
+        : theirFailures.filter((f) => matches(needle, f.example, f.signature, f.engines.join(" "))),
+    [theirFailures, needle, filtering],
+  );
   const shownProblems = useMemo(() => {
     const byLevel = level === "all" ? problems : problems.filter((p) => p.level === level);
     return !filtering
@@ -72,7 +82,8 @@ export function Telemetry({
       : byLevel.filter((p) => matches(needle, p.signature, p.source, JSON.stringify(p.sample)));
   }, [problems, needle, filtering, level]);
 
-  const totalShown = shownStuck.length + shownFailures.length + shownProblems.length;
+  const totalShown =
+    shownStuck.length + shownFailures.length + shownTheirs.length + shownProblems.length;
   const errorCount = problems.filter((p) => p.level === "error").length;
   const warnCount = problems.filter((p) => p.level === "warn").length;
 
@@ -158,15 +169,18 @@ export function Telemetry({
         </Section>
       )}
 
-      {/* ---- Run failures --------------------------------------------------- */}
+      {/* ---- Run failures (our key) ---------------------------------------- */}
       <Section
         icon={<XCircle className="h-4 w-4 text-terracotta" aria-hidden />}
         title="Run failures"
         total={failures.length}
         shown={shownFailures.length}
         filtering={filtering}
+        hint="On our key. These are ours to fix and count against the figures above."
         empty={
-          failures.length === 0 ? "No failed runs in the window." : `Nothing matches “${q}”.`
+          failures.length === 0
+            ? "No failed runs on our key in the window."
+            : `Nothing matches “${q}”.`
         }
       >
         {shownFailures.map((f) => (
@@ -183,6 +197,33 @@ export function Telemetry({
           </Row>
         ))}
       </Section>
+
+      {/* ---- Run failures on customers' own keys ---------------------------- */}
+      {theirFailures.length > 0 && (
+        <Section
+          icon={<KeyRound className="h-4 w-4 text-ink-faint" aria-hidden />}
+          title="On customers' own keys"
+          total={theirFailures.length}
+          shown={shownTheirs.length}
+          filtering={filtering}
+          hint="Their provider account, not ours: out of credit, over quota, a revoked key. Shown so you can see it; not counted in the figures above."
+          empty={`Nothing matches “${q}”.`}
+        >
+          {shownTheirs.map((f) => (
+            <Row key={f.signature}>
+              <div className="min-w-0 flex-1">
+                <p className="text-sm text-ink-soft">{f.example}</p>
+                <p className="mt-0.5 truncate font-mono text-xs text-ink-faint">
+                  {f.engines.join(", ")} · {timeAgo(f.lastSeen)} · their key
+                </p>
+              </div>
+              <Badge tone="neutral">
+                <span className="tabular-nums">{f.count}</span>
+              </Badge>
+            </Row>
+          ))}
+        </Section>
+      )}
 
       {/* ---- Recorded issues ------------------------------------------------ */}
       <Section

--- a/app/api/cron/run/route.ts
+++ b/app/api/cron/run/route.ts
@@ -122,6 +122,7 @@ async function sweepAndRun(span: Span) {
         model: key.model,
         apiKey: key.apiKey!,
         route: key.route,
+        keySource: key.source === "trial" ? "trial" : "own",
         budgetMicros: runBudgetMicros(key),
         context: {
           channel: "cron",

--- a/app/api/runs/route.ts
+++ b/app/api/runs/route.ts
@@ -141,6 +141,7 @@ export async function POST(request: Request) {
       model: key.model,
       apiKey: key.apiKey!,
       route: key.route,
+      keySource: key.source,
       budgetMicros: runBudgetMicros(key),
       context: {
         channel: "dashboard",

--- a/app/api/v1/v1-routes.test.ts
+++ b/app/api/v1/v1-routes.test.ts
@@ -623,6 +623,7 @@ describe("GET /api/v1/runs/:id/status", () => {
       model: "claude-sonnet-4-6",
       // Direct provider key, as every run before router support was.
       route: null,
+      key_source: null,
       prompt_count: 12,
       completed_count: 5,
       replicates: 2,

--- a/lib/api-service.test.ts
+++ b/lib/api-service.test.ts
@@ -141,6 +141,7 @@ function makeRun(overrides: Partial<Run>): Run {
     model: "claude-sonnet-4-6",
     // Direct provider key, as every run before router support was.
     route: null,
+    key_source: null,
     prompt_count: 2,
     completed_count: 2,
     replicates: 1,

--- a/lib/api-service.ts
+++ b/lib/api-service.ts
@@ -1299,6 +1299,7 @@ export async function triggerRunForProject(
     model: key.model,
     apiKey: key.apiKey!,
     route: key.route,
+    keySource: key.source,
     budgetMicros: runBudgetMicros(key),
     context: options?.context,
   };

--- a/lib/engine.ts
+++ b/lib/engine.ts
@@ -205,6 +205,14 @@ export interface ExecuteRunParams {
   /** Attribution for the activity log. Defaults to the internal system. */
   context?: RunContext;
   /**
+   * Whose credential `apiKey` is: the operator's shared trial key or the
+   * account's own. Recorded on the run so the operations page can tell a
+   * customer's provider account running dry (their billing) from our own key
+   * failing (our outage). Optional only so a caller that doesn't know can say
+   * so honestly with null rather than guess.
+   */
+  keySource?: "own" | "trial" | null;
+  /**
    * How much operator money this run may spend, in micro-dollars. Omit (or
    * null) for a run on the user's own key, where there is nothing for us to
    * ration.
@@ -295,6 +303,7 @@ export async function prepareRun(params: ExecuteRunParams): Promise<PreparedRun>
       // Null for a direct provider key. Never a substitute for `provider`: the
       // engine that answered is what the run measured.
       route: route?.router ?? null,
+      key_source: params.keySource ?? null,
       // Planned ANSWERS, not prompts — this is what the UI counts against.
       prompt_count: jobs.length,
       completed_count: 0,
@@ -637,6 +646,9 @@ async function resumeRunMeasured(
       provider,
       model,
       route: route?.router ?? "direct",
+      // "own" = the customer's credential failed, which is theirs to fix;
+      // "trial" = ours. The report demotes own-key failures to warnings.
+      key_source: params.keySource ?? "unknown",
       planned: jobs.length,
       stored: succeeded,
       failed: jobs.length - succeeded,

--- a/lib/onboard.ts
+++ b/lib/onboard.ts
@@ -332,6 +332,7 @@ export async function firstSweep(opts: {
         model: k.model,
         apiKey: k.apiKey!,
         route: k.route,
+        keySource: k.source as "own" | "trial",
         budgetMicros: budget === null ? null : Math.floor(budget / Math.max(trialRuns, 1)),
         context: opts.context,
       };

--- a/lib/ops-live.ts
+++ b/lib/ops-live.ts
@@ -38,13 +38,32 @@ export interface FailureGroup {
   engines: string[];
 }
 
+/** Whose credential a run ran on. "ours" covers the shared trial key AND rows
+ *  from before key_source was recorded: an unattributed failure must keep
+ *  counting against us rather than quietly vanish from the figures. */
+export type KeyOwner = "ours" | "theirs";
+
+export function keyOwnerOf(keySource: string | null | undefined): KeyOwner {
+  return keySource === "own" ? "theirs" : "ours";
+}
+
 export interface LiveHealth {
+  /** Runs on OUR key (the shared trial key, plus unattributed rows). This is
+   *  what the health figures are computed from. */
   runs24h: { completed: number; failed: number; running: number; pending: number; total: number };
+  /** Runs on the CUSTOMER'S own key. A failure here is their provider
+   *  account — out of credit, over quota, key revoked — and is theirs to fix,
+   *  so it is reported but never counted against the deployment. */
+  theirs24h: { completed: number; failed: number };
   successRate: number | null;
   /** Runs that say "running" but have not moved in a long time — the failure
    *  mode where an invocation dies without ever writing a status. */
   stuck: StuckRun[];
+  /** Failures on our key: the ones that mean something is wrong with us. */
   failures: FailureGroup[];
+  /** Failures on customers' own keys: worth seeing, not worth an alarm. */
+  theirFailures: FailureGroup[];
+  /** Per engine, on our key only — "is this provider failing for us". */
   engines: { engine: string; completed: number; failed: number; rate: number | null }[];
   signups24h: number;
   totalUsers: number;
@@ -68,6 +87,7 @@ interface RunRow {
   completed_count: number;
   started_at: string | null;
   created_at: string;
+  key_source?: string | null;
 }
 
 export function shapeLive(
@@ -78,36 +98,52 @@ export function shapeLive(
   apiErrors24h: number,
   degraded: string | null = null,
 ): LiveHealth {
-  const counts = { completed: 0, failed: 0, running: 0, pending: 0, total: runs.length };
+  const counts = { completed: 0, failed: 0, running: 0, pending: 0, total: 0 };
+  const theirs = { completed: 0, failed: 0 };
   const failures = new Map<string, FailureGroup>();
+  const theirFailures = new Map<string, FailureGroup>();
   const engines = new Map<string, { completed: number; failed: number }>();
   const stuck: StuckRun[] = [];
   let lastRunAt: string | null = null;
 
   for (const r of runs) {
     if (!lastRunAt || r.created_at > lastRunAt) lastRunAt = r.created_at;
-    if (r.status === "completed") counts.completed += 1;
-    else if (r.status === "failed") counts.failed += 1;
-    else if (r.status === "running") counts.running += 1;
-    else counts.pending += 1;
+    const owner = keyOwnerOf(r.key_source);
+
+    // A customer's own key: counted on its own line, never in ours. Their
+    // provider account running dry was, before this split, three "run
+    // failures" and a dented success rate on a deployment that was fine.
+    if (owner === "theirs") {
+      if (r.status === "completed") theirs.completed += 1;
+      else if (r.status === "failed") theirs.failed += 1;
+    } else {
+      counts.total += 1;
+      if (r.status === "completed") counts.completed += 1;
+      else if (r.status === "failed") counts.failed += 1;
+      else if (r.status === "running") counts.running += 1;
+      else counts.pending += 1;
+    }
 
     const engine = `${r.provider}/${r.model}`;
-    const e = engines.get(engine) ?? { completed: 0, failed: 0 };
-    if (r.status === "completed") e.completed += 1;
-    if (r.status === "failed") e.failed += 1;
-    engines.set(engine, e);
+    if (owner === "ours") {
+      const e = engines.get(engine) ?? { completed: 0, failed: 0 };
+      if (r.status === "completed") e.completed += 1;
+      if (r.status === "failed") e.failed += 1;
+      engines.set(engine, e);
+    }
 
     if (r.status === "failed" && r.error) {
       // Group by the SHAPE of the message, so one provider outage is one line
       // with a count rather than fifty near-identical rows.
       const sig = signatureOf(r.error);
-      const g = failures.get(sig);
+      const bucket = owner === "theirs" ? theirFailures : failures;
+      const g = bucket.get(sig);
       if (g) {
         g.count += 1;
         if (r.created_at > g.lastSeen) g.lastSeen = r.created_at;
         if (!g.engines.includes(engine)) g.engines.push(engine);
       } else {
-        failures.set(sig, {
+        bucket.set(sig, {
           signature: sig,
           count: 1,
           lastSeen: r.created_at,
@@ -117,6 +153,7 @@ export function shapeLive(
       }
     }
 
+    // A stuck run is stuck whoever paid: an invocation that died is ours.
     if (r.status === "running" || r.status === "pending") {
       const started = r.started_at ?? r.created_at;
       const minutes = Math.floor((now - new Date(started).getTime()) / 60000);
@@ -135,15 +172,17 @@ export function shapeLive(
   }
 
   const settled = counts.completed + counts.failed;
+  const byCount = (a: FailureGroup, b: FailureGroup) =>
+    b.count - a.count || b.lastSeen.localeCompare(a.lastSeen);
   return {
     runs24h: counts,
+    theirs24h: theirs,
     // Null, not 100, when nothing settled — see ops-report for why that
     // distinction is the whole point of this number.
     successRate: settled > 0 ? Math.round((counts.completed / settled) * 100) : null,
     stuck: stuck.sort((a, b) => b.minutes - a.minutes),
-    failures: [...failures.values()].sort(
-      (a, b) => b.count - a.count || b.lastSeen.localeCompare(a.lastSeen),
-    ),
+    failures: [...failures.values()].sort(byCount),
+    theirFailures: [...theirFailures.values()].sort(byCount),
     engines: [...engines.entries()]
       // Only engines that have actually settled something. A row of zeroes says
       // nothing about health and pushes the real rows down.
@@ -176,7 +215,9 @@ export async function liveHealth(hours = 24): Promise<LiveHealth> {
     const [runsRes, signupRes, usersRes, apiErrRes] = await Promise.all([
       admin
         .from("runs")
-        .select("id, status, provider, model, error, prompt_count, completed_count, started_at, created_at")
+        .select(
+          "id, status, provider, model, error, prompt_count, completed_count, started_at, created_at, key_source",
+        )
         .gte("created_at", sinceIso)
         .order("created_at", { ascending: false })
         .limit(2000),

--- a/lib/ops-report.ts
+++ b/lib/ops-report.ts
@@ -65,16 +65,24 @@ export function shapeOps(rows: OpsRow[], hours: number, enabled: boolean): OpsRe
     const n = r.occurrences ?? 0;
     if (!latest || r.last_seen_at > latest) latest = r.last_seen_at;
 
+    // A run that failed on the CUSTOMER'S own key is their provider account,
+    // not our outage: it is kept as a warning (visible, searchable) and left
+    // out of the failure count and the error headline. Events from before
+    // key_source was sampled carry no marker and stay errors, as they were.
+    const theirKey = asRecord(r.sample).key_source === "own";
+    const level: "info" | "warn" | "error" =
+      r.kind === "run.failed" && theirKey ? "warn" : r.level;
+
     if (r.kind === "run.completed") completed += n;
-    else if (r.kind === "run.failed") failed += n;
+    else if (r.kind === "run.failed" && !theirKey) failed += n;
     else if (r.kind === "run.abandoned") abandoned += n;
 
     // Warnings are included, not just errors. A warn is something the code
     // deliberately chose to report; dropping it here would mean it could never
     // be seen anywhere, which makes recording it pointless. Only `errors`
     // counts strictly errors, since that is what the headline figure means.
-    if (r.level === "error" || r.level === "warn") {
-      if (r.level === "error") errors += n;
+    if (level === "error" || level === "warn") {
+      if (level === "error") errors += n;
       const existing = problems.get(r.signature);
       const sample = asRecord(r.sample);
       const source = String(sample.source ?? r.kind);
@@ -85,7 +93,7 @@ export function shapeOps(rows: OpsRow[], hours: number, enabled: boolean): OpsRe
         problems.set(r.signature, {
           signature: r.signature,
           kind: r.kind,
-          level: r.level === "error" ? "error" : "warn",
+          level: level === "error" ? "error" : "warn",
           occurrences: n,
           lastSeen: r.last_seen_at,
           source,
@@ -94,7 +102,7 @@ export function shapeOps(rows: OpsRow[], hours: number, enabled: boolean): OpsRe
       }
     }
 
-    if (r.kind === "run.completed" || r.kind === "run.failed") {
+    if ((r.kind === "run.completed" || r.kind === "run.failed") && !theirKey) {
       const sample = asRecord(r.sample);
       const engine = `${sample.provider ?? "?"}/${sample.model ?? "?"}`;
       const e = engines.get(engine) ?? { completed: 0, failed: 0 };

--- a/lib/ops.test.ts
+++ b/lib/ops.test.ts
@@ -247,6 +247,107 @@ describe("shapeLive", () => {
   });
 });
 
+describe("shapeLive — whose key paid", () => {
+  const now = new Date("2026-08-03T16:00:00.000Z").getTime();
+  const run = (over: Record<string, unknown> = {}) => ({
+    id: "aaaaaaaa-0000-0000-0000-000000000000",
+    status: "completed",
+    provider: "anthropic",
+    model: "claude-opus-4-8",
+    error: null,
+    prompt_count: 10,
+    completed_count: 10,
+    started_at: "2026-08-03T15:50:00.000Z",
+    created_at: "2026-08-03T15:50:00.000Z",
+    ...over,
+  });
+  const CREDIT = '400 {"type":"error","error":{"type":"invalid_request_error","message":"Your credit balance is too low"}}';
+
+  // The reported case: a customer's own Anthropic account ran dry, three
+  // scheduled runs failed, and the deployment read 98% with "2 distinct run
+  // failures" — an alarm about someone else's billing.
+  it("keeps a customer's own-key failure out of our figures, but still lists it", () => {
+    const r = shapeLive(
+      [
+        run({ key_source: "trial" }),
+        run({ key_source: "trial" }),
+        run({ status: "failed", error: CREDIT, key_source: "own" }),
+        run({ status: "failed", error: CREDIT, key_source: "own" }),
+        run({ status: "failed", error: CREDIT, key_source: "own" }),
+        run({ key_source: "own" }),
+      ],
+      now,
+      0,
+      0,
+      0,
+    );
+    expect(r.runs24h).toMatchObject({ completed: 2, failed: 0, total: 2 });
+    expect(r.successRate).toBe(100);
+    expect(r.failures).toEqual([]);
+    expect(r.theirs24h).toEqual({ completed: 1, failed: 3 });
+    expect(r.theirFailures).toHaveLength(1);
+    expect(r.theirFailures[0]).toMatchObject({ count: 3, engines: ["anthropic/claude-opus-4-8"] });
+    // Engines are ours only: their Opus 4.8 never appears as a failing engine.
+    expect(r.engines).toEqual([{ engine: "anthropic/claude-opus-4-8", completed: 2, failed: 0, rate: 100 }]);
+  });
+
+  it("counts a failure on our key against us", () => {
+    const r = shapeLive([run({ key_source: "trial" }), run({ status: "failed", error: "boom", key_source: "trial" })], now, 0, 0, 0);
+    expect(r.successRate).toBe(50);
+    expect(r.failures).toHaveLength(1);
+    expect(r.theirFailures).toEqual([]);
+  });
+
+  // Rows from before key_source existed carry null. Treating those as
+  // "theirs" would make the whole history vanish from the figures the day
+  // this shipped; treating them as ours keeps every old failure counted.
+  it("treats an unattributed run as ours", () => {
+    const r = shapeLive([run({ status: "failed", error: "boom", key_source: null }), run({ status: "failed", error: "boom" })], now, 0, 0, 0);
+    expect(r.runs24h.failed).toBe(2);
+    expect(r.failures[0].count).toBe(2);
+  });
+
+  it("flags a stuck run whoever paid — a dead invocation is ours", () => {
+    const r = shapeLive([run({ status: "running", started_at: "2026-08-03T14:00:00.000Z", key_source: "own" })], now, 0, 0, 0);
+    expect(r.stuck).toHaveLength(1);
+    // But it is not one of OUR settled runs.
+    expect(r.runs24h.total).toBe(0);
+  });
+});
+
+describe("shapeOps — whose key paid", () => {
+  it("demotes a run that failed on the customer's key to a warning and leaves it out of the failure count", () => {
+    const r = shapeOps(
+      [
+        opsRow({ kind: "run.failed", level: "error", signature: "run.failed:anthropic/claude-opus-4-8", occurrences: 3, sample: { provider: "anthropic", model: "claude-opus-4-8", key_source: "own" } }),
+        opsRow({ kind: "run.completed", level: "info", signature: "run.completed:anthropic/claude-haiku-4-5", occurrences: 20, sample: { provider: "anthropic", model: "claude-haiku-4-5", key_source: "trial" } }),
+      ],
+      24,
+      true,
+    );
+    expect(r.runs).toMatchObject({ completed: 20, failed: 0, successRate: 100 });
+    expect(r.errors).toBe(0);
+    expect(r.problems).toHaveLength(1);
+    expect(r.problems[0]).toMatchObject({ level: "warn", occurrences: 3 });
+    // Their engine does not appear in the per-engine table.
+    expect(r.engines).toEqual([{ engine: "anthropic/claude-haiku-4-5", completed: 20, failed: 0 }]);
+  });
+
+  it("keeps a failure on our key, or an unmarked older one, as an error", () => {
+    const r = shapeOps(
+      [
+        opsRow({ kind: "run.failed", level: "error", signature: "a", occurrences: 1, sample: { provider: "openai", model: "gpt-4o", key_source: "trial" } }),
+        opsRow({ kind: "run.failed", level: "error", signature: "b", occurrences: 1, sample: { provider: "openai", model: "gpt-4o" } }),
+      ],
+      24,
+      true,
+    );
+    expect(r.runs.failed).toBe(2);
+    expect(r.errors).toBe(2);
+    expect(r.problems.every((p) => p.level === "error")).toBe(true);
+  });
+});
+
 describe("isAdminEmail", () => {
   const original = process.env.ADMIN_EMAILS;
   afterEach(() => {

--- a/lib/results-seen.test.ts
+++ b/lib/results-seen.test.ts
@@ -32,6 +32,7 @@ const RUN: Run = {
   provider: "anthropic",
   model: "claude-sonnet-4-6",
   route: null,
+  key_source: null,
   prompt_count: 10,
   completed_count: 10,
   replicates: 1,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -162,6 +162,9 @@ export interface Run {
   /** The LLM router that carried this run, or null for a direct provider key.
    *  `provider` above is still the engine that answered — see lib/routers.ts. */
   route: RouterId | null;
+  /** Whose credential paid: the operator's shared trial key, or the account's
+   *  own. Null on runs from before this was recorded. */
+  key_source: "own" | "trial" | null;
   /** Planned answers for this run: active prompts x replicates. */
   prompt_count: number;
   completed_count: number;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -532,6 +532,17 @@ alter table public.runs drop constraint if exists runs_route_check;
 alter table public.runs
   add constraint runs_route_check check (route is null or route in ('concentrate', 'openrouter'));
 
+-- Whose credential paid for this run: 'trial' = the operator's shared key,
+-- 'own' = the account's own provider or router key. Null on rows from before
+-- the column existed. The operations page keeps its health figures to runs on
+-- OUR key: a customer's own Anthropic account running out of credit is their
+-- billing, not our outage, and it was counting against our success rate.
+-- Same add-column + named-constraint split as `route`, for the same reason.
+alter table public.runs add column if not exists key_source text;
+alter table public.runs drop constraint if exists runs_key_source_check;
+alter table public.runs
+  add constraint runs_key_source_check check (key_source is null or key_source in ('own', 'trial'));
+
 -- ---------- responses ------------------------------------------------
 create table if not exists public.responses (
   id uuid primary key default gen_random_uuid(),


### PR DESCRIPTION
## Why

Today's Operations page showed "2 distinct run failures" and a 98% success rate. All five failed runs in the window were on customers' **own** keys: one account's Anthropic credit ran out, two others hit Google's free-tier quota. That is their billing, not our outage, and it was dragging our figures and raising the banner.

## What

- **`runs.key_source`** (nullable, `'own' | 'trial'`), written by every run: the Run button, the scheduler, the API, onboarding sweeps. Already applied to the production database (additive, nullable).
- **Operations figures come from runs on our key only.** Success rate, failed count, per-engine rates and the failure groups. Rows from before the column carry null and keep counting as ours, so nothing in history vanishes. Stuck runs count whoever paid: a dead invocation is ours.
- **Customer-key runs are still visible.** Their own counts, mentioned in the banner and the success card without alarming, and a separate unaccented "On customers' own keys" section in the failures list. The run detail page says "their key" or "our key".
- **Telemetry** samples `key_source` too; a `run.failed` on a customer key is recorded as a warning rather than an error and stays out of the failure count.

## Verified

983 tests (7 new on the two shapers), `tsc`, lint on changed files, and `next build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sa4k6crcCiPet7kf76cBdZ

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791503680&installation_model_id=431526&pr_number=176&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F176&signature=9ac70a3d2dae0e0635ee55e015731bb2e5e357a0a90ad4decf995477282b53c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->