### PR TITLE
Dashboard: on a phone the sidebar is a drawer behind a menu button

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -188,16 +188,17 @@ export default async function DashboardLayout({
             <SignOutButton className="w-full justify-start" />
           </div>
 
-          <div className="flex items-center justify-between gap-2 border-t border-ink/10 pt-4 md:hidden">
-            <div className="flex min-w-0 flex-col gap-1">
-              <WhyFree />
-              <p className="truncate text-xs text-ink-faint" title={user.email ?? undefined}>
-                {user.email}
-              </p>
-            </div>
-            <div className="flex shrink-0 items-center gap-2">
-              <ThemeToggle />
+          {/* Pinned to the foot of the drawer (mt-auto), below whatever space
+              the nav and the CTA leave, so the account controls sit where a
+              thumb expects them rather than mid-drawer above a blank half. */}
+          <div className="mt-auto flex flex-col gap-3 border-t border-ink/10 pt-4 md:hidden">
+            <WhyFree />
+            <p className="truncate text-xs text-ink-faint" title={user.email ?? undefined}>
+              {user.email}
+            </p>
+            <div className="flex items-center justify-between gap-2">
               <SignOutButton className="whitespace-nowrap" />
+              <ThemeToggle />
             </div>
           </div>
       </SidebarShell>

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { Logo } from "@/components/logo";
 import { DashboardNav, type NavReport } from "@/components/dashboard/nav";
+import { SidebarShell } from "@/components/dashboard/sidebar-shell";
 import { OrgSwitcher } from "@/components/dashboard/org-switcher";
 import { SignOutButton } from "@/components/dashboard/signout";
 import { WhyFree } from "@/components/dashboard/why-free";
@@ -144,13 +145,15 @@ export default async function DashboardLayout({
           navigating between dashboard routes. */}
       {offerFounderCall && callUrl && <FounderCallOffer url={callUrl} />}
 
-      <aside className="flex flex-col border-b border-ink/10 bg-paper md:h-screen md:w-[260px] md:shrink-0 md:border-b-0 md:border-r">
-        {/* Scrolls: six reports in the sub-menu plus the CTA push Sign out past
-            the fold, and an h-screen column without it leaves them unreachable. */}
-        <div className="flex flex-col gap-6 px-5 py-6 md:h-full md:overflow-y-auto">
-          <div className="flex items-center justify-between gap-2">
+      {/* On a phone the sidebar is a drawer behind a menu button, so the page
+          opens on its content rather than on a screen of navigation. At md+
+          SidebarShell is the same static column it always was. */}
+      <SidebarShell>
+          {/* The phone's drawer carries its own logo row (with the close
+              control); this one is the desktop column's. */}
+          <div className="hidden items-center justify-between gap-2 md:flex">
             <Logo />
-            <ThemeToggle className="hidden md:inline-flex" />
+            <ThemeToggle />
           </div>
 
           {project ? (
@@ -192,13 +195,12 @@ export default async function DashboardLayout({
                 {user.email}
               </p>
             </div>
-            <div className="flex items-center gap-2">
+            <div className="flex shrink-0 items-center gap-2">
               <ThemeToggle />
-              <SignOutButton />
+              <SignOutButton className="whitespace-nowrap" />
             </div>
           </div>
-        </div>
-      </aside>
+      </SidebarShell>
 
       <main className="flex-1 overflow-y-auto px-6 py-8 md:px-10 md:h-screen">
         <div className="mx-auto max-w-6xl">

--- a/components/dashboard/nav.tsx
+++ b/components/dashboard/nav.tsx
@@ -11,8 +11,8 @@ interface NavItem {
   label: string;
   /** Base name of the icon in /public/images/icons (Default + active variants). */
   icon: string;
-  /** Rendered only in the wrapped phone row; at md+ the item's content lives
-      in the Reports sub-menu under Overview instead. */
+  /** Rendered only in the phone drawer; at md+ the item's content lives in
+      the Reports sub-menu under Overview instead. */
   mobileOnly?: boolean;
 }
 
@@ -29,8 +29,8 @@ const NAV_ITEMS: NavItem[] = [
   { href: "/dashboard/topics", label: "Topics", icon: "Topics" },
   { href: "/dashboard/competitors", label: "Competitors", icon: "Competitors" },
   // Reports lives under Overview at md+ (see the sub-menu below); this item
-  // exists so the section is still reachable from the phone row, where a
-  // nested list inside a wrapping flex-row would be unreadable.
+  // exists so the section is still one tap away in the phone drawer, which
+  // keeps the sub-menu (six dated reports) for the wider column.
   { href: "/dashboard/runs", label: "Reports", icon: "Runs", mobileOnly: true },
   { href: "/dashboard/logs", label: "Logs", icon: "Logs" },
   { href: "/dashboard/settings", label: "Settings", icon: "Settings" },
@@ -51,11 +51,10 @@ export function DashboardNav({
   const [reportsOpen, setReportsOpen] = useState(true);
 
   return (
-    // Six labelled items in one un-wrapping row overflowed the viewport on a
-    // phone, pushing every dashboard page ~267px wide. Wrapping keeps the
-    // labels and needs no scrolling; the column layout at md+ must not wrap, or
-    // the fixed-height sidebar would spill items into a second column.
-    <nav className="flex flex-row flex-wrap gap-1 md:flex-col md:flex-nowrap">
+    // One column at every size. On a phone the nav now lives in a drawer the
+    // width of a sidebar (it used to be a wrapping row across the top of the
+    // page), so the same column reads the same way there.
+    <nav className="flex flex-col gap-1">
       {NAV_ITEMS.map(({ href, label, icon, mobileOnly }) => {
         const isOverview = href === "/dashboard";
         const active =

--- a/components/dashboard/sidebar-shell.tsx
+++ b/components/dashboard/sidebar-shell.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useEffect, useId, useState, type ReactNode } from "react";
+import { usePathname } from "next/navigation";
+import { Menu, X } from "lucide-react";
+import { Logo } from "@/components/logo";
+import { cn } from "@/lib/utils";
+
+/**
+ * The sidebar's container, in two shapes.
+ *
+ * At md and up this is exactly the aside it always was: a fixed-width column
+ * on the left, scrolling on its own. Nothing here changes desktop.
+ *
+ * Below md the same column used to render ABOVE the page content — logo, org
+ * switcher, six nav items, the Phantomstory offer, the account row — so every
+ * dashboard page on a phone opened on a screen and a half of navigation
+ * before the first number. Now the phone gets a slim top bar (logo + menu
+ * button) and the column becomes a drawer that slides in from the left over
+ * a backdrop. Same children, same order, same server-rendered content; only
+ * where it sits.
+ *
+ * Closes on navigation, on Escape, on the backdrop, and on the X. Locks body
+ * scroll while open so the page underneath doesn't scroll with the drawer.
+ */
+export function SidebarShell({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+  const pathname = usePathname();
+  const drawerId = useId();
+
+  // A tap on a nav link navigates; the drawer must not stay over the page it
+  // just navigated to. Keyed on the path, not the click, so a link to the
+  // current page (no navigation) leaves it open — nothing happened.
+  useEffect(() => {
+    setOpen(false);
+  }, [pathname]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", onKey);
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = previous;
+    };
+  }, [open]);
+
+  return (
+    <>
+      {/* ---- Phone: the top bar ------------------------------------------- */}
+      <header className="sticky top-0 z-30 flex items-center justify-between gap-3 border-b border-ink/10 bg-paper px-4 py-3 md:hidden">
+        <Logo />
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          aria-label="Open menu"
+          aria-expanded={open}
+          aria-controls={drawerId}
+          className="inline-flex h-9 w-9 items-center justify-center rounded border border-ink/15 text-ink-soft transition-colors hover:bg-ink/5 hover:text-ink"
+        >
+          <Menu className="h-5 w-5" aria-hidden />
+        </button>
+      </header>
+
+      {/* ---- Phone: the backdrop ------------------------------------------ */}
+      {/* Below the org switcher's confirmation overlay (z-50) and the "why is
+          this free" dialog (z-60), both of which can open from inside the
+          drawer and must sit above it. */}
+      <div
+        onClick={() => setOpen(false)}
+        aria-hidden
+        className={cn(
+          "fixed inset-0 z-30 bg-ink/40 transition-opacity md:hidden",
+          open ? "opacity-100" : "pointer-events-none opacity-0",
+        )}
+      />
+
+      {/* ---- The column: drawer on a phone, static aside at md+ ------------- */}
+      <aside
+        id={drawerId}
+        className={cn(
+          // Phone: off-canvas, sliding in from the left. `invisible` while
+          // closed takes the drawer's links out of the tab order and the
+          // accessibility tree, which an off-screen transform alone does not.
+          "fixed inset-y-0 left-0 z-40 flex w-[280px] max-w-[85vw] flex-col bg-paper shadow-card transition-[transform,visibility] duration-200 ease-out",
+          open ? "visible translate-x-0" : "invisible -translate-x-full",
+          // md+: exactly the aside this replaced. `static` cancels the fixed
+          // positioning, `translate-x-0` the off-canvas transform, `visible`
+          // the phone's closed state.
+          "md:visible md:static md:h-screen md:w-[260px] md:max-w-none md:shrink-0 md:translate-x-0 md:border-r md:border-ink/10 md:shadow-none md:transition-none",
+        )}
+      >
+        {/* Scrolls: six reports in the sub-menu plus the CTA push Sign out past
+            the fold, and a full-height column without it leaves them unreachable. */}
+        <div className="flex h-full flex-col gap-6 overflow-y-auto px-5 py-6">
+          {/* The drawer's own head, mirroring the top bar it slid out from, so
+              the close control sits where the open control was. md+ has the
+              layout's logo row instead. */}
+          <div className="flex items-center justify-between gap-2 md:hidden">
+            <Logo />
+            <button
+              type="button"
+              onClick={() => setOpen(false)}
+              aria-label="Close menu"
+              className="inline-flex h-9 w-9 items-center justify-center rounded border border-ink/15 text-ink-soft transition-colors hover:bg-ink/5 hover:text-ink"
+            >
+              <X className="h-5 w-5" aria-hidden />
+            </button>
+          </div>
+          {children}
+        </div>
+      </aside>
+    </>
+  );
+}


### PR DESCRIPTION
## What

On a phone, every dashboard page opened on a screen and a half of navigation before the first number (see Kabir's screenshot). Below the `md` breakpoint the sidebar is now a slim top bar with the logo and a menu button, and the sidebar column slides in from the left over a backdrop when tapped. It closes on navigation, Escape, the backdrop, and its own X, and locks body scroll while open.

**Desktop is untouched.** At `md` and above the new `SidebarShell` renders exactly the static aside it replaced, with the same children in the same order. The Phantomstory CTA is unchanged and shows in both the desktop column and the phone drawer, as it already did.

The nav is a single column at every size now that the phone has a sidebar-width drawer; the wrapping-row layout only existed for the old top strip.

## Verified

Headless Chromium with a real signed-in session at 390×844 and 1280×800:

| Check | Phone | Desktop |
|---|---|---|
| Menu button present | yes | no |
| Sidebar visible before opening | no | yes |
| Phantomstory CTA visible | in the open drawer | in the column |
| Drawer closes after navigating to Topics | yes | n/a |

`tsc`, lint, 977 tests, and `next build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sa4k6crcCiPet7kf76cBdZ

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791568735&installation_model_id=431526&pr_number=177&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F177&signature=8a71bf99628003881424d72962dd3900e4f947825247d3c88c038ef91ab253ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->