### PR TITLE
Let projects choose custom-interval scheduled monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Lettertrace is a self-hostable AEO tool, focused purely on **diagnosing and moni
 - ⚔️ **Competitor benchmarking**, ingest competitors and see how often each shows up.
 - 🏢 **Multiple organizations**, one account can track many brands/domains and switch between them from the sidebar.
 - 🔎 **Web search + source attribution**, query the models with their native web search on and capture the exact sources they cite, so you can see which posts drove an answer, and whether your own site is being used, even when you aren't named.
-- ⏱️ **Scheduled monitoring**, daily/weekly runs via a cron endpoint.
+- ⏱️ **Scheduled monitoring**, daily/weekly/custom-interval runs via a cron endpoint.
 
 ## Core concepts
 
@@ -268,7 +268,7 @@ Router keys are encrypted at rest exactly like provider keys, and resolution ord
 
 ## Scheduled monitoring
 
-Set a project's schedule to **Daily** or **Weekly** in Settings, then hit the cron endpoint on an interval:
+Set a project's schedule to **Daily**, **Weekly**, or a **custom** number of days (1–90) in Settings — or, for a new account, at the end of onboarding — then hit the cron endpoint on an interval:
 
 ```bash
 curl -X POST https://your-app.com/api/cron/run \
@@ -298,7 +298,7 @@ While a user has free runs left and no key of their own, monitoring runs and var
 > and `project_invites` tables plus the `can_access_project` / `is_project_owner`
 > helpers behind [Teams](#teams) — which every project-scoped RLS policy now
 > calls, so an older deployment keeps single-person behaviour until it is
-> applied. It also adds the trial columns (`trial_runs_used`, `trial_tokens_used`), their increment functions, the multi-organization column `profiles.active_project_id`, the `router_keys` table and `runs.route` for [LLM routers](#llm-routers-one-key-several-assistants), and widens the `provider` allow-list on `provider_keys` and `projects` to include `google` (all safe to re-run).
+> applied. It also adds the trial columns (`trial_runs_used`, `trial_tokens_used`), their increment functions, the multi-organization column `profiles.active_project_id`, the `router_keys` table and `runs.route` for [LLM routers](#llm-routers-one-key-several-assistants), widens the `provider` allow-list on `provider_keys` and `projects` to include `google`, and widens `projects.schedule` to add `custom` plus the `schedule_interval_days` column `custom` reads (all safe to re-run).
 
 ## Teams
 

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Router keys are encrypted at rest exactly like provider keys, and resolution ord
 
 ## Scheduled monitoring
 
-Set a project's schedule to **Daily**, **Weekly**, or a **custom** number of days (1–90) in Settings — or, for a new account, at the end of onboarding — then hit the cron endpoint on an interval:
+Set a project's schedule to **Daily**, **Weekly**, or a **custom** number of days (1–90) from the Runs page — or, for a new account, at the end of onboarding — then hit the cron endpoint on an interval:
 
 ```bash
 curl -X POST https://your-app.com/api/cron/run \
@@ -276,6 +276,12 @@ curl -X POST https://your-app.com/api/cron/run \
 ```
 
 The endpoint uses the Supabase **service role** to find due projects across all users, resolves each owner's own credential — a provider key or a [router key](#llm-routers-one-key-several-assistants) — and runs them. Scheduled runs are strictly self-funded: an owner on the free trial is skipped rather than spending the operator's allowance unattended. Only requests with the correct `CRON_SECRET` are accepted.
+
+Cadence counts whole **calendar days** (UTC) since the previous run's **start**
+time, so neither how long a model takes to answer nor a project's position in
+the nightly sweep can make it miss the next tick. One edge worth knowing: a
+manual run late in the day starts a fresh interval that turns over again at
+the very next morning's tick, a few hours later rather than a full day on.
 
 - **Vercel:** [`vercel.json`](./vercel.json) registers a daily cron. Set `CRON_SECRET` in your Vercel env, Vercel automatically sends it as the `Authorization` bearer.
 - **Anything else:** a system crontab, GitHub Actions, or any scheduler that can send an authenticated HTTP request works.
@@ -294,7 +300,9 @@ Set in your environment:
 While a user has free runs left and no key of their own, monitoring runs and variation generation use the shared key — whether they start from the dashboard, the scheduler, the REST API, MCP, or the one-shot [onboarding endpoint](#onboarding-a-url-in-one-call). Completed runs are counted on `profiles.trial_runs_used` (token spend is also recorded on `profiles.trial_tokens_used` so you can watch cost). A banner in the dashboard shows how many free runs are left; once they're gone, data collection stops with a clear prompt (and optional video) to add their own key. Adding a key removes the limit entirely: the owner's own provider or router key always beats the trial, so an organization set up on the free runs hands over to the owner's key the moment they add one, with no transfer step.
 
 
-> After upgrading, re-run `supabase/schema.sql`. It adds the `project_members`
+> Before deploying an upgrade, re-run `supabase/schema.sql`. Apply the schema
+> before the application code: project writes include columns introduced here
+> as soon as the new code is live. It adds the `project_members`
 > and `project_invites` tables plus the `can_access_project` / `is_project_owner`
 > helpers behind [Teams](#teams) — which every project-scoped RLS policy now
 > calls, so an older deployment keeps single-person behaviour until it is
@@ -519,6 +527,9 @@ curl -X POST https://your-app.com/api/v1/onboard \
   -d '{"url": "acme.io", "topics": [{"name": "CRM", "prompts": ["best crm for startups"]}], "schedule": "weekly"}'
 curl -X POST https://your-app.com/api/v1/onboard \
   -H "Authorization: Bearer lt_live_..." -H "Content-Type: application/json" \
+  -d '{"url": "acme.io", "schedule": "custom", "schedule_interval_days": 14}'
+curl -X POST https://your-app.com/api/v1/onboard \
+  -H "Authorization: Bearer lt_live_..." -H "Content-Type: application/json" \
   -d '{"url": "acme.io", "run": false}'
 ```
 
@@ -530,7 +541,7 @@ curl -X POST https://your-app.com/api/v1/onboard \
   -d '{"url": "acme.io", "brand_name": "Acme", "email": "jo@acme.io", "key": {"name": "Letterbrace"}}'
 ```
 
-The response carries `project`, `site` (what was read), `suggestion`, `saved` counts, `runs` (each with `keySource`), `trial` (used / limit / remaining), and — for a transfer — `account` and `api_key`. `needsKey` + `keyMessage` explain a sweep that could not start; `sweep_skipped: "no_prompts"` means nothing was suggested and nothing was sent to ask.
+The response carries `project`, `site` (what was read), `suggestion`, `saved` counts, `runs` (each with `keySource`), `trial` (used / limit / remaining), and — for a transfer — `account` and `api_key`. Project summaries include `schedule_interval_days` (`null` unless `schedule` is `custom`). `needsKey` + `keyMessage` explain a sweep that could not start; `sweep_skipped: "no_prompts"` means nothing was suggested and nothing was sent to ask.
 
 The run report carries four blocks. Read them in this order:
 
@@ -744,7 +755,9 @@ values
 Notes:
 
 - API-triggered runs are **BYOK-only** — the account must hold its own credential, either a provider key or a [router key](#llm-routers-one-key-several-assistants); free-trial runs stay dashboard-only. Either can be set over the API too (`PUT /api/v1/keys/<provider>`, `PUT /api/v1/router-keys/<router>`, or `lettertrace keys set` / `routers set`), so an agent never has to hand the user back to the browser mid-setup.
-- Projects created via the API start with `schedule: "off"` — trigger runs explicitly (or flip the schedule in the dashboard).
+- Projects created via `POST /api/v1/projects` start with `schedule: "off"`.
+  The one-shot `/api/v1/onboard` endpoint may instead receive `schedule`, plus
+  `schedule_interval_days` when that schedule is `custom`.
 - API keys grant access to all of the account's organizations. Revoke them anytime from Settings.
 - Requires `SUPABASE_SERVICE_ROLE_KEY` (the same variable scheduled runs use), since API-key requests carry no browser session.
 - OAuth tokens are scoped and audience-bound; a classic `lt_live_` API key stays full-access across all of the account's organizations. Revoke either anytime (API keys from Settings; OAuth grants via `/api/oauth/revoke`).

--- a/app/admin/accounts/[id]/page.tsx
+++ b/app/admin/accounts/[id]/page.tsx
@@ -6,7 +6,8 @@ import { classifyEmail } from "@/lib/growth";
 import { deriveCompany } from "@/lib/accounts";
 import { createServiceClient } from "@/lib/supabase/service";
 import { Badge, Card, SectionHeading, StatCard } from "@/components/ui";
-import { formatDate, timeAgo } from "@/lib/utils";
+import { formatDate, scheduleLabel, timeAgo } from "@/lib/utils";
+import type { Schedule } from "@/lib/types";
 
 export const dynamic = "force-dynamic";
 export const metadata = { robots: { index: false, follow: false } };
@@ -24,7 +25,7 @@ export const metadata = { robots: { index: false, follow: false } };
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const DAY_MS = 86_400_000;
 
-const SCHEDULE_TONE = { off: "sand", daily: "mint", weekly: "teal" } as const;
+const SCHEDULE_TONE = { off: "sand", daily: "mint", weekly: "teal", custom: "neutral" } as const;
 
 interface ProjectRow {
   id: string;
@@ -32,7 +33,8 @@ interface ProjectRow {
   brand_name: string;
   brand_domains: string[];
   description: string | null;
-  schedule: "off" | "daily" | "weekly";
+  schedule: Schedule;
+  schedule_interval_days: number | null;
   default_provider: string;
   default_model: string;
   replicates: number;
@@ -157,7 +159,7 @@ export default async function AdminAccountPage({ params }: { params: { id: strin
   const { data: projectRows } = await svc
     .from("projects")
     .select(
-      "id, name, brand_name, brand_domains, description, schedule, default_provider, default_model, replicates, use_web_search, last_run_at, created_at",
+      "id, name, brand_name, brand_domains, description, schedule, schedule_interval_days, default_provider, default_model, replicates, use_web_search, last_run_at, created_at",
     )
     .eq("user_id", profile.id)
     .order("created_at", { ascending: true });
@@ -392,7 +394,9 @@ export default async function AdminAccountPage({ params }: { params: { id: strin
                           {p.brand_domains.length > 0 ? p.brand_domains.join(" · ") : "no domains"}
                         </p>
                       </div>
-                      <Badge tone={SCHEDULE_TONE[p.schedule] ?? "sand"}>{p.schedule}</Badge>
+                      <Badge tone={SCHEDULE_TONE[p.schedule] ?? "sand"}>
+                        {scheduleLabel(p.schedule, p.schedule_interval_days)}
+                      </Badge>
                     </div>
                     {p.description && (
                       <p className="line-clamp-2 text-xs text-ink-soft">{p.description}</p>

--- a/app/api/cron/run/route.ts
+++ b/app/api/cron/run/route.ts
@@ -10,22 +10,12 @@ import {
   runBudgetMicros,
 } from "@/lib/trial";
 import { withSpan } from "@/lib/otel";
+import { isScheduleDue } from "@/lib/utils";
 import type { Span } from "@opentelemetry/api";
 import type { Project } from "@/lib/types";
 
 export const maxDuration = 800;
 export const dynamic = "force-dynamic";
-
-const DAY_MS = 24 * 60 * 60 * 1000;
-const WEEK_MS = 7 * DAY_MS;
-
-function isDue(project: Project, now: number): boolean {
-  if (project.schedule === "off") return false;
-  if (!project.last_run_at) return true;
-  const last = new Date(project.last_run_at).getTime();
-  const interval = project.schedule === "weekly" ? WEEK_MS : DAY_MS;
-  return now - last >= interval;
-}
 
 interface ProjectResult {
   projectId: string;
@@ -80,7 +70,7 @@ async function sweepAndRun(span: Span) {
   const results: ProjectResult[] = [];
 
   for (const project of projects) {
-    if (!isDue(project, now)) continue;
+    if (!isScheduleDue(project, now)) continue;
 
     try {
       // Ask the run resolver rather than reading provider_keys directly. The

--- a/app/api/cron/run/route.ts
+++ b/app/api/cron/run/route.ts
@@ -80,9 +80,10 @@ async function sweepAndRun(span: Span) {
       // project's grounding survives the route.
       //
       // Scheduled runs execute on the user's own key, or on the trial while
-      // its allowance lasts — "cadence from the onset": onboarding starts
-      // every project on a daily schedule, and the trial funds the beginning.
-      // The same atomic gate as manual runs applies, via the service-scoped
+      // its allowance lasts — "cadence from the onset": onboarding defaults
+      // to daily but lets the user pick the cadence up front, and the trial
+      // funds the beginning either way. The same atomic gate as manual runs
+      // applies, via the service-scoped
       // RPC (auth.uid() doesn't exist here); when the allowance is out — or
       // the RPC isn't applied to this database yet — the consume returns
       // false and the project is skipped, exactly as it always was.

--- a/app/api/onboarding/complete/route.ts
+++ b/app/api/onboarding/complete/route.ts
@@ -3,6 +3,8 @@ import { createClient } from "@/lib/supabase/server";
 import { setActiveProject } from "@/lib/data";
 import {
   firstSweep,
+  OnboardError,
+  parseOnboardingCadence,
   persistOnboarding,
   pickProjectEngine,
   sessionTrialMeter,
@@ -10,8 +12,7 @@ import {
 } from "@/lib/onboard";
 import { normalizeCompetitorList } from "@/lib/competitors";
 import { logDashboard } from "@/lib/activity";
-import { CUSTOM_INTERVAL_MAX, CUSTOM_INTERVAL_MIN, SCHEDULES } from "@/lib/utils";
-import type { Project, Schedule } from "@/lib/types";
+import type { Project } from "@/lib/types";
 
 export const maxDuration = 300;
 export const dynamic = "force-dynamic";
@@ -112,41 +113,18 @@ export async function POST(request: Request) {
     );
   }
 
-  // Cadence chosen on the onboarding CTA. Absent -> 'daily' rather than an
-  // error, so any client that doesn't send this field still gets the schedule
-  // this route used to hard-code. An explicit-but-wrong value is refused
-  // rather than coerced, same as PATCH /api/project/schedule.
-  const rawSchedule = body.schedule;
-  let schedule: Schedule = "daily";
-  if (rawSchedule !== undefined && rawSchedule !== null) {
-    if (typeof rawSchedule !== "string" || !SCHEDULES.includes(rawSchedule as Schedule)) {
-      return NextResponse.json(
-        { error: `schedule must be one of ${SCHEDULES.join(", ")}` },
-        { status: 400 },
-      );
+  // Absent remains daily for backwards compatibility with the dashboard
+  // wizard. The v1 one-shot flow uses the same parser with an "off" fallback.
+  // This route's body uses camelCase `intervalDays`, so the field name is
+  // passed through rather than string-rewritten out of the parser's message.
+  let cadence: ReturnType<typeof parseOnboardingCadence>;
+  try {
+    cadence = parseOnboardingCadence(body.schedule, body.intervalDays, "daily", "intervalDays");
+  } catch (error) {
+    if (error instanceof OnboardError) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
     }
-    schedule = rawSchedule as Schedule;
-  }
-
-  // Only 'custom' reads intervalDays; every other schedule carries its
-  // interval in its own name (see scheduleIntervalDays).
-  let schedule_interval_days: number | null = null;
-  if (schedule === "custom") {
-    const raw = body.intervalDays;
-    if (
-      typeof raw !== "number" ||
-      !Number.isInteger(raw) ||
-      raw < CUSTOM_INTERVAL_MIN ||
-      raw > CUSTOM_INTERVAL_MAX
-    ) {
-      return NextResponse.json(
-        {
-          error: `intervalDays must be a whole number of days between ${CUSTOM_INTERVAL_MIN} and ${CUSTOM_INTERVAL_MAX}`,
-        },
-        { status: 400 },
-      );
-    }
-    schedule_interval_days = raw;
+    throw error;
   }
 
   // Start the project on an engine this user can actually run — the user's
@@ -170,8 +148,8 @@ export async function POST(request: Request) {
       // onboarding CTA itself (validated above) instead of every project
       // silently starting on 'daily'. The Runs page control changes it any
       // time after.
-      schedule,
-      schedule_interval_days,
+      schedule: cadence.schedule,
+      schedule_interval_days: cadence.scheduleIntervalDays,
     })
     .select("*")
     .single();
@@ -198,8 +176,8 @@ export async function POST(request: Request) {
       topics: topics.length,
       competitors: competitors.length,
       brand_name,
-      schedule,
-      interval_days: schedule_interval_days,
+      schedule: cadence.schedule,
+      interval_days: cadence.scheduleIntervalDays,
     },
   });
 

--- a/app/api/onboarding/complete/route.ts
+++ b/app/api/onboarding/complete/route.ts
@@ -10,7 +10,8 @@ import {
 } from "@/lib/onboard";
 import { normalizeCompetitorList } from "@/lib/competitors";
 import { logDashboard } from "@/lib/activity";
-import type { Project } from "@/lib/types";
+import { CUSTOM_INTERVAL_MAX, CUSTOM_INTERVAL_MIN, SCHEDULES } from "@/lib/utils";
+import type { Project, Schedule } from "@/lib/types";
 
 export const maxDuration = 300;
 export const dynamic = "force-dynamic";
@@ -111,6 +112,43 @@ export async function POST(request: Request) {
     );
   }
 
+  // Cadence chosen on the onboarding CTA. Absent -> 'daily' rather than an
+  // error, so any client that doesn't send this field still gets the schedule
+  // this route used to hard-code. An explicit-but-wrong value is refused
+  // rather than coerced, same as PATCH /api/project/schedule.
+  const rawSchedule = body.schedule;
+  let schedule: Schedule = "daily";
+  if (rawSchedule !== undefined && rawSchedule !== null) {
+    if (typeof rawSchedule !== "string" || !SCHEDULES.includes(rawSchedule as Schedule)) {
+      return NextResponse.json(
+        { error: `schedule must be one of ${SCHEDULES.join(", ")}` },
+        { status: 400 },
+      );
+    }
+    schedule = rawSchedule as Schedule;
+  }
+
+  // Only 'custom' reads intervalDays; every other schedule carries its
+  // interval in its own name (see scheduleIntervalDays).
+  let schedule_interval_days: number | null = null;
+  if (schedule === "custom") {
+    const raw = body.intervalDays;
+    if (
+      typeof raw !== "number" ||
+      !Number.isInteger(raw) ||
+      raw < CUSTOM_INTERVAL_MIN ||
+      raw > CUSTOM_INTERVAL_MAX
+    ) {
+      return NextResponse.json(
+        {
+          error: `intervalDays must be a whole number of days between ${CUSTOM_INTERVAL_MIN} and ${CUSTOM_INTERVAL_MAX}`,
+        },
+        { status: 400 },
+      );
+    }
+    schedule_interval_days = raw;
+  }
+
   // Start the project on an engine this user can actually run — the user's
   // own key wins over the trial; the env default applies only when they have
   // none. See pickProjectEngine.
@@ -128,11 +166,12 @@ export async function POST(request: Request) {
       description,
       default_provider: provider,
       default_model: model,
-      // "Cadence from the onset": a new project monitors on a schedule from
-      // day one (trial-funded until the allowance runs out, then unblocked by
-      // the user's own key) instead of being a one-shot demo whose schedule
-      // hides in Settings. The Runs page control turns it off in one click.
-      schedule: "daily",
+      // "Cadence from the onset": the user picks the schedule on the
+      // onboarding CTA itself (validated above) instead of every project
+      // silently starting on 'daily'. The Runs page control changes it any
+      // time after.
+      schedule,
+      schedule_interval_days,
     })
     .select("*")
     .single();
@@ -155,7 +194,13 @@ export async function POST(request: Request) {
     projectId: project.id,
     targetType: "project",
     targetId: project.id,
-    metadata: { topics: topics.length, competitors: competitors.length, brand_name },
+    metadata: {
+      topics: topics.length,
+      competitors: competitors.length,
+      brand_name,
+      schedule,
+      interval_days: schedule_interval_days,
+    },
   });
 
   // Competitors first, then topics + prompts: executeRun reads competitors to

--- a/app/api/onboarding/onboarding-route.test.ts
+++ b/app/api/onboarding/onboarding-route.test.ts
@@ -138,3 +138,38 @@ describe("POST /api/onboarding/complete, creating more organizations", () => {
     expect(res.status).toBe(400);
   });
 });
+
+describe("POST /api/onboarding/complete — cadence validation", () => {
+  const good = { ...BASE, topics: [{ name: "CDN", prompts: ["best cdn?"] }] };
+
+  // Same wording PATCH /api/project/schedule uses, built from SCHEDULES so the
+  // message and the check it describes can't fall out of step.
+  it("rejects an unrecognised schedule, naming the accepted values", async () => {
+    const res = await POST(req({ ...good, schedule: "hourly" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("schedule must be one of off, daily, weekly, custom");
+  });
+
+  it("rejects 'custom' with no intervalDays", async () => {
+    const res = await POST(req({ ...good, schedule: "custom" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/intervalDays must be a whole number of days between 1 and 90/);
+  });
+
+  it("rejects 'custom' with an out-of-range or non-integer intervalDays", async () => {
+    for (const bad of [0, 91, 1.5]) {
+      const res = await POST(req({ ...good, schedule: "custom", intervalDays: bad }));
+      expect(res.status).toBe(400);
+    }
+  });
+
+  // The mocked client throws on any .from() call, so reaching the database is
+  // itself the assertion that validation let a good cadence through.
+  it("lets a valid cadence through to the insert", async () => {
+    await expect(
+      POST(req({ ...good, schedule: "custom", intervalDays: 10 })),
+    ).rejects.toThrow(/before touching the database/);
+  });
+});

--- a/app/api/onboarding/onboarding-schedule.test.ts
+++ b/app/api/onboarding/onboarding-schedule.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Same recording-fake pattern as onboarding-competitors.test.ts: these cases
+// need to see what actually reaches the projects insert, which the throwing
+// mock in onboarding-route.test.ts deliberately can't provide (400s there
+// return before ever calling .from()). Rejection cases stay in that file;
+// only "does the resolved value reach the insert" cases live here.
+
+const inserts: { table: string; values: unknown }[] = [];
+
+const PROJECT = {
+  id: "proj-1",
+  user_id: "user-1",
+  brand_name: "Acme",
+  brand_domains: ["acme.com"],
+  default_provider: "anthropic",
+  default_model: "claude-sonnet-4-6",
+};
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: () => ({
+    auth: { getUser: async () => ({ data: { user: { id: "user-1", email: "a@b.co" } } }) },
+    from: (table: string) => ({
+      insert(values: unknown) {
+        inserts.push({ table, values });
+        const row = table === "projects" ? PROJECT : { id: `${table}-row` };
+        return {
+          select: () => ({ single: async () => ({ data: row, error: null }) }),
+          // Batch inserts are awaited directly, with no .select() after them.
+          then: (ok: (v: unknown) => unknown) => Promise.resolve({ error: null }).then(ok),
+        };
+      },
+      select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: null }) }) }),
+      update: () => ({ eq: async () => ({ error: null }) }),
+    }),
+  }),
+}));
+
+vi.mock("@/lib/data", () => ({
+  setActiveProject: vi.fn(),
+  getProjects: vi.fn(async () => []),
+  getConfiguredProviders: vi.fn(async () => []),
+  getRouterKeysPublic: vi.fn(async () => []),
+}));
+vi.mock("@/lib/llm", () => ({ humanError: (e: unknown) => String(e) }));
+vi.mock("@/lib/activity", () => ({ logDashboard: vi.fn() }));
+vi.mock("@/lib/trial", () => ({
+  pickDefaultProvider: vi.fn(() => "anthropic"),
+  // No key: the route returns before executing a run, which is all we need.
+  resolveRunKey: vi.fn(async () => ({
+    source: "none",
+    provider: "anthropic",
+    model: "claude-sonnet-4-6",
+    requested: { provider: "anthropic", model: "claude-sonnet-4-6" },
+  })),
+  engineKeyMessage: () => "add a key",
+  recordTrialUsage: vi.fn(),
+  recordTrialSpend: vi.fn(),
+  consumeTrialRun: vi.fn(),
+  resolveRunKeyFor: vi.fn(async () => ({
+    source: "none",
+    provider: "anthropic",
+    model: "claude-sonnet-4-6",
+    requested: { provider: "anthropic", model: "claude-sonnet-4-6" },
+  })),
+  runBudgetMicros: () => null,
+  getTrialUsage: vi.fn(async () => ({ runs: 0, spendMicros: 0 })),
+  trialRunLimit: () => 15,
+  trialCoveredProviders: () => [],
+}));
+vi.mock("@/lib/engine", () => ({ executeRun: vi.fn() }));
+
+const { POST } = await import("@/app/api/onboarding/complete/route");
+
+function req(body: unknown) {
+  return new Request("http://localhost/api/onboarding/complete", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+const BASE = {
+  brand_name: "Acme",
+  name: "Acme",
+  brand_domains: ["acme.com"],
+  topics: [{ name: "CDN", prompts: ["best cdn?"] }],
+};
+
+const projectInsert = () =>
+  inserts.find((i) => i.table === "projects")?.values as {
+    schedule: string;
+    schedule_interval_days: number | null;
+  };
+
+beforeEach(() => {
+  inserts.length = 0;
+  vi.clearAllMocks();
+});
+
+describe("POST /api/onboarding/complete — cadence reaches the project insert", () => {
+  it("stores a named schedule with no interval", async () => {
+    for (const schedule of ["daily", "weekly"]) {
+      inserts.length = 0;
+      const res = await POST(req({ ...BASE, schedule }));
+      expect(res.status).toBe(200);
+      expect(projectInsert()).toMatchObject({ schedule, schedule_interval_days: null });
+    }
+  });
+
+  // The toggle off is a schedule of its own, not a missing field — an
+  // unscheduled project still has to be created.
+  it("stores 'off' when the toggle is switched off", async () => {
+    const res = await POST(req({ ...BASE, schedule: "off", intervalDays: null }));
+    expect(res.status).toBe(200);
+    expect(projectInsert()).toMatchObject({ schedule: "off", schedule_interval_days: null });
+  });
+
+  it("stores a custom schedule together with its interval", async () => {
+    const res = await POST(req({ ...BASE, schedule: "custom", intervalDays: 14 }));
+    expect(res.status).toBe(200);
+    expect(projectInsert()).toMatchObject({
+      schedule: "custom",
+      schedule_interval_days: 14,
+    });
+  });
+
+  // The onboarding CTA always sends a schedule, but any older client doesn't —
+  // absent must still land on the schedule this route used to hard-code rather
+  // than reject the whole signup.
+  it("defaults to daily when no schedule is sent", async () => {
+    const res = await POST(req(BASE));
+    expect(res.status).toBe(200);
+    expect(projectInsert()).toMatchObject({
+      schedule: "daily",
+      schedule_interval_days: null,
+    });
+  });
+});

--- a/app/api/project/route.test.ts
+++ b/app/api/project/route.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const insertSpy = vi.fn();
+const updateSpy = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: () => ({
+    auth: { getUser: async () => ({ data: { user: { id: "user-1" } } }) },
+    from: () => ({
+      insert: (fields: Record<string, unknown>) => {
+        insertSpy(fields);
+        return {
+          select: () => ({
+            single: async () => ({ data: { id: "project-1", ...fields }, error: null }),
+          }),
+        };
+      },
+      update: (fields: Record<string, unknown>) => {
+        updateSpy(fields);
+        return {
+          eq: () => ({
+            select: () => ({
+              single: async () => ({ data: { id: "project-1", ...fields }, error: null }),
+            }),
+          }),
+        };
+      },
+    }),
+  }),
+}));
+vi.mock("@/lib/data", () => ({
+  getProject: vi.fn(async () => null),
+  setActiveProject: vi.fn(),
+}));
+vi.mock("@/lib/models", () => ({
+  isProvider: () => false,
+  resolveEngine: () => ({ ok: true, provider: "anthropic", model: "model-1" }),
+}));
+vi.mock("@/lib/trial", () => ({ pickDefaultProvider: () => "anthropic" }));
+vi.mock("@/lib/llm", () => ({ humanError: (error: unknown) => String(error) }));
+vi.mock("@/lib/activity", () => ({ logDashboard: vi.fn() }));
+
+const { POST } = await import("./route");
+
+function req(body: Record<string, unknown>) {
+  return new Request("http://localhost/api/project", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ name: "Acme", brand_name: "Acme", ...body }),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("POST /api/project — custom cadence validation", () => {
+  it("rejects every malformed custom interval instead of coercing or defaulting", async () => {
+    for (const intervalDays of [undefined, null, "14", "", 0, 0.9, 1.5, 91]) {
+      const res = await POST(req({ schedule: "custom", intervalDays }));
+      expect(res.status).toBe(400);
+    }
+    expect(insertSpy).not.toHaveBeenCalled();
+  });
+
+  it("stores a valid custom interval", async () => {
+    const res = await POST(req({ schedule: "custom", intervalDays: 14 }));
+    expect(res.status).toBe(200);
+    expect(insertSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ schedule: "custom", schedule_interval_days: 14 }),
+    );
+  });
+
+  it("nulls the interval for named and disabled schedules", async () => {
+    for (const schedule of ["off", "daily", "weekly"]) {
+      insertSpy.mockClear();
+      const res = await POST(req({ schedule, intervalDays: 30 }));
+      expect(res.status).toBe(200);
+      expect(insertSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ schedule, schedule_interval_days: null }),
+      );
+    }
+  });
+
+  it("omits cadence from a new project's insert when the body doesn't send it", async () => {
+    // Settings no longer offers a schedule control, so its save omits the
+    // field entirely; the new row falls through to the database's own
+    // default ('off') rather than this route re-asserting one.
+    const res = await POST(req({}));
+    expect(res.status).toBe(200);
+    const fields = insertSpy.mock.calls[0][0];
+    expect(fields).not.toHaveProperty("schedule");
+    expect(fields).not.toHaveProperty("schedule_interval_days");
+  });
+
+  it("leaves an existing project's cadence untouched when the body doesn't send it", async () => {
+    // A body without `schedule` (e.g. a Settings save) must not silently
+    // reset a project already on a custom cadence back to 'off'.
+    const data = await import("@/lib/data");
+    vi.mocked(data.getProject).mockResolvedValueOnce({
+      id: "project-1",
+      default_provider: "anthropic",
+    } as never);
+
+    const res = await POST(req({}));
+    expect(res.status).toBe(200);
+    const fields = updateSpy.mock.calls[0][0];
+    expect(fields).not.toHaveProperty("schedule");
+    expect(fields).not.toHaveProperty("schedule_interval_days");
+  });
+});

--- a/app/api/project/route.ts
+++ b/app/api/project/route.ts
@@ -5,9 +5,8 @@ import { isProvider, resolveEngine } from "@/lib/models";
 import { pickDefaultProvider } from "@/lib/trial";
 import { humanError } from "@/lib/llm";
 import { logDashboard } from "@/lib/activity";
+import { CUSTOM_INTERVAL_MAX, CUSTOM_INTERVAL_MIN, SCHEDULES } from "@/lib/utils";
 import type { Provider, Schedule } from "@/lib/types";
-
-const SCHEDULES: Schedule[] = ["off", "daily", "weekly"];
 
 function toAliases(value: unknown): string[] {
   const parts =
@@ -89,6 +88,20 @@ export async function POST(request: Request) {
       ? (b.schedule as Schedule)
       : "off";
 
+  // Only meaningful for 'custom' - every other schedule carries its interval
+  // in its own name. Clamped rather than rejected, matching this route's
+  // existing forgiving-default posture for `schedule` above (an unrecognised
+  // value falls back to "off" rather than erroring). Null for anything but
+  // 'custom' so a stale interval left over from a previous selection can't
+  // resurface if the user picks 'custom' again later without a fresh number.
+  const scheduleIntervalDays =
+    schedule === "custom"
+      ? Math.min(
+          CUSTOM_INTERVAL_MAX,
+          Math.max(CUSTOM_INTERVAL_MIN, Math.trunc(Number(b.intervalDays)) || 14),
+        )
+      : null;
+
   const baseFields = {
     name,
     brand_name,
@@ -96,6 +109,7 @@ export async function POST(request: Request) {
     brand_domains: toDomains(b.brand_domains),
     description: toNullableString(b.description),
     schedule,
+    schedule_interval_days: scheduleIntervalDays,
     ...(typeof b.use_web_search === "boolean" ? { use_web_search: b.use_web_search } : {}),
   };
 
@@ -145,7 +159,7 @@ export async function POST(request: Request) {
         projectId: existing.id,
         targetType: "project",
         targetId: existing.id,
-        metadata: { schedule },
+        metadata: { schedule, schedule_interval_days: scheduleIntervalDays },
       });
       return NextResponse.json(data);
     }

--- a/app/api/project/route.ts
+++ b/app/api/project/route.ts
@@ -5,7 +5,7 @@ import { isProvider, resolveEngine } from "@/lib/models";
 import { pickDefaultProvider } from "@/lib/trial";
 import { humanError } from "@/lib/llm";
 import { logDashboard } from "@/lib/activity";
-import { CUSTOM_INTERVAL_MAX, CUSTOM_INTERVAL_MIN, SCHEDULES } from "@/lib/utils";
+import { customIntervalError, parseCustomInterval, SCHEDULES } from "@/lib/utils";
 import type { Provider, Schedule } from "@/lib/types";
 
 function toAliases(value: unknown): string[] {
@@ -83,24 +83,30 @@ export async function POST(request: Request) {
       ? b.default_model.trim()
       : undefined;
 
-  const schedule: Schedule =
-    typeof b.schedule === "string" && SCHEDULES.includes(b.schedule as Schedule)
-      ? (b.schedule as Schedule)
-      : "off";
+  // Cadence is set at onboarding and on the Runs page, not here — Settings no
+  // longer offers it. A body that omits `schedule` must leave both columns
+  // untouched on an update; including them unconditionally would silently
+  // reset an existing project's cadence to 'off' on every unrelated save.
+  let cadence: { schedule: Schedule; schedule_interval_days: number | null } | undefined;
+  if (b.schedule !== undefined) {
+    const schedule: Schedule =
+      typeof b.schedule === "string" && SCHEDULES.includes(b.schedule as Schedule)
+        ? (b.schedule as Schedule)
+        : "off";
 
-  // Only meaningful for 'custom' - every other schedule carries its interval
-  // in its own name. Clamped rather than rejected, matching this route's
-  // existing forgiving-default posture for `schedule` above (an unrecognised
-  // value falls back to "off" rather than erroring). Null for anything but
-  // 'custom' so a stale interval left over from a previous selection can't
-  // resurface if the user picks 'custom' again later without a fresh number.
-  const scheduleIntervalDays =
-    schedule === "custom"
-      ? Math.min(
-          CUSTOM_INTERVAL_MAX,
-          Math.max(CUSTOM_INTERVAL_MIN, Math.trunc(Number(b.intervalDays)) || 14),
-        )
-      : null;
+    // All server entrypoints reject the same malformed custom intervals.
+    // Browser controls normalise their drafts before sending; direct callers
+    // must not get a route-specific clamp or silent default.
+    const scheduleIntervalDays =
+      schedule === "custom" ? parseCustomInterval(b.intervalDays) : null;
+    if (schedule === "custom" && scheduleIntervalDays === null) {
+      return NextResponse.json(
+        { error: customIntervalError() },
+        { status: 400 },
+      );
+    }
+    cadence = { schedule, schedule_interval_days: scheduleIntervalDays };
+  }
 
   const baseFields = {
     name,
@@ -108,8 +114,7 @@ export async function POST(request: Request) {
     brand_aliases: toAliases(b.brand_aliases),
     brand_domains: toDomains(b.brand_domains),
     description: toNullableString(b.description),
-    schedule,
-    schedule_interval_days: scheduleIntervalDays,
+    ...cadence,
     ...(typeof b.use_web_search === "boolean" ? { use_web_search: b.use_web_search } : {}),
   };
 
@@ -159,7 +164,7 @@ export async function POST(request: Request) {
         projectId: existing.id,
         targetType: "project",
         targetId: existing.id,
-        metadata: { schedule, schedule_interval_days: scheduleIntervalDays },
+        metadata: cadence ?? {},
       });
       return NextResponse.json(data);
     }

--- a/app/api/project/schedule/route.test.ts
+++ b/app/api/project/schedule/route.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const updateSpy = vi.fn();
+let updateResult: { data: unknown; error: unknown } = { data: null, error: null };
+
+// The route pulls in the Supabase server client (next/headers); we build just
+// enough of the chain PATCH actually calls: from().update().eq().eq().select().single().
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: () => ({
+    auth: { getUser: async () => ({ data: { user: { id: "user-1" } } }) },
+    from: () => ({
+      update: (fields: unknown) => {
+        updateSpy(fields);
+        return {
+          eq: () => ({
+            eq: () => ({
+              select: () => ({
+                single: async () => updateResult,
+              }),
+            }),
+          }),
+        };
+      },
+    }),
+  }),
+}));
+// getProject uses React's cache(), which only exists in a server-component
+// runtime — same treatment the onboarding route tests give lib/data.
+vi.mock("@/lib/data", () => ({
+  getProject: vi.fn(async () => ({ id: "proj-1", user_id: "user-1" })),
+}));
+vi.mock("@/lib/llm", () => ({ humanError: (e: unknown) => String(e) }));
+vi.mock("@/lib/activity", () => ({ logDashboard: vi.fn() }));
+
+const { PATCH } = await import("./route");
+
+function req(body: unknown) {
+  return new Request("http://localhost/api/project/schedule", {
+    method: "PATCH",
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  updateResult = { data: { id: "proj-1", schedule: "daily" }, error: null };
+});
+
+describe("PATCH /api/project/schedule — validation", () => {
+  it("rejects an unrecognised schedule, naming the accepted values", async () => {
+    const res = await PATCH(req({ schedule: "hourly" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("schedule must be one of off, daily, weekly, custom");
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects 'custom' with no intervalDays", async () => {
+    const res = await PATCH(req({ schedule: "custom" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/intervalDays must be a whole number of days between 1 and 90/);
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects 'custom' with an out-of-range intervalDays", async () => {
+    for (const bad of [0, -3, 91, 1.5]) {
+      updateSpy.mockClear();
+      const res = await PATCH(req({ schedule: "custom", intervalDays: bad }));
+      expect(res.status).toBe(400);
+      expect(updateSpy).not.toHaveBeenCalled();
+    }
+  });
+
+  it("accepts 'custom' with an in-range whole number and stores it", async () => {
+    const res = await PATCH(req({ schedule: "custom", intervalDays: 14 }));
+    expect(res.status).toBe(200);
+    expect(updateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ schedule: "custom", schedule_interval_days: 14 }),
+    );
+  });
+
+  // A stale interval left over from a previous 'custom' selection must not
+  // resurface silently if the schedule is later switched away from 'custom'.
+  it("nulls schedule_interval_days for every schedule but 'custom'", async () => {
+    for (const schedule of ["off", "daily", "weekly"]) {
+      updateSpy.mockClear();
+      const res = await PATCH(req({ schedule, intervalDays: 30 }));
+      expect(res.status).toBe(200);
+      expect(updateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ schedule, schedule_interval_days: null }),
+      );
+    }
+  });
+
+  it("rejects a non-string schedule and invalid JSON the same way as before", async () => {
+    expect((await PATCH(req({ schedule: 3 }))).status).toBe(400);
+    const badJson = new Request("http://localhost/api/project/schedule", {
+      method: "PATCH",
+      body: "{not json",
+    });
+    expect((await PATCH(badJson)).status).toBe(400);
+  });
+});

--- a/app/api/project/schedule/route.ts
+++ b/app/api/project/schedule/route.ts
@@ -3,9 +3,8 @@ import { createClient } from "@/lib/supabase/server";
 import { getProject } from "@/lib/data";
 import { humanError } from "@/lib/llm";
 import { logDashboard } from "@/lib/activity";
+import { CUSTOM_INTERVAL_MAX, CUSTOM_INTERVAL_MIN, SCHEDULES } from "@/lib/utils";
 import type { Schedule } from "@/lib/types";
-
-const SCHEDULES: Schedule[] = ["off", "daily", "weekly"];
 
 // Schedule-only write, so the Runs page can offer the toggle where people
 // actually go looking for it. POST /api/project is a full-form upsert —
@@ -29,10 +28,35 @@ export async function PATCH(request: Request) {
   }
   const schedule = (body as { schedule?: unknown } | null)?.schedule;
   if (typeof schedule !== "string" || !SCHEDULES.includes(schedule as Schedule)) {
+    // Built from SCHEDULES rather than typed out again, so this message can't
+    // fall out of step with what the check above actually accepts.
     return NextResponse.json(
-      { error: "schedule must be one of off, daily or weekly" },
+      { error: `schedule must be one of ${SCHEDULES.join(", ")}` },
       { status: 400 },
     );
+  }
+
+  // Only 'custom' reads this; every other schedule carries its interval in its
+  // own name. Nulled below for anything but 'custom' so a stale interval left
+  // over from a previous 'custom' selection can't resurface if the user picks
+  // 'custom' again later without re-entering a number.
+  let intervalDays: number | null = null;
+  if (schedule === "custom") {
+    const raw = (body as { intervalDays?: unknown } | null)?.intervalDays;
+    if (
+      typeof raw !== "number" ||
+      !Number.isInteger(raw) ||
+      raw < CUSTOM_INTERVAL_MIN ||
+      raw > CUSTOM_INTERVAL_MAX
+    ) {
+      return NextResponse.json(
+        {
+          error: `intervalDays must be a whole number of days between ${CUSTOM_INTERVAL_MIN} and ${CUSTOM_INTERVAL_MAX}`,
+        },
+        { status: 400 },
+      );
+    }
+    intervalDays = raw;
   }
 
   try {
@@ -43,7 +67,11 @@ export async function PATCH(request: Request) {
 
     const { data, error } = await supabase
       .from("projects")
-      .update({ schedule, updated_at: new Date().toISOString() })
+      .update({
+        schedule,
+        schedule_interval_days: intervalDays,
+        updated_at: new Date().toISOString(),
+      })
       .eq("id", project.id)
       .eq("user_id", user.id)
       .select("*")
@@ -56,11 +84,14 @@ export async function PATCH(request: Request) {
     await logDashboard(user, request, {
       category: "project",
       action: "project.updated",
-      summary: `Set monitoring schedule to ${schedule}`,
+      summary:
+        schedule === "custom"
+          ? `Set monitoring schedule to every ${intervalDays} days`
+          : `Set monitoring schedule to ${schedule}`,
       projectId: project.id,
       targetType: "project",
       targetId: project.id,
-      metadata: { schedule },
+      metadata: { schedule, schedule_interval_days: intervalDays },
     });
     return NextResponse.json(data);
   } catch (e) {

--- a/app/api/project/schedule/route.ts
+++ b/app/api/project/schedule/route.ts
@@ -3,7 +3,7 @@ import { createClient } from "@/lib/supabase/server";
 import { getProject } from "@/lib/data";
 import { humanError } from "@/lib/llm";
 import { logDashboard } from "@/lib/activity";
-import { CUSTOM_INTERVAL_MAX, CUSTOM_INTERVAL_MIN, SCHEDULES } from "@/lib/utils";
+import { customIntervalError, parseCustomInterval, SCHEDULES } from "@/lib/utils";
 import type { Schedule } from "@/lib/types";
 
 // Schedule-only write, so the Runs page can offer the toggle where people
@@ -43,20 +43,13 @@ export async function PATCH(request: Request) {
   let intervalDays: number | null = null;
   if (schedule === "custom") {
     const raw = (body as { intervalDays?: unknown } | null)?.intervalDays;
-    if (
-      typeof raw !== "number" ||
-      !Number.isInteger(raw) ||
-      raw < CUSTOM_INTERVAL_MIN ||
-      raw > CUSTOM_INTERVAL_MAX
-    ) {
+    intervalDays = parseCustomInterval(raw);
+    if (intervalDays === null) {
       return NextResponse.json(
-        {
-          error: `intervalDays must be a whole number of days between ${CUSTOM_INTERVAL_MIN} and ${CUSTOM_INTERVAL_MAX}`,
-        },
+        { error: customIntervalError() },
         { status: 400 },
       );
     }
-    intervalDays = raw;
   }
 
   try {

--- a/app/api/v1/onboard/onboard-route.test.ts
+++ b/app/api/v1/onboard/onboard-route.test.ts
@@ -47,20 +47,49 @@ vi.mock("@/lib/llm", () => ({ humanError: (e: unknown) => (e instanceof Error ? 
 // lib/data (React's cache(), server-runtime only) and the whole run stack,
 // none of which this seam needs. The error class is redefined here so the
 // route's instanceof check meets the same class the tests throw.
-vi.mock("@/lib/onboard", () => ({
-  OnboardError: class OnboardError extends Error {
+vi.mock("@/lib/onboard", () => {
+  class OnboardError extends Error {
     constructor(
       public code: "invalid",
       message: string,
     ) {
       super(message);
     }
-  },
-  onboardFromUrl: vi.fn(),
-  resolveOnboardingAccount: vi.fn(),
-  mintApiKey: vi.fn(),
-  serviceTrialMeter: vi.fn((_db: unknown, userId: string) => ({ for: userId })),
-}));
+  }
+  return {
+    OnboardError,
+    parseOnboardingCadence: (
+      rawSchedule: unknown,
+      rawInterval: unknown,
+      fallback: string,
+    ) => {
+      const schedules = ["off", "daily", "weekly", "custom"];
+      const schedule = rawSchedule ?? fallback;
+      if (typeof schedule !== "string" || !schedules.includes(schedule)) {
+        throw new OnboardError("invalid", `schedule must be one of ${schedules.join(", ")}`);
+      }
+      if (schedule !== "custom") {
+        return { schedule, scheduleIntervalDays: null };
+      }
+      if (
+        typeof rawInterval !== "number" ||
+        !Number.isInteger(rawInterval) ||
+        rawInterval < 1 ||
+        rawInterval > 90
+      ) {
+        throw new OnboardError(
+          "invalid",
+          "schedule_interval_days must be a whole number of days between 1 and 90",
+        );
+      }
+      return { schedule, scheduleIntervalDays: rawInterval };
+    },
+    onboardFromUrl: vi.fn(),
+    resolveOnboardingAccount: vi.fn(),
+    mintApiKey: vi.fn(),
+    serviceTrialMeter: vi.fn((_db: unknown, userId: string) => ({ for: userId })),
+  };
+});
 
 const admin = await import("@/lib/admin");
 const guards = await import("@/lib/api-guards");
@@ -129,7 +158,18 @@ describe("POST /api/v1/onboard — validation", () => {
   it("rejects an unknown schedule", async () => {
     const res = await POST(req({ url: "acme.com", schedule: "hourly" }));
     expect(res.status).toBe(400);
-    expect((await res.json()).error).toMatch(/Unknown schedule/);
+    expect((await res.json()).error).toMatch(/schedule must be one of/);
+    expect(onboard.onboardFromUrl).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid custom intervals before starting onboarding", async () => {
+    for (const schedule_interval_days of [undefined, "14", 0, 1.5, 91]) {
+      const res = await POST(
+        req({ url: "acme.com", schedule: "custom", schedule_interval_days }),
+      );
+      expect(res.status).toBe(400);
+    }
+    expect(onboard.onboardFromUrl).not.toHaveBeenCalled();
   });
 
   it("rejects a sent topic with no prompts", async () => {
@@ -200,6 +240,21 @@ describe("POST /api/v1/onboard — into the caller's own account", () => {
       expect.objectContaining({ userId: "caller-1", action: "onboarding.completed" }),
     );
     expect(onboard.mintApiKey).not.toHaveBeenCalled();
+  });
+
+  it("accepts custom cadence and maps the public interval field", async () => {
+    const res = await POST(
+      req({
+        url: "acme.com",
+        schedule: "custom",
+        schedule_interval_days: 14,
+      }),
+    );
+    expect(res.status).toBe(202);
+    expect(vi.mocked(onboard.onboardFromUrl).mock.calls[0][0].input).toMatchObject({
+      schedule: "custom",
+      scheduleIntervalDays: 14,
+    });
   });
 
   it("answers 201 with the sweep settled, and relays a key refusal", async () => {

--- a/app/api/v1/onboard/route.ts
+++ b/app/api/v1/onboard/route.ts
@@ -7,6 +7,7 @@ import {
   mintApiKey,
   onboardFromUrl,
   OnboardError,
+  parseOnboardingCadence,
   resolveOnboardingAccount,
   serviceTrialMeter,
   type OnboardingAccount,
@@ -14,15 +15,12 @@ import {
 } from "@/lib/onboard";
 import { apiActor, logActivity, logApiRequest } from "@/lib/activity";
 import { humanError } from "@/lib/llm";
-import type { Schedule } from "@/lib/types";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
 // A sweep in the foreground can run for minutes; background (the default)
 // answers as soon as the run rows exist.
 export const maxDuration = 300;
 export const dynamic = "force-dynamic";
-
-const SCHEDULES: Schedule[] = ["off", "daily", "weekly"];
 
 // POST /api/v1/onboard — a URL in, a monitored organization out.
 //
@@ -36,7 +34,8 @@ const SCHEDULES: Schedule[] = ["off", "daily", "weekly"];
 //
 // Body: { url, brand_name?, name?, description?, brand_aliases?,
 //         brand_domains?, topics?: [{name, prompts[]}], competitors?,
-//         schedule? ("off" default), run? (true), background? (true),
+//         schedule? ("off" default), schedule_interval_days? (for "custom"),
+//         run? (true), background? (true),
 //         email?, key?: boolean | { name }, seat?: boolean }
 //
 // `email` is the transfer: it onboards the URL into THAT account — adopted
@@ -79,11 +78,18 @@ export async function POST(request: Request) {
     );
   }
 
-  if (typeof body.schedule === "string" && !SCHEDULES.includes(body.schedule as Schedule)) {
-    return NextResponse.json(
-      { error: `Unknown schedule "${body.schedule}". Use one of: ${SCHEDULES.join(", ")}.` },
-      { status: 400 },
+  let cadence: ReturnType<typeof parseOnboardingCadence>;
+  try {
+    cadence = parseOnboardingCadence(
+      body.schedule,
+      body.schedule_interval_days,
+      "off",
     );
+  } catch (error) {
+    if (error instanceof OnboardError) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+    throw error;
   }
 
   const topics: TopicInput[] | null = Array.isArray(body.topics)
@@ -154,7 +160,8 @@ export async function POST(request: Request) {
         extraDomains: toDomains(body.brand_domains),
         topics,
         competitors: body.competitors,
-        schedule: typeof body.schedule === "string" ? (body.schedule as Schedule) : "off",
+        schedule: cadence.schedule,
+        scheduleIntervalDays: cadence.scheduleIntervalDays,
         run,
         background: body.background !== false,
       },

--- a/app/dashboard/onboarding.tsx
+++ b/app/dashboard/onboarding.tsx
@@ -14,7 +14,11 @@ import {
 import { Badge, Button, Card, CardBody, Input, Label, Spinner, Textarea } from "@/components/ui";
 import { CadencePicker, type OnboardingCadence } from "@/components/dashboard/cadence-picker";
 import { brandNameFromSite, hostOf } from "@/lib/brand-name";
-import { cn } from "@/lib/utils";
+import {
+  cn,
+  CUSTOM_INTERVAL_DEFAULT,
+  normalizeCustomInterval,
+} from "@/lib/utils";
 
 interface Topic {
   name: string;
@@ -62,7 +66,7 @@ export function Onboarding() {
   // "Custom" is a day count, not off. See CadencePicker.
   const [scheduleOn, setScheduleOn] = useState(true);
   const [cadence, setCadence] = useState<OnboardingCadence>("daily");
-  const [customDays, setCustomDays] = useState(14);
+  const [customDays, setCustomDays] = useState(CUSTOM_INTERVAL_DEFAULT);
 
   // --- Step 1 -> suggest -----------------------------------------------------
   // Doubles as the Retry handler: re-submitting is the whole recovery.
@@ -204,6 +208,11 @@ export function Onboarding() {
 
   // --- Step 2 -> complete + run ----------------------------------------------
   async function handleStart() {
+    const submittedCustomDays = normalizeCustomInterval(
+      customDays,
+      CUSTOM_INTERVAL_DEFAULT,
+    );
+    if (submittedCustomDays !== customDays) setCustomDays(submittedCustomDays);
     const cleaned = topics.map((t) => ({
       name: t.name.trim(),
       // Blank question rows are fine — they're just unused inputs, so drop
@@ -257,7 +266,8 @@ export function Onboarding() {
           brand_domains: hostOf(domain) ? [hostOf(domain)] : [],
           description: description.trim() || null,
           schedule: scheduleOn ? cadence : "off",
-          intervalDays: scheduleOn && cadence === "custom" ? customDays : null,
+          intervalDays:
+            scheduleOn && cadence === "custom" ? submittedCustomDays : null,
           topics: cleaned,
           // Blank rows are just unused inputs, so drop them rather than
           // blocking the submit — a nameless competitor holds nothing else.

--- a/app/dashboard/onboarding.tsx
+++ b/app/dashboard/onboarding.tsx
@@ -12,6 +12,7 @@ import {
   X,
 } from "lucide-react";
 import { Badge, Button, Card, CardBody, Input, Label, Spinner, Textarea } from "@/components/ui";
+import { CadencePicker, type OnboardingCadence } from "@/components/dashboard/cadence-picker";
 import { brandNameFromSite, hostOf } from "@/lib/brand-name";
 import { cn } from "@/lib/utils";
 
@@ -55,6 +56,13 @@ export function Onboarding() {
 
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Cadence for the project about to be created. Defaults on, at daily — the
+  // schedule this route used to hard-code. The toggle is the off switch;
+  // "Custom" is a day count, not off. See CadencePicker.
+  const [scheduleOn, setScheduleOn] = useState(true);
+  const [cadence, setCadence] = useState<OnboardingCadence>("daily");
+  const [customDays, setCustomDays] = useState(14);
 
   // --- Step 1 -> suggest -----------------------------------------------------
   // Doubles as the Retry handler: re-submitting is the whole recovery.
@@ -248,6 +256,8 @@ export function Onboarding() {
           // showed a full URL with a path back in the Settings domain field.
           brand_domains: hostOf(domain) ? [hostOf(domain)] : [],
           description: description.trim() || null,
+          schedule: scheduleOn ? cadence : "off",
+          intervalDays: scheduleOn && cadence === "custom" ? customDays : null,
           topics: cleaned,
           // Blank rows are just unused inputs, so drop them rather than
           // blocking the submit — a nameless competitor holds nothing else.
@@ -617,6 +627,17 @@ export function Onboarding() {
               <Check className="h-4 w-4" />
               Start monitoring
             </Button>
+          </div>
+          <div className="mt-4">
+            <CadencePicker
+              enabled={scheduleOn}
+              onEnabledChange={setScheduleOn}
+              cadence={cadence}
+              onCadenceChange={setCadence}
+              customDays={customDays}
+              onCustomDaysChange={setCustomDays}
+              disabled={busy}
+            />
           </div>
           <p className="mt-3 text-center text-xs text-ink-faint">
             We&apos;ll run your first search right away, on the house.

--- a/app/dashboard/runs/page.tsx
+++ b/app/dashboard/runs/page.tsx
@@ -161,6 +161,7 @@ export default async function RunsPage() {
           daily?" gets asked. */}
       <ScheduleControl
         schedule={project.schedule}
+        scheduleIntervalDays={project.schedule_interval_days}
         keySource={key.source}
         providerLabel={PROVIDERS[project.default_provider].label}
       />

--- a/app/dashboard/runs/schedule-control.tsx
+++ b/app/dashboard/runs/schedule-control.tsx
@@ -1,13 +1,15 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { CalendarClock } from "lucide-react";
-import { Card, CardBody, Select } from "@/components/ui";
+import { Card, CardBody, Input, Select } from "@/components/ui";
 import {
+  CUSTOM_INTERVAL_DEFAULT,
   CUSTOM_INTERVAL_MAX,
   CUSTOM_INTERVAL_MIN,
+  normalizeCustomInterval,
   SCHEDULE_LABELS,
   SCHEDULES,
   scheduleLabel,
@@ -33,18 +35,36 @@ export function ScheduleControl({
 }) {
   const router = useRouter();
   const [schedule, setSchedule] = useState<Schedule>(saved);
-  // Kept separately from `schedule` because picking 'custom' in the select and
-  // typing its interval are two different edits, made in either order, and
-  // only one of them should trigger the save.
-  const [intervalDays, setIntervalDays] = useState<number>(savedIntervalDays ?? 14);
+  const initialInterval = savedIntervalDays ?? CUSTOM_INTERVAL_DEFAULT;
+  // A string draft lets the user clear and replace the number without turning
+  // the transient empty field into a one-day schedule.
+  const [intervalDraft, setIntervalDraft] = useState(String(initialInterval));
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const intervalInput = useRef<HTMLInputElement>(null);
+  const savingRef = useRef(false);
+  const confirmed = useRef({ schedule: saved, intervalDays: initialInterval });
+
+  useEffect(() => {
+    if (savingRef.current) return;
+    const intervalDays = savedIntervalDays ?? CUSTOM_INTERVAL_DEFAULT;
+    confirmed.current = { schedule: saved, intervalDays };
+    setSchedule(saved);
+    setIntervalDraft(String(intervalDays));
+  }, [saved, savedIntervalDays]);
 
   async function save(next: Schedule, nextIntervalDays: number) {
-    const previous = schedule;
-    const previousIntervalDays = intervalDays;
+    if (savingRef.current) return;
+    const previous = confirmed.current;
+    const unchanged =
+      next === previous.schedule &&
+      (next !== "custom" || nextIntervalDays === previous.intervalDays);
+
     setSchedule(next);
-    if (next === "custom") setIntervalDays(nextIntervalDays);
+    if (next === "custom") setIntervalDraft(String(nextIntervalDays));
+    if (unchanged) return;
+
+    savingRef.current = true;
     setSaving(true);
     setError(null);
     try {
@@ -60,22 +80,41 @@ export function ScheduleControl({
       });
       const data = await res.json().catch(() => ({}));
       if (!res.ok || data?.error) {
-        setSchedule(previous);
-        setIntervalDays(previousIntervalDays);
+        setSchedule(previous.schedule);
+        setIntervalDraft(String(previous.intervalDays));
         setError(data?.error ?? "Couldn't save the schedule.");
         return;
       }
+      confirmed.current = {
+        schedule: next,
+        intervalDays: next === "custom" ? nextIntervalDays : CUSTOM_INTERVAL_DEFAULT,
+      };
       router.refresh();
     } catch {
-      setSchedule(previous);
-      setIntervalDays(previousIntervalDays);
+      setSchedule(previous.schedule);
+      setIntervalDraft(String(previous.intervalDays));
       setError("Network error, please try again.");
     } finally {
+      savingRef.current = false;
       setSaving(false);
     }
   }
 
+  function commitCustom() {
+    if (savingRef.current || schedule !== "custom") return;
+    const normalized = normalizeCustomInterval(
+      intervalDraft,
+      confirmed.current.intervalDays,
+    );
+    setIntervalDraft(String(normalized));
+    void save("custom", normalized);
+  }
+
   const scheduled = schedule !== "off";
+  const intervalDays = normalizeCustomInterval(
+    intervalDraft,
+    confirmed.current.intervalDays,
+  );
   // The cron runs own-key projects, and trial projects while the allowance
   // lasts ("cadence from the onset"). Everything else it skips — that's the
   // state worth shouting about.
@@ -135,13 +174,37 @@ export function ScheduleControl({
             {error && <p className="text-xs text-terracotta">{error}</p>}
           </div>
         </div>
-        <div className="flex items-center gap-2">
+        <div
+          className="flex items-center gap-2"
+          onBlur={(event) => {
+            // Moving between the select and number input stays within one edit.
+            // Commit only when focus leaves the whole control.
+            if (event.currentTarget.contains(event.relatedTarget as Node | null)) return;
+            commitCustom();
+          }}
+        >
           <Select
             aria-label="Monitoring schedule"
             value={schedule}
             disabled={saving}
-            onChange={(e) => save(e.target.value as Schedule, intervalDays)}
-            className="w-auto"
+            onChange={(e) => {
+              const next = e.target.value as Schedule;
+              if (next === "custom") {
+                setSchedule(next);
+                setError(null);
+                requestAnimationFrame(() => {
+                  intervalInput.current?.focus();
+                  intervalInput.current?.select();
+                });
+                return;
+              }
+              void save(next, intervalDays);
+            }}
+            // w-auto doesn't reliably grow a select styled with
+            // appearance-none to fit its longest option; "Every N days" (the
+            // 'custom' label) was clipped. Sized to the longest label plus
+            // the arrow padding fieldBase reserves.
+            className="w-auto min-w-[10rem]"
           >
             {SCHEDULES.map((s) => (
               <option key={s} value={s}>
@@ -150,27 +213,23 @@ export function ScheduleControl({
             ))}
           </Select>
           {schedule === "custom" && (
-            <input
+            <Input
+              ref={intervalInput}
               type="number"
               aria-label="Days between runs"
               min={CUSTOM_INTERVAL_MIN}
               max={CUSTOM_INTERVAL_MAX}
-              value={intervalDays}
+              step={1}
+              value={intervalDraft}
               disabled={saving}
-              onChange={(e) => {
-                const next = Number(e.target.value);
-                if (Number.isFinite(next)) setIntervalDays(next);
+              onChange={(e) => setIntervalDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  e.currentTarget.blur();
+                }
               }}
-              // Saved on blur, not per keystroke: typing "14" would otherwise
-              // PATCH "1" first and schedule a daily run for a moment.
-              onBlur={(e) => {
-                const clamped = Math.min(
-                  CUSTOM_INTERVAL_MAX,
-                  Math.max(CUSTOM_INTERVAL_MIN, Number(e.target.value) || CUSTOM_INTERVAL_MIN),
-                );
-                save("custom", clamped);
-              }}
-              className="w-16 rounded border border-ink/15 bg-paper px-2 py-1.5 text-sm text-ink"
+              className="w-16 bg-paper px-2 py-1.5"
             />
           )}
         </div>

--- a/app/dashboard/runs/schedule-control.tsx
+++ b/app/dashboard/runs/schedule-control.tsx
@@ -5,16 +5,25 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { CalendarClock } from "lucide-react";
 import { Card, CardBody, Select } from "@/components/ui";
-import { SCHEDULE_LABELS } from "@/lib/utils";
+import {
+  CUSTOM_INTERVAL_MAX,
+  CUSTOM_INTERVAL_MIN,
+  SCHEDULE_LABELS,
+  SCHEDULES,
+  scheduleLabel,
+} from "@/lib/utils";
 import type { KeySource } from "@/lib/trial";
 import type { Schedule } from "@/lib/types";
 
 export function ScheduleControl({
   schedule: saved,
+  scheduleIntervalDays: savedIntervalDays,
   keySource,
   providerLabel,
 }: {
   schedule: Schedule;
+  /** Days between runs when schedule is 'custom'; ignored otherwise. */
+  scheduleIntervalDays: number | null;
   /** Whose key the next run would use. Scheduled runs are strictly self-funded
    *  (the cron skips anything but 'own'), so any other source means a schedule
    *  set here silently never fires — the exact state this control exists to
@@ -24,29 +33,42 @@ export function ScheduleControl({
 }) {
   const router = useRouter();
   const [schedule, setSchedule] = useState<Schedule>(saved);
+  // Kept separately from `schedule` because picking 'custom' in the select and
+  // typing its interval are two different edits, made in either order, and
+  // only one of them should trigger the save.
+  const [intervalDays, setIntervalDays] = useState<number>(savedIntervalDays ?? 14);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  async function save(next: Schedule) {
+  async function save(next: Schedule, nextIntervalDays: number) {
     const previous = schedule;
+    const previousIntervalDays = intervalDays;
     setSchedule(next);
+    if (next === "custom") setIntervalDays(nextIntervalDays);
     setSaving(true);
     setError(null);
     try {
       const res = await fetch("/api/project/schedule", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ schedule: next }),
+        body: JSON.stringify({
+          schedule: next,
+          // Only meaningful for 'custom' - the route nulls this column for
+          // every other schedule, so a stale interval can't resurface later.
+          intervalDays: next === "custom" ? nextIntervalDays : null,
+        }),
       });
       const data = await res.json().catch(() => ({}));
       if (!res.ok || data?.error) {
         setSchedule(previous);
+        setIntervalDays(previousIntervalDays);
         setError(data?.error ?? "Couldn't save the schedule.");
         return;
       }
       router.refresh();
     } catch {
       setSchedule(previous);
+      setIntervalDays(previousIntervalDays);
       setError("Network error, please try again.");
     } finally {
       setSaving(false);
@@ -74,13 +96,14 @@ export function ScheduleControl({
             )}
             {scheduled && keySource === "own" && (
               <p className="text-xs text-ink-faint">
-                Runs {schedule} around 8:00 UTC on your own key.
+                Runs {scheduleLabel(schedule, intervalDays).toLowerCase()} around 8:00 UTC on your
+                own key.
               </p>
             )}
             {scheduled && keySource === "trial" && (
               <p className="text-xs text-ink-faint">
-                Runs {schedule} around 8:00 UTC on complimentary tokens while
-                they last. Add your {providerLabel} key in{" "}
+                Runs {scheduleLabel(schedule, intervalDays).toLowerCase()} around 8:00 UTC on
+                complimentary tokens while they last. Add your {providerLabel} key in{" "}
                 <Link
                   href="/dashboard/settings"
                   className="text-terracotta-dark hover:text-terracotta"
@@ -95,8 +118,7 @@ export function ScheduleControl({
                 in its own JSON response and a span attribute. */}
             {scheduled && !willFire && (
               <p className="text-xs text-terracotta">
-                This {SCHEDULE_LABELS[schedule].toLowerCase()} schedule
-                won&apos;t run
+                This {scheduleLabel(schedule, intervalDays).toLowerCase()} schedule won&apos;t run
                 {keySource === "exhausted"
                   ? ": your free runs are used up. "
                   : ": no usable key for your answer engine. "}
@@ -113,19 +135,45 @@ export function ScheduleControl({
             {error && <p className="text-xs text-terracotta">{error}</p>}
           </div>
         </div>
-        <Select
-          aria-label="Monitoring schedule"
-          value={schedule}
-          disabled={saving}
-          onChange={(e) => save(e.target.value as Schedule)}
-          className="w-auto"
-        >
-          {(["off", "daily", "weekly"] as Schedule[]).map((s) => (
-            <option key={s} value={s}>
-              {SCHEDULE_LABELS[s]}
-            </option>
-          ))}
-        </Select>
+        <div className="flex items-center gap-2">
+          <Select
+            aria-label="Monitoring schedule"
+            value={schedule}
+            disabled={saving}
+            onChange={(e) => save(e.target.value as Schedule, intervalDays)}
+            className="w-auto"
+          >
+            {SCHEDULES.map((s) => (
+              <option key={s} value={s}>
+                {SCHEDULE_LABELS[s]}
+              </option>
+            ))}
+          </Select>
+          {schedule === "custom" && (
+            <input
+              type="number"
+              aria-label="Days between runs"
+              min={CUSTOM_INTERVAL_MIN}
+              max={CUSTOM_INTERVAL_MAX}
+              value={intervalDays}
+              disabled={saving}
+              onChange={(e) => {
+                const next = Number(e.target.value);
+                if (Number.isFinite(next)) setIntervalDays(next);
+              }}
+              // Saved on blur, not per keystroke: typing "14" would otherwise
+              // PATCH "1" first and schedule a daily run for a moment.
+              onBlur={(e) => {
+                const clamped = Math.min(
+                  CUSTOM_INTERVAL_MAX,
+                  Math.max(CUSTOM_INTERVAL_MIN, Number(e.target.value) || CUSTOM_INTERVAL_MIN),
+                );
+                save("custom", clamped);
+              }}
+              className="w-16 rounded border border-ink/15 bg-paper px-2 py-1.5 text-sm text-ink"
+            />
+          )}
+        </div>
       </CardBody>
     </Card>
   );

--- a/app/dashboard/settings/project-form.tsx
+++ b/app/dashboard/settings/project-form.tsx
@@ -11,14 +11,8 @@ import {
   engineCoverage,
   type RouterCoverage,
 } from "@/lib/routers";
-import {
-  article,
-  CUSTOM_INTERVAL_MAX,
-  CUSTOM_INTERVAL_MIN,
-  SCHEDULE_LABELS,
-  SCHEDULES,
-} from "@/lib/utils";
-import type { Project, Provider, Schedule } from "@/lib/types";
+import { article } from "@/lib/utils";
+import type { Project, Provider } from "@/lib/types";
 
 // The answer engine is stored as a (provider, model) pair; the picker packs
 // both into one "provider:model" option value and unpacks on submit.
@@ -71,8 +65,6 @@ export default function ProjectForm({
     (project?.brand_domains ?? []).join(", "),
   );
   const [description, setDescription] = useState(project?.description ?? "");
-  const [schedule, setSchedule] = useState<Schedule>(project?.schedule ?? "off");
-  const [intervalDays, setIntervalDays] = useState<number>(project?.schedule_interval_days ?? 14);
   const [useWebSearch, setUseWebSearch] = useState(project?.use_web_search ?? true);
   const [engine, setEngine] = useState(
     project ? `${project.default_provider}:${project.default_model}` : DEFAULT_ENGINE,
@@ -143,10 +135,9 @@ export default function ProjectForm({
           brand_aliases: aliases,
           brand_domains: brandDomains,
           description,
-          schedule,
-          // Only meaningful for 'custom' - the route ignores it (and stores
-          // null) for every other schedule, so no clamping is needed here.
-          intervalDays,
+          // schedule/intervalDays deliberately omitted: cadence is set at
+          // onboarding and on the Runs page, not here. The route leaves both
+          // columns untouched when the body doesn't carry `schedule`.
           use_web_search: useWebSearch,
           default_provider,
           default_model,
@@ -213,58 +204,21 @@ export default function ProjectForm({
         </p>
       </div>
 
-      <div className="grid gap-4 sm:grid-cols-2">
-        <div>
-          <Label htmlFor="p-domains">Brand domains</Label>
-          <Input
-            id="p-domains"
-            value={brandDomains}
-            onChange={(e) => {
-              setBrandDomains(e.target.value);
-              setSaved(false);
-            }}
-            placeholder="acme.com, acme-guides.com"
-          />
-          <p className="mt-1.5 text-xs text-ink-faint">
-            Comma-separated, main domain first. Sources cited from any of these
-            count as yours. Include phantom sites for this brand.
-          </p>
-        </div>
-        <div>
-          <Label htmlFor="p-schedule">Monitoring schedule</Label>
-          <div className="flex items-center gap-2">
-            <Select
-              id="p-schedule"
-              value={schedule}
-              onChange={(e) => {
-                setSchedule(e.target.value as Schedule);
-                setSaved(false);
-              }}
-            >
-              {SCHEDULES.map((s) => (
-                <option key={s} value={s}>
-                  {SCHEDULE_LABELS[s]}
-                </option>
-              ))}
-            </Select>
-            {schedule === "custom" && (
-              <input
-                type="number"
-                id="p-schedule-interval"
-                aria-label="Days between runs"
-                min={CUSTOM_INTERVAL_MIN}
-                max={CUSTOM_INTERVAL_MAX}
-                value={intervalDays}
-                onChange={(e) => {
-                  const next = Number(e.target.value);
-                  if (Number.isFinite(next)) setIntervalDays(next);
-                  setSaved(false);
-                }}
-                className="w-16 rounded border border-ink/15 bg-paper px-2 py-1.5 text-sm text-ink"
-              />
-            )}
-          </div>
-        </div>
+      <div>
+        <Label htmlFor="p-domains">Brand domains</Label>
+        <Input
+          id="p-domains"
+          value={brandDomains}
+          onChange={(e) => {
+            setBrandDomains(e.target.value);
+            setSaved(false);
+          }}
+          placeholder="acme.com, acme-guides.com"
+        />
+        <p className="mt-1.5 text-xs text-ink-faint">
+          Comma-separated, main domain first. Sources cited from any of these
+          count as yours. Include phantom sites for this brand.
+        </p>
       </div>
 
       <div>

--- a/app/dashboard/settings/project-form.tsx
+++ b/app/dashboard/settings/project-form.tsx
@@ -11,7 +11,13 @@ import {
   engineCoverage,
   type RouterCoverage,
 } from "@/lib/routers";
-import { article, SCHEDULE_LABELS } from "@/lib/utils";
+import {
+  article,
+  CUSTOM_INTERVAL_MAX,
+  CUSTOM_INTERVAL_MIN,
+  SCHEDULE_LABELS,
+  SCHEDULES,
+} from "@/lib/utils";
 import type { Project, Provider, Schedule } from "@/lib/types";
 
 // The answer engine is stored as a (provider, model) pair; the picker packs
@@ -66,6 +72,7 @@ export default function ProjectForm({
   );
   const [description, setDescription] = useState(project?.description ?? "");
   const [schedule, setSchedule] = useState<Schedule>(project?.schedule ?? "off");
+  const [intervalDays, setIntervalDays] = useState<number>(project?.schedule_interval_days ?? 14);
   const [useWebSearch, setUseWebSearch] = useState(project?.use_web_search ?? true);
   const [engine, setEngine] = useState(
     project ? `${project.default_provider}:${project.default_model}` : DEFAULT_ENGINE,
@@ -137,6 +144,9 @@ export default function ProjectForm({
           brand_domains: brandDomains,
           description,
           schedule,
+          // Only meaningful for 'custom' - the route ignores it (and stores
+          // null) for every other schedule, so no clamping is needed here.
+          intervalDays,
           use_web_search: useWebSearch,
           default_provider,
           default_model,
@@ -222,20 +232,38 @@ export default function ProjectForm({
         </div>
         <div>
           <Label htmlFor="p-schedule">Monitoring schedule</Label>
-          <Select
-            id="p-schedule"
-            value={schedule}
-            onChange={(e) => {
-              setSchedule(e.target.value as Schedule);
-              setSaved(false);
-            }}
-          >
-            {(["off", "daily", "weekly"] as Schedule[]).map((s) => (
-              <option key={s} value={s}>
-                {SCHEDULE_LABELS[s]}
-              </option>
-            ))}
-          </Select>
+          <div className="flex items-center gap-2">
+            <Select
+              id="p-schedule"
+              value={schedule}
+              onChange={(e) => {
+                setSchedule(e.target.value as Schedule);
+                setSaved(false);
+              }}
+            >
+              {SCHEDULES.map((s) => (
+                <option key={s} value={s}>
+                  {SCHEDULE_LABELS[s]}
+                </option>
+              ))}
+            </Select>
+            {schedule === "custom" && (
+              <input
+                type="number"
+                id="p-schedule-interval"
+                aria-label="Days between runs"
+                min={CUSTOM_INTERVAL_MIN}
+                max={CUSTOM_INTERVAL_MAX}
+                value={intervalDays}
+                onChange={(e) => {
+                  const next = Number(e.target.value);
+                  if (Number.isFinite(next)) setIntervalDays(next);
+                  setSaved(false);
+                }}
+                className="w-16 rounded border border-ink/15 bg-paper px-2 py-1.5 text-sm text-ink"
+              />
+            )}
+          </div>
         </div>
       </div>
 

--- a/components/dashboard/cadence-picker.tsx
+++ b/components/dashboard/cadence-picker.tsx
@@ -1,7 +1,17 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { Clock } from "lucide-react";
-import { cn, CUSTOM_INTERVAL_MAX, CUSTOM_INTERVAL_MIN } from "@/lib/utils";
+import { Input } from "@/components/ui";
+import {
+  cn,
+  CUSTOM_INTERVAL_MAX,
+  CUSTOM_INTERVAL_MIN,
+  normalizeCustomInterval,
+  SCHEDULE_LABELS,
+  SCHEDULES,
+} from "@/lib/utils";
+import type { Schedule } from "@/lib/types";
 
 /**
  * Controlled cadence control: a schedule on/off switch plus a
@@ -12,13 +22,17 @@ import { cn, CUSTOM_INTERVAL_MAX, CUSTOM_INTERVAL_MIN } from "@/lib/utils";
  * defaulting to one and hiding in Settings.
  */
 
-export type OnboardingCadence = "daily" | "weekly" | "custom";
+export type OnboardingCadence = Exclude<Schedule, "off">;
 
-const PILLS: { value: OnboardingCadence; label: string }[] = [
-  { value: "daily", label: "Daily" },
-  { value: "weekly", label: "Weekly" },
-  { value: "custom", label: "Custom" },
-];
+const ONBOARDING_CADENCES = SCHEDULES.filter(
+  (schedule): schedule is OnboardingCadence => schedule !== "off",
+);
+
+const SHORT_LABELS: Record<OnboardingCadence, string> = {
+  daily: SCHEDULE_LABELS.daily,
+  weekly: SCHEDULE_LABELS.weekly,
+  custom: "Custom",
+};
 
 export function CadencePicker({
   enabled,
@@ -38,6 +52,19 @@ export function CadencePicker({
   disabled?: boolean;
 }) {
   const pillsDisabled = disabled || !enabled;
+  // Keep the editable string local so clearing the field is a harmless draft,
+  // not Number("") = 0 leaking into the parent's valid numeric state.
+  const [customDraft, setCustomDraft] = useState(String(customDays));
+
+  useEffect(() => {
+    setCustomDraft(String(customDays));
+  }, [customDays]);
+
+  function commitCustomDraft() {
+    const normalized = normalizeCustomInterval(customDraft, customDays);
+    setCustomDraft(String(normalized));
+    if (normalized !== customDays) onCustomDaysChange(normalized);
+  }
 
   return (
     <div className="rounded border border-ink/10 bg-paper-shade/40 p-4">
@@ -54,7 +81,7 @@ export function CadencePicker({
           disabled={disabled}
           onClick={() => onEnabledChange(!enabled)}
           className={cn(
-            "relative inline-flex h-6 w-11 shrink-0 items-center rounded transition disabled:opacity-50",
+            "relative inline-flex h-6 w-11 shrink-0 items-center rounded transition disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-terracotta/40 focus-visible:ring-offset-2 focus-visible:ring-offset-paper",
             enabled ? "bg-terracotta" : "bg-ink/15",
           )}
         >
@@ -69,39 +96,44 @@ export function CadencePicker({
 
       <div className="mt-3 flex flex-wrap items-center gap-2 pl-6">
         <div className="flex items-center gap-1 rounded border border-ink/10 bg-surface p-1">
-          {PILLS.map((p) => (
+          {ONBOARDING_CADENCES.map((value) => (
             <button
-              key={p.value}
+              key={value}
               type="button"
-              aria-pressed={cadence === p.value}
+              aria-pressed={cadence === value}
               disabled={pillsDisabled}
-              onClick={() => onCadenceChange(p.value)}
+              onClick={() => onCadenceChange(value)}
               className={cn(
-                "rounded-sm px-2.5 py-1 text-xs transition disabled:opacity-50",
-                cadence === p.value
+                "rounded-sm px-2.5 py-1 text-xs transition disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-terracotta/40",
+                cadence === value
                   ? "bg-ink/[0.08] font-medium text-ink"
                   : "text-ink-faint hover:text-ink-soft",
               )}
             >
-              {p.label}
+              {SHORT_LABELS[value]}
             </button>
           ))}
         </div>
         {cadence === "custom" && (
           <span className="flex items-center gap-1.5 text-sm text-ink-faint">
             every
-            <input
+            <Input
               type="number"
               aria-label="Days between runs"
               min={CUSTOM_INTERVAL_MIN}
               max={CUSTOM_INTERVAL_MAX}
-              value={customDays}
+              step={1}
+              value={customDraft}
               disabled={pillsDisabled}
-              onChange={(e) => {
-                const next = Number(e.target.value);
-                if (Number.isFinite(next)) onCustomDaysChange(next);
+              onChange={(e) => setCustomDraft(e.target.value)}
+              onBlur={commitCustomDraft}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  e.currentTarget.blur();
+                }
               }}
-              className="w-16 rounded border border-ink/15 bg-paper px-2 py-1.5 text-sm text-ink disabled:opacity-50"
+              className="w-16 bg-paper px-2 py-1.5 disabled:opacity-50"
             />
             days
           </span>

--- a/components/dashboard/cadence-picker.tsx
+++ b/components/dashboard/cadence-picker.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { Clock } from "lucide-react";
+import { cn, CUSTOM_INTERVAL_MAX, CUSTOM_INTERVAL_MIN } from "@/lib/utils";
+
+/**
+ * Controlled cadence control: a schedule on/off switch plus a
+ * Daily/Weekly/Custom pill row, with a day-count input when Custom is picked.
+ * No fetching — the caller owns the state and decides what to do with it.
+ * Used at the end of onboarding (app/dashboard/onboarding.tsx), pre-submit,
+ * so the schedule is chosen before the project row is created rather than
+ * defaulting to one and hiding in Settings.
+ */
+
+export type OnboardingCadence = "daily" | "weekly" | "custom";
+
+const PILLS: { value: OnboardingCadence; label: string }[] = [
+  { value: "daily", label: "Daily" },
+  { value: "weekly", label: "Weekly" },
+  { value: "custom", label: "Custom" },
+];
+
+export function CadencePicker({
+  enabled,
+  onEnabledChange,
+  cadence,
+  onCadenceChange,
+  customDays,
+  onCustomDaysChange,
+  disabled = false,
+}: {
+  enabled: boolean;
+  onEnabledChange: (value: boolean) => void;
+  cadence: OnboardingCadence;
+  onCadenceChange: (value: OnboardingCadence) => void;
+  customDays: number;
+  onCustomDaysChange: (value: number) => void;
+  disabled?: boolean;
+}) {
+  const pillsDisabled = disabled || !enabled;
+
+  return (
+    <div className="rounded border border-ink/10 bg-paper-shade/40 p-4">
+      <div className="flex items-center justify-between gap-4">
+        <span className="flex items-center gap-2">
+          <Clock className="h-4 w-4 shrink-0 text-ink-faint" aria-hidden />
+          <span className="text-sm font-medium text-ink">Keep this report up to date</span>
+        </span>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={enabled}
+          aria-label="Keep this report up to date"
+          disabled={disabled}
+          onClick={() => onEnabledChange(!enabled)}
+          className={cn(
+            "relative inline-flex h-6 w-11 shrink-0 items-center rounded transition disabled:opacity-50",
+            enabled ? "bg-terracotta" : "bg-ink/15",
+          )}
+        >
+          <span
+            className={cn(
+              "inline-block h-4 w-4 transform rounded-sm bg-white transition",
+              enabled ? "translate-x-6" : "translate-x-1",
+            )}
+          />
+        </button>
+      </div>
+
+      <div className="mt-3 flex flex-wrap items-center gap-2 pl-6">
+        <div className="flex items-center gap-1 rounded border border-ink/10 bg-surface p-1">
+          {PILLS.map((p) => (
+            <button
+              key={p.value}
+              type="button"
+              aria-pressed={cadence === p.value}
+              disabled={pillsDisabled}
+              onClick={() => onCadenceChange(p.value)}
+              className={cn(
+                "rounded-sm px-2.5 py-1 text-xs transition disabled:opacity-50",
+                cadence === p.value
+                  ? "bg-ink/[0.08] font-medium text-ink"
+                  : "text-ink-faint hover:text-ink-soft",
+              )}
+            >
+              {p.label}
+            </button>
+          ))}
+        </div>
+        {cadence === "custom" && (
+          <span className="flex items-center gap-1.5 text-sm text-ink-faint">
+            every
+            <input
+              type="number"
+              aria-label="Days between runs"
+              min={CUSTOM_INTERVAL_MIN}
+              max={CUSTOM_INTERVAL_MAX}
+              value={customDays}
+              disabled={pillsDisabled}
+              onChange={(e) => {
+                const next = Number(e.target.value);
+                if (Number.isFinite(next)) onCustomDaysChange(next);
+              }}
+              className="w-16 rounded border border-ink/15 bg-paper px-2 py-1.5 text-sm text-ink disabled:opacity-50"
+            />
+            days
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/ui.tsx
+++ b/components/ui.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { forwardRef } from "react";
 import type { ButtonHTMLAttributes, InputHTMLAttributes, ReactNode, SelectHTMLAttributes, TextareaHTMLAttributes } from "react";
 import { cn } from "@/lib/utils";
 
@@ -215,9 +216,11 @@ export function Label({
 const fieldBase =
   "w-full rounded border border-ink/15 bg-surface px-3.5 py-2.5 text-sm text-ink placeholder:text-ink-faint/70 transition focus:border-terracotta focus:outline-none focus:ring-2 focus:ring-terracotta/20";
 
-export function Input({ className, ...props }: InputHTMLAttributes<HTMLInputElement>) {
-  return <input className={cn(fieldBase, className)} {...props} />;
-}
+export const Input = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputElement>>(
+  function Input({ className, ...props }, ref) {
+    return <input ref={ref} className={cn(fieldBase, className)} {...props} />;
+  },
+);
 
 export function Textarea({ className, ...props }: TextareaHTMLAttributes<HTMLTextAreaElement>) {
   return <textarea className={cn(fieldBase, "min-h-[90px] resize-y", className)} {...props} />;

--- a/lib/api-service.test.ts
+++ b/lib/api-service.test.ts
@@ -204,7 +204,18 @@ describe("projectSummary", () => {
       id: "proj-1",
       brand_name: "Credal",
       default_provider: "anthropic",
+      schedule_interval_days: null,
     });
+  });
+
+  it("keeps the number attached to a custom schedule", () => {
+    expect(
+      projectSummary({
+        ...PROJECT,
+        schedule: "custom",
+        schedule_interval_days: 14,
+      }),
+    ).toMatchObject({ schedule: "custom", schedule_interval_days: 14 });
   });
 });
 
@@ -589,6 +600,7 @@ describe("triggerRunForProject", () => {
       competitors: [],
       attribution: {} as never,
       startedMs: 0,
+      startedAt: "1970-01-01T00:00:00.000Z",
     });
     let finish!: (r: typeof COMPLETED) => void;
     vi.mocked(resumeRun).mockReturnValue(

--- a/lib/api-service.test.ts
+++ b/lib/api-service.test.ts
@@ -125,6 +125,7 @@ const PROJECT: Project = {
   default_model: "claude-sonnet-4-6",
   results_seen_at: null,
   schedule: "off",
+  schedule_interval_days: null,
   use_web_search: true,
   replicates: 1,
   last_run_at: null,

--- a/lib/api-service.ts
+++ b/lib/api-service.ts
@@ -101,6 +101,7 @@ export function projectSummary(p: Project) {
     default_provider: p.default_provider,
     default_model: p.default_model,
     schedule: p.schedule,
+    schedule_interval_days: p.schedule_interval_days,
     use_web_search: p.use_web_search,
     replicates: p.replicates,
     last_run_at: p.last_run_at,

--- a/lib/engine-budget.test.ts
+++ b/lib/engine-budget.test.ts
@@ -30,6 +30,7 @@ import { spendMicros } from "@/lib/pricing";
 /** Records what the run wrote, and answers the reads resumeRun makes. */
 function makeDb() {
   const runUpdates: Record<string, unknown>[] = [];
+  const projectUpdates: Record<string, unknown>[] = [];
   const responses: Record<string, unknown>[] = [];
   let responseId = 0;
 
@@ -47,6 +48,7 @@ function makeDb() {
         },
         update(patch: Record<string, unknown>) {
           if (table === "runs") runUpdates.push(patch);
+          if (table === "projects") projectUpdates.push(patch);
           return {
             eq: () => ({
               eq: () => ({ select: async () => ({ data: [] }) }),
@@ -57,7 +59,7 @@ function makeDb() {
       };
     },
   };
-  return { db: db as never, runUpdates, responses };
+  return { db: db as never, runUpdates, projectUpdates, responses };
 }
 
 const project = {
@@ -90,6 +92,7 @@ function prepared(jobCount: number): PreparedRun {
       targetType: "run",
     } as never,
     startedMs: Date.now(),
+    startedAt: new Date().toISOString(),
   };
 }
 
@@ -110,15 +113,22 @@ beforeEach(() => {
 });
 
 function run(jobs: number, budgetMicros: number | null) {
-  const { db, runUpdates, responses } = makeDb();
-  return resumeRun(prepared(jobs), {
+  const { db, runUpdates, projectUpdates, responses } = makeDb();
+  const preparedRun = prepared(jobs);
+  return resumeRun(preparedRun, {
     supabase: db,
     project,
     provider: "anthropic",
     model: "claude-haiku-4-5",
     apiKey: "sk-ant-operator",
     budgetMicros,
-  } as never).then((result) => ({ result, runUpdates, responses }));
+  } as never).then((result) => ({
+    result,
+    runUpdates,
+    projectUpdates,
+    responses,
+    preparedRun,
+  }));
 }
 
 describe("a run on the operator's money", () => {
@@ -162,6 +172,22 @@ describe("a run on the operator's money", () => {
     // No answers stored is a failed run by the engine's existing rule; what
     // matters here is that it cost nothing.
     expect(result.spendMicros).toBe(0);
+  });
+
+  it("anchors the project's next cadence to run start, not finish", async () => {
+    const { projectUpdates, preparedRun } = await run(1, null);
+    expect(projectUpdates).toContainEqual({ last_run_at: preparedRun.startedAt });
+  });
+
+  // A scheduled project with zero active prompts used to leave last_run_at
+  // untouched here, so isScheduleDue saw it as never having run and the cron
+  // opened a new, empty `runs` row on every single tick, forever.
+  it("still advances the cadence anchor for a run with no prompts", async () => {
+    const { projectUpdates, preparedRun, runUpdates } = await run(0, PER_ANSWER * 3);
+    expect(vi.mocked(runQuery)).not.toHaveBeenCalled();
+    expect(projectUpdates).toContainEqual({ last_run_at: preparedRun.startedAt });
+    const settle = runUpdates.find((u) => "status" in u)!;
+    expect(settle.status).toBe("completed");
   });
 });
 

--- a/lib/engine.ts
+++ b/lib/engine.ts
@@ -242,6 +242,10 @@ export interface PreparedRun {
     targetType: string;
   };
   startedMs: number;
+  /** The exact value stored on runs.started_at and later used as the project's
+   * cadence anchor. Keeping it once prevents run duration from shifting the
+   * next due time. */
+  startedAt: string;
 }
 
 /**
@@ -254,6 +258,7 @@ export interface PreparedRun {
 export async function prepareRun(params: ExecuteRunParams): Promise<PreparedRun> {
   const { supabase, project, provider, model, route } = params;
   const startedMs = Date.now();
+  const startedAt = new Date(startedMs).toISOString();
 
   // Attribution shared by every run event below. project.user_id is always the
   // owner, so a run is visible in its owner's feed no matter who triggered it.
@@ -308,7 +313,7 @@ export async function prepareRun(params: ExecuteRunParams): Promise<PreparedRun>
       prompt_count: jobs.length,
       completed_count: 0,
       replicates,
-      started_at: new Date().toISOString(),
+      started_at: startedAt,
     })
     .select("id")
     .single();
@@ -327,7 +332,7 @@ export async function prepareRun(params: ExecuteRunParams): Promise<PreparedRun>
     metadata: { provider, model, route: route?.router ?? null, prompt_count: jobs.length, replicates },
   });
 
-  return { runId, jobs, competitors, attribution, startedMs };
+  return { runId, jobs, competitors, attribution, startedMs, startedAt };
 }
 
 /** Execute a prepared run's jobs and settle the run row. */
@@ -370,13 +375,14 @@ async function resumeRunMeasured(
   params: ExecuteRunParams,
 ): Promise<RunResult> {
   const { supabase, project, provider, model, apiKey, route, budgetMicros } = params;
-  const { runId, jobs, competitors, attribution, startedMs } = prepared;
+  const { runId, jobs, competitors, attribution, startedMs, startedAt } = prepared;
 
   if (jobs.length === 0) {
     await supabase
       .from("runs")
       .update({ status: "completed", finished_at: new Date().toISOString() })
       .eq("id", runId);
+    await supabase.from("projects").update({ last_run_at: startedAt }).eq("id", project.id);
     await logActivity({
       ...attribution,
       action: "run.completed",
@@ -610,7 +616,7 @@ async function resumeRunMeasured(
 
   await supabase
     .from("projects")
-    .update({ last_run_at: finishedAt })
+    .update({ last_run_at: startedAt })
     .eq("id", project.id);
 
   await logActivity({

--- a/lib/onboard.test.ts
+++ b/lib/onboard.test.ts
@@ -116,6 +116,7 @@ const PROJECT: Project = {
   default_model: "claude-sonnet-4-6",
   results_seen_at: null,
   schedule: "off",
+  schedule_interval_days: null,
   use_web_search: true,
   replicates: 1,
   last_run_at: null,

--- a/lib/onboard.test.ts
+++ b/lib/onboard.test.ts
@@ -337,6 +337,7 @@ describe("firstSweep", () => {
       competitors: [],
       attribution: {} as never,
       startedMs: 0,
+      startedAt: "1970-01-01T00:00:00.000Z",
     });
     let finish!: (r: ReturnType<typeof completed>) => void;
     vi.mocked(engine.resumeRun).mockReturnValue(
@@ -529,6 +530,59 @@ describe("onboardFromUrl", () => {
     });
     expect(inserted(db, "prompts").flat()[0]).toMatchObject({ source: "manual" });
     expect(outcome.sweep).toMatchObject({ ran: true });
+  });
+
+  it("stores a valid custom cadence with its interval", async () => {
+    vi.mocked(scrapeDomain).mockResolvedValue({
+      ok: true,
+      url: "https://acme.com/",
+      text: "Acme",
+    });
+    vi.mocked(trial.resolveRunKeyFor).mockImplementation(async (_db, _u, p) => own(p));
+    vi.mocked(data.getConfiguredProviders).mockResolvedValue(["anthropic"]);
+    vi.mocked(engine.executeRun).mockResolvedValue(completed("run-1"));
+    const db = happyDb();
+
+    await onboardFromUrl({
+      supabase: db as never,
+      userId: "owner-1",
+      meter: meter(),
+      context: {},
+      input: {
+        url: "acme.com",
+        topics: [{ name: "CDN", prompts: ["best cdn?"] }],
+        schedule: "custom",
+        scheduleIntervalDays: 14,
+      },
+    });
+
+    expect(inserted(db, "projects")[0]).toMatchObject({
+      schedule: "custom",
+      schedule_interval_days: 14,
+    });
+  });
+
+  it("rejects invalid cadence before reading the site or spending model work", async () => {
+    for (const input of [
+      { schedule: "hourly" },
+      { schedule: "custom" },
+      { schedule: "custom", scheduleIntervalDays: 0 },
+      { schedule: "custom", scheduleIntervalDays: 1.5 },
+      { schedule: "custom", scheduleIntervalDays: "14" },
+      { schedule: "custom", scheduleIntervalDays: 91 },
+    ]) {
+      await expect(
+        onboardFromUrl({
+          supabase: fakeDb() as never,
+          userId: "owner-1",
+          meter: meter(),
+          context: {},
+          input: { url: "acme.com", ...input },
+        }),
+      ).rejects.toMatchObject({ code: "invalid" });
+    }
+    expect(scrapeDomain).not.toHaveBeenCalled();
+    expect(suggestFromSite).not.toHaveBeenCalled();
   });
 
   it("does not start a sweep with nothing to ask", async () => {

--- a/lib/onboard.ts
+++ b/lib/onboard.ts
@@ -38,6 +38,7 @@ import { scrapeDomain } from "@/lib/scrape";
 import { brandNameFromSite } from "@/lib/brand-name";
 import { suggestFromSite, humanError } from "@/lib/llm";
 import { normalizeCompetitorList, type CompetitorInput } from "@/lib/competitors";
+import { customIntervalError, parseCustomInterval, SCHEDULES } from "@/lib/utils";
 import type { Project, Provider, Schedule } from "@/lib/types";
 
 // ------------------------------------------------------------------
@@ -430,6 +431,33 @@ export class OnboardError extends Error {
   }
 }
 
+export function parseOnboardingCadence(
+  rawSchedule: unknown,
+  rawIntervalDays: unknown,
+  fallback: Schedule,
+  // The public v1 API uses the snake_case column name; the dashboard's
+  // camelCase-bodied routes pass their own field name so the 400 names the
+  // key the caller actually sent instead of the internal one.
+  intervalField = "schedule_interval_days",
+): { schedule: Schedule; scheduleIntervalDays: number | null } {
+  let schedule = fallback;
+  if (rawSchedule !== undefined && rawSchedule !== null) {
+    if (typeof rawSchedule !== "string" || !SCHEDULES.includes(rawSchedule as Schedule)) {
+      throw new OnboardError("invalid", `schedule must be one of ${SCHEDULES.join(", ")}`);
+    }
+    schedule = rawSchedule as Schedule;
+  }
+
+  if (schedule !== "custom") {
+    return { schedule, scheduleIntervalDays: null };
+  }
+  const scheduleIntervalDays = parseCustomInterval(rawIntervalDays);
+  if (scheduleIntervalDays === null) {
+    throw new OnboardError("invalid", customIntervalError(intervalField));
+  }
+  return { schedule, scheduleIntervalDays };
+}
+
 export interface OnboardInput {
   url: string;
   brandName?: string | null;
@@ -444,7 +472,9 @@ export interface OnboardInput {
   competitors?: unknown;
   /** API onboarding defaults to "off": programmatic callers orchestrate their
    *  own cadence. The dashboard wizard starts daily. */
-  schedule?: Schedule;
+  schedule?: unknown;
+  /** Required, as a whole number from 1–90, when schedule is "custom". */
+  scheduleIntervalDays?: unknown;
   /** Run the first sweep (default true). */
   run?: boolean;
   /** Return once the run rows exist (default true for the API). */
@@ -504,6 +534,14 @@ export async function onboardFromUrl(opts: {
   context: RunContext;
 }): Promise<OnboardOutcome> {
   const { supabase, userId, meter, input } = opts;
+
+  // Validate before the site read or suggestion call: a malformed cadence
+  // must not spend scrape credits or metered model tokens before being refused.
+  const cadence = parseOnboardingCadence(
+    input.schedule,
+    input.scheduleIntervalDays,
+    "off",
+  );
 
   const host = hostOfUrl(input.url);
   if (!host) throw new OnboardError("invalid", "That doesn't look like a valid URL.");
@@ -609,7 +647,8 @@ export async function onboardFromUrl(opts: {
       description,
       default_provider: engine.provider,
       default_model: engine.model,
-      schedule: input.schedule ?? "off",
+      schedule: cadence.schedule,
+      schedule_interval_days: cadence.scheduleIntervalDays,
     })
     .select("*")
     .single();

--- a/lib/results-seen.test.ts
+++ b/lib/results-seen.test.ts
@@ -13,6 +13,7 @@ const PROJECT: Project = {
   default_provider: "anthropic",
   default_model: "claude-sonnet-4-6",
   schedule: "off",
+  schedule_interval_days: null,
   use_web_search: true,
   replicates: 1,
   last_run_at: null,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -14,7 +14,7 @@ export type EntityType = "brand" | "competitor";
 
 export type Sentiment = "positive" | "neutral" | "negative";
 
-export type Schedule = "off" | "daily" | "weekly";
+export type Schedule = "off" | "daily" | "weekly" | "custom";
 
 export type PromptSource = "ai" | "manual";
 
@@ -102,6 +102,10 @@ export interface Project {
   default_provider: Provider;
   default_model: string;
   schedule: Schedule;
+  /** Days between runs when schedule is 'custom'; null otherwise. The other
+   *  schedules carry their interval in their name — only 'custom' needs a
+   *  number to go with it. See scheduleIntervalDays in lib/utils.ts. */
+  schedule_interval_days: number | null;
   use_web_search: boolean;
   /** Times each active prompt is asked per run (1–10). >1 buys confidence in a "no mention". */
   replicates: number;

--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect } from "vitest";
 import {
   article,
+  CUSTOM_INTERVAL_DEFAULT,
   duration,
   isScheduleDue,
+  normalizeCustomInterval,
+  parseCustomInterval,
   resolveRedirectBase,
   safePath,
   SCHEDULE_LABELS,
@@ -146,6 +149,29 @@ describe("SCHEDULES", () => {
   });
 });
 
+describe("custom interval input", () => {
+  it("strictly accepts only whole numeric days inside the API range", () => {
+    expect(parseCustomInterval(1)).toBe(1);
+    expect(parseCustomInterval(90)).toBe(90);
+    expect(parseCustomInterval(14)).toBe(14);
+  });
+
+  it("rejects missing, coerced, fractional, non-finite, and out-of-range values", () => {
+    for (const value of [undefined, null, "14", "", 1.5, 0, -1, 91, NaN, Infinity]) {
+      expect(parseCustomInterval(value)).toBeNull();
+    }
+  });
+
+  it("normalises editable drafts without turning an empty field into one day", () => {
+    expect(normalizeCustomInterval("", 30)).toBe(30);
+    expect(normalizeCustomInterval("nope", 30)).toBe(30);
+    expect(normalizeCustomInterval("1.9", 30)).toBe(1);
+    expect(normalizeCustomInterval("0", 30)).toBe(1);
+    expect(normalizeCustomInterval("120", 30)).toBe(90);
+    expect(normalizeCustomInterval("14")).toBe(CUSTOM_INTERVAL_DEFAULT);
+  });
+});
+
 describe("scheduleIntervalDays", () => {
   it("reads the interval out of the schedule's own name", () => {
     expect(scheduleIntervalDays("off", null)).toBeNull();
@@ -213,22 +239,28 @@ describe("isScheduleDue", () => {
     expect(isScheduleDue(project("custom", ago(3 * DAY), 3), NOW)).toBe(true);
   });
 
-  // The bug the grace window fixes: last_run_at is stamped at run FINISH, so a
-  // run that took a few minutes is that many minutes short of a full interval
-  // at the next 08:00 tick — it missed that tick, then missed the day after too
-  // because last_run_at hadn't moved. Six hours is well under the 24h tick
-  // spacing, so it can only pull a due date earlier, never fire twice.
-  it("still fires a daily schedule whose last run finished just under a day ago", () => {
-    expect(isScheduleDue(project("daily", ago(DAY - 5 * 60 * 1000)), NOW)).toBe(true);
-    expect(isScheduleDue(project("weekly", ago(7 * DAY - 20 * 60 * 1000)), NOW)).toBe(true);
+  // The cron reads the clock once before a sequential sweep
+  // (app/api/cron/run/route.ts), so a run starts minutes after the `now` the
+  // NEXT tick is judged against; an exact 24h check was short by the
+  // project's queue position and halved every daily project's cadence except
+  // the first in the sweep. Day granularity fixes this without a grace
+  // constant: whatever time a project's run started, it's due again the
+  // moment the calendar has turned over `intervalDays` times.
+  it("fires at the next day's tick however late in the sweep the last run started", () => {
+    expect(isScheduleDue(project("daily", "2026-09-08T08:06:30Z"), NOW)).toBe(true);
+    expect(isScheduleDue(project("daily", "2026-09-08T23:59:00Z"), NOW)).toBe(true);
+    expect(isScheduleDue(project("weekly", "2026-09-02T08:06:30Z"), NOW)).toBe(true);
+    expect(isScheduleDue(project("custom", "2026-09-06T08:06:30Z", 3), NOW)).toBe(true);
   });
 
-  it("does not let the grace window fire the same interval twice", () => {
-    // A run that finished at this tick must not be due again 2h later; the
-    // grace only reaches back 6h from a full interval, not into one.
-    expect(isScheduleDue(project("daily", ago(HOUR)), NOW)).toBe(false);
-    expect(isScheduleDue(project("daily", ago(6 * HOUR)), NOW)).toBe(false);
-    expect(isScheduleDue(project("daily", ago(18 * HOUR)), NOW)).toBe(true);
+  it("cannot fire the same schedule twice in one UTC day", () => {
+    expect(isScheduleDue(project("daily", "2026-09-09T00:00:00Z"), NOW)).toBe(false);
+    expect(isScheduleDue(project("daily", "2026-09-09T08:00:00Z"), NOW)).toBe(false);
+  });
+
+  it("counts the day boundary crossed, not the hours elapsed", () => {
+    expect(isScheduleDue(project("weekly", "2026-09-03T00:01:00Z"), NOW)).toBe(false);
+    expect(isScheduleDue(project("custom", "2026-09-07T23:59:00Z", 3), NOW)).toBe(false);
   });
 
   it("refuses a 'custom' row with no interval rather than guessing one", () => {

--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect } from "vitest";
-import { article, duration, resolveRedirectBase, safePath } from "@/lib/utils";
+import {
+  article,
+  duration,
+  isScheduleDue,
+  resolveRedirectBase,
+  safePath,
+  SCHEDULE_LABELS,
+  SCHEDULES,
+  scheduleIntervalDays,
+  scheduleLabel,
+} from "@/lib/utils";
 
 describe("resolveRedirectBase", () => {
   const PROD = "https://lettertrace.com";
@@ -117,5 +127,111 @@ describe("duration", () => {
     expect(duration(null)).toBe("—");
     expect(duration(-1)).toBe("—");
     expect(duration(Number.NaN)).toBe("—");
+  });
+});
+
+describe("SCHEDULES", () => {
+  // SCHEDULES used to be a separate array, hand-copied into several files. A
+  // schedule value added to the Schedule union but missed in one of those
+  // copies would validate on some surfaces and 400 on others, or reach the
+  // database with no cron branch that knows how to run it. Deriving it from
+  // SCHEDULE_LABELS instead means the only way to add a schedule is to add
+  // its label, and every surface picks it up from there.
+  it("is derived from SCHEDULE_LABELS, not written out separately", () => {
+    expect(SCHEDULES).toEqual(Object.keys(SCHEDULE_LABELS));
+  });
+
+  it("lists exactly the four schedules in use, in display order", () => {
+    expect(SCHEDULES).toEqual(["off", "daily", "weekly", "custom"]);
+  });
+});
+
+describe("scheduleIntervalDays", () => {
+  it("reads the interval out of the schedule's own name", () => {
+    expect(scheduleIntervalDays("off", null)).toBeNull();
+    expect(scheduleIntervalDays("daily", null)).toBe(1);
+    expect(scheduleIntervalDays("weekly", null)).toBe(7);
+  });
+
+  it("only 'custom' reads the stored number", () => {
+    expect(scheduleIntervalDays("custom", 14)).toBe(14);
+    // The named schedules ignore a stray interval rather than preferring it.
+    expect(scheduleIntervalDays("weekly", 3)).toBe(7);
+  });
+
+  // The database refuses to store this row (projects_custom_needs_interval),
+  // so null here means a bug upstream, not a case to paper over with a default.
+  it("returns null for 'custom' with no interval", () => {
+    expect(scheduleIntervalDays("custom", null)).toBeNull();
+  });
+});
+
+describe("scheduleLabel", () => {
+  it("names the real interval for 'custom'", () => {
+    expect(scheduleLabel("custom", 14)).toBe("Every 14 days");
+    expect(scheduleLabel("custom", 1)).toBe("Every 1 days");
+  });
+
+  it("falls back to the label when there's no number to name", () => {
+    expect(scheduleLabel("custom", null)).toBe("Every N days");
+  });
+
+  it("passes the other schedules through to their labels", () => {
+    expect(scheduleLabel("off", null)).toBe("Manual only");
+    expect(scheduleLabel("daily", null)).toBe("Daily");
+    expect(scheduleLabel("weekly", 3)).toBe("Weekly");
+  });
+});
+
+describe("isScheduleDue", () => {
+  const NOW = new Date("2026-09-09T08:00:00Z").getTime();
+  const HOUR = 60 * 60 * 1000;
+  const DAY = 24 * HOUR;
+  const ago = (ms: number) => new Date(NOW - ms).toISOString();
+
+  const project = (
+    schedule: "off" | "daily" | "weekly" | "custom",
+    last_run_at: string | null,
+    schedule_interval_days: number | null = null,
+  ) => ({ schedule, last_run_at, schedule_interval_days });
+
+  it("never fires an 'off' schedule, however long it has been", () => {
+    expect(isScheduleDue(project("off", null), NOW)).toBe(false);
+    expect(isScheduleDue(project("off", ago(30 * DAY)), NOW)).toBe(false);
+  });
+
+  it("is due when a scheduled project has never run", () => {
+    expect(isScheduleDue(project("daily", null), NOW)).toBe(true);
+    expect(isScheduleDue(project("custom", null, 30), NOW)).toBe(true);
+  });
+
+  it("waits out the interval it was given", () => {
+    expect(isScheduleDue(project("daily", ago(2 * HOUR)), NOW)).toBe(false);
+    expect(isScheduleDue(project("weekly", ago(3 * DAY)), NOW)).toBe(false);
+    expect(isScheduleDue(project("weekly", ago(7 * DAY)), NOW)).toBe(true);
+    expect(isScheduleDue(project("custom", ago(2 * DAY), 3), NOW)).toBe(false);
+    expect(isScheduleDue(project("custom", ago(3 * DAY), 3), NOW)).toBe(true);
+  });
+
+  // The bug the grace window fixes: last_run_at is stamped at run FINISH, so a
+  // run that took a few minutes is that many minutes short of a full interval
+  // at the next 08:00 tick — it missed that tick, then missed the day after too
+  // because last_run_at hadn't moved. Six hours is well under the 24h tick
+  // spacing, so it can only pull a due date earlier, never fire twice.
+  it("still fires a daily schedule whose last run finished just under a day ago", () => {
+    expect(isScheduleDue(project("daily", ago(DAY - 5 * 60 * 1000)), NOW)).toBe(true);
+    expect(isScheduleDue(project("weekly", ago(7 * DAY - 20 * 60 * 1000)), NOW)).toBe(true);
+  });
+
+  it("does not let the grace window fire the same interval twice", () => {
+    // A run that finished at this tick must not be due again 2h later; the
+    // grace only reaches back 6h from a full interval, not into one.
+    expect(isScheduleDue(project("daily", ago(HOUR)), NOW)).toBe(false);
+    expect(isScheduleDue(project("daily", ago(6 * HOUR)), NOW)).toBe(false);
+    expect(isScheduleDue(project("daily", ago(18 * HOUR)), NOW)).toBe(true);
+  });
+
+  it("refuses a 'custom' row with no interval rather than guessing one", () => {
+    expect(isScheduleDue(project("custom", ago(90 * DAY), null), NOW)).toBe(false);
   });
 });

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,4 +1,4 @@
-import type { Schedule } from "@/lib/types";
+import type { Project, Schedule } from "@/lib/types";
 
 // Tiny className combiner (no external deps). Filters falsy, joins with spaces.
 export function cn(...parts: Array<string | false | null | undefined>): string {
@@ -130,10 +130,93 @@ export function article(word: string): "a" | "an" {
 }
 
 /** The one wording of each schedule option, shared by every surface that
- *  offers the setting (Settings form, Runs page) so the same choice can't be
- *  called two different things. */
+ *  offers the setting (Settings form, Runs page, onboarding) so the same
+ *  choice can't be called two different things. Order here is display order:
+ *  off first as the baseline, then increasing interval, 'custom' last as the
+ *  pick-your-own-number escape hatch. */
 export const SCHEDULE_LABELS: Record<Schedule, string> = {
   off: "Manual only",
   daily: "Daily",
   weekly: "Weekly",
+  custom: "Every N days",
 };
+
+// Derived from the labels rather than written out again: this used to be a
+// separate hand-copied array in four different files, which is exactly the
+// shape of bug this repo's own conventions warn about — a schedule value
+// added to the union but missed in one of those copies would validate on some
+// surfaces and 400 on others, or reach the database with no cron branch that
+// knows how to run it.
+export const SCHEDULES = Object.keys(SCHEDULE_LABELS) as Schedule[];
+
+// 0 would make isScheduleDue() true on every cron tick; a project should
+// re-pick a preset (or 90+ days) rather than lean on an unbounded custom
+// interval that reads as scheduled and effectively never fires.
+export const CUSTOM_INTERVAL_MIN = 1;
+export const CUSTOM_INTERVAL_MAX = 90;
+
+/**
+ * Days between runs, or null when nothing is scheduled. The single place a
+ * schedule becomes a duration, so the cron's due-check and every bit of UI
+ * copy that names an interval read the same arithmetic.
+ *
+ * 'custom' is the only schedule whose interval isn't implied by its own name,
+ * so it's the only one that reads `intervalDays` — and it MUST have one: a
+ * 'custom' row with a null interval is rejected at the database (see
+ * projects_custom_needs_interval in supabase/schema.sql), so falling back to
+ * 1 here would only mask a bug that should already be impossible.
+ */
+export function scheduleIntervalDays(
+  schedule: Schedule,
+  intervalDays: number | null,
+): number | null {
+  switch (schedule) {
+    case "off":
+      return null;
+    case "daily":
+      return 1;
+    case "weekly":
+      return 7;
+    case "custom":
+      return intervalDays;
+  }
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// last_run_at is stamped at run FINISH (lib/engine.ts), not at the tick that
+// started it, so a run that took even a few minutes is that many minutes
+// short of a full interval at the next 08:00 tick - and misses it, then misses
+// the day after too since last_run_at still hasn't moved. Six hours is well
+// under a day (the cron's tick spacing), so this can only ever pull a due
+// date earlier - it can never make the same interval fire twice in one cycle.
+const SCHEDULE_GRACE_MS = 6 * 60 * 60 * 1000;
+
+/**
+ * Whether a project's schedule has come due, as of `now`. The cron's whole
+ * due-check, pulled out of app/api/cron/run/route.ts so it's a pure function
+ * this repo's node-env tests can call directly — that route imports
+ * lib/supabase/server, which pulls in React's cache() and can't be imported
+ * outside a Next.js runtime.
+ */
+export function isScheduleDue(
+  project: Pick<Project, "schedule" | "schedule_interval_days" | "last_run_at">,
+  now: number,
+): boolean {
+  if (project.schedule === "off") return false;
+  if (!project.last_run_at) return true;
+  const intervalDays = scheduleIntervalDays(project.schedule, project.schedule_interval_days);
+  // Only reachable for a 'custom' row with a null interval, which the
+  // database itself refuses to store (projects_custom_needs_interval) - this
+  // is a belt on top of that suspenders, not the primary guard.
+  if (!intervalDays) return false;
+  const last = new Date(project.last_run_at).getTime();
+  return now - last >= intervalDays * DAY_MS - SCHEDULE_GRACE_MS;
+}
+
+/** SCHEDULE_LABELS plus the actual number for 'custom' (e.g. "Every 14 days"),
+ *  since "Every N days" on its own names a shape, not a schedule. */
+export function scheduleLabel(schedule: Schedule, intervalDays: number | null): string {
+  if (schedule === "custom" && intervalDays) return `Every ${intervalDays} days`;
+  return SCHEDULE_LABELS[schedule];
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -154,6 +154,40 @@ export const SCHEDULES = Object.keys(SCHEDULE_LABELS) as Schedule[];
 // interval that reads as scheduled and effectively never fires.
 export const CUSTOM_INTERVAL_MIN = 1;
 export const CUSTOM_INTERVAL_MAX = 90;
+export const CUSTOM_INTERVAL_DEFAULT = 14;
+
+/** Strict parser for values received across an API boundary. Browser controls
+ * normalise their drafts before sending; direct callers get the same rejection
+ * policy everywhere instead of route-specific coercion or defaults. */
+export function parseCustomInterval(value: unknown): number | null {
+  return typeof value === "number" &&
+    Number.isFinite(value) &&
+    Number.isInteger(value) &&
+    value >= CUSTOM_INTERVAL_MIN &&
+    value <= CUSTOM_INTERVAL_MAX
+    ? value
+    : null;
+}
+
+export function customIntervalError(field = "intervalDays"): string {
+  return `${field} must be a whole number of days between ${CUSTOM_INTERVAL_MIN} and ${CUSTOM_INTERVAL_MAX}`;
+}
+
+/** Turn an editable number-input draft into a valid interval. Empty or
+ * non-numeric drafts restore the caller's previous valid value; numeric drafts
+ * are truncated to whole days and clamped to the supported range. */
+export function normalizeCustomInterval(
+  value: string | number,
+  previous = CUSTOM_INTERVAL_DEFAULT,
+): number {
+  if (value === "") return previous;
+  const numeric = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(numeric)) return previous;
+  return Math.min(
+    CUSTOM_INTERVAL_MAX,
+    Math.max(CUSTOM_INTERVAL_MIN, Math.trunc(numeric)),
+  );
+}
 
 /**
  * Days between runs, or null when nothing is scheduled. The single place a
@@ -184,13 +218,8 @@ export function scheduleIntervalDays(
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
-// last_run_at is stamped at run FINISH (lib/engine.ts), not at the tick that
-// started it, so a run that took even a few minutes is that many minutes
-// short of a full interval at the next 08:00 tick - and misses it, then misses
-// the day after too since last_run_at still hasn't moved. Six hours is well
-// under a day (the cron's tick spacing), so this can only ever pull a due
-// date earlier - it can never make the same interval fire twice in one cycle.
-const SCHEDULE_GRACE_MS = 6 * 60 * 60 * 1000;
+/** The UTC calendar day a timestamp falls in — whole days since the epoch. */
+const utcDay = (ms: number) => Math.floor(ms / DAY_MS);
 
 /**
  * Whether a project's schedule has come due, as of `now`. The cron's whole
@@ -198,6 +227,19 @@ const SCHEDULE_GRACE_MS = 6 * 60 * 60 * 1000;
  * this repo's node-env tests can call directly — that route imports
  * lib/supabase/server, which pulls in React's cache() and can't be imported
  * outside a Next.js runtime.
+ *
+ * Compares whole UTC days turned over, not elapsed milliseconds. The cron
+ * reads the clock once before a sequential sweep (app/api/cron/run/route.ts),
+ * so a project's run starts minutes after the `now` the NEXT tick is judged
+ * against — an exact 24h check is short by the project's queue position and
+ * skips it, so a project that started 6m30s into a sweep was 23h53m old at
+ * the next tick and a "daily" cadence became every other day for every
+ * project but the first in the queue. Day granularity is immune to queue
+ * position, run duration and cron jitter alike, and cannot fire the same
+ * schedule twice in a day (0 >= 1 is false). It does mean a manual run late
+ * in the day makes the next morning's tick due only a few hours later —
+ * accepted, since the alternative (a duration-based grace) is what produced
+ * the every-other-day bug this replaces.
  */
 export function isScheduleDue(
   project: Pick<Project, "schedule" | "schedule_interval_days" | "last_run_at">,
@@ -211,7 +253,7 @@ export function isScheduleDue(
   // is a belt on top of that suspenders, not the primary guard.
   if (!intervalDays) return false;
   const last = new Date(project.last_run_at).getTime();
-  return now - last >= intervalDays * DAY_MS - SCHEDULE_GRACE_MS;
+  return utcDay(now) - utcDay(last) >= intervalDays;
 }
 
 /** SCHEDULE_LABELS plus the actual number for 'custom' (e.g. "Every 14 days"),

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -442,6 +442,39 @@ alter table public.projects
 alter table public.projects
   add column if not exists results_seen_at timestamptz;
 
+-- An earlier draft of this file allowed 'every_3_days'. It is gone; the
+-- constraint below cannot be added while a row still holds it, so fold those
+-- rows into the nearest surviving cadence (weekly never increases anyone's
+-- spend). A no-op on any deployment that never ran that draft.
+update public.projects set schedule = 'weekly' where schedule = 'every_3_days';
+
+-- Widen the schedule allow-list with 'custom': any interval a user names, in
+-- days (see schedule_interval_days below). Safe to re-run.
+alter table public.projects drop constraint if exists projects_schedule_check;
+alter table public.projects
+  add constraint projects_schedule_check
+  check (schedule in ('off', 'daily', 'weekly', 'custom'));
+
+-- Days between runs when schedule = 'custom'; unused (and expected null) for
+-- every other schedule, which already carries its interval in its own name.
+-- Split into add-column + named constraint (same shape as runs.route further
+-- down): an inline check on `add column if not exists` is skipped once the
+-- column exists, which would leave the range unenforced on a deployment
+-- upgrading from an earlier version of this file. Safe to re-run.
+alter table public.projects add column if not exists schedule_interval_days integer;
+alter table public.projects drop constraint if exists projects_schedule_interval_check;
+alter table public.projects
+  add constraint projects_schedule_interval_check
+  check (schedule_interval_days is null or schedule_interval_days between 1 and 90);
+
+-- A 'custom' row with no interval would fall through to the cron's daily
+-- branch and run up to 90x more often than the user asked for, silently, on
+-- their own key. Refusing the write is cheaper than debugging the spend.
+alter table public.projects drop constraint if exists projects_custom_needs_interval;
+alter table public.projects
+  add constraint projects_custom_needs_interval
+  check (schedule <> 'custom' or schedule_interval_days is not null);
+
 -- ---------- competitors ----------------------------------------------
 create table if not exists public.competitors (
   id uuid primary key default gen_random_uuid(),

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -442,12 +442,6 @@ alter table public.projects
 alter table public.projects
   add column if not exists results_seen_at timestamptz;
 
--- An earlier draft of this file allowed 'every_3_days'. It is gone; the
--- constraint below cannot be added while a row still holds it, so fold those
--- rows into the nearest surviving cadence (weekly never increases anyone's
--- spend). A no-op on any deployment that never ran that draft.
-update public.projects set schedule = 'weekly' where schedule = 'every_3_days';
-
 -- Widen the schedule allow-list with 'custom': any interval a user names, in
 -- days (see schedule_interval_days below). Safe to re-run.
 alter table public.projects drop constraint if exists projects_schedule_check;


### PR DESCRIPTION
## Why

`cmillstein1`'s review on this PR caught a merge-order blocker, two API gaps, an
undisclosed cadence change, and several UI races. This revision fixes all nine
review comments — including replacing the grace-window fix with one that
actually works (see "What the research changed" below) — and removes the
Settings-tab schedule control per a follow-up decision.

## What

- `lib/utils.ts`: one shared `parseCustomInterval` / `customIntervalError` /
  `normalizeCustomInterval`, used by every server entrypoint and every UI
  control instead of three different clamp/reject policies.
- `lib/onboard.ts`: `parseOnboardingCadence` validates cadence **before** the
  site scrape or the metered suggestion call, shared by both onboarding routes.
- `lib/api-service.ts`: `projectSummary` now carries `schedule_interval_days`,
  so the v1 API, `POST /api/v1/onboard`, and the MCP `list_projects` tool all
  report a custom interval instead of just `"custom"` with no number.
- `lib/utils.ts` / `lib/engine.ts`: the cron's due-check now anchors on run
  **start** and compares whole **UTC calendar days**, not elapsed milliseconds
  against a finish timestamp.
- `app/dashboard/runs/schedule-control.tsx`: one commit per intentional edit —
  clearing the days box restores the previous value instead of becoming 1,
  picking "custom" reveals the input without saving, and a `savingRef` closes
  the select/input save race.
- `components/dashboard/cadence-picker.tsx`: `OnboardingCadence` and its pills
  are derived from `Schedule`/`SCHEDULE_LABELS` instead of hand-retyped; an
  editable draft keeps a blank field from ever becoming `0`.
- `app/dashboard/settings/project-form.tsx`: the schedule control is removed —
  cadence is now set at onboarding and on the Runs page only.
- `supabase/schema.sql`: the dead `every_3_days` migration statement is gone.

## What the research changed

The original fix for the grace-window comment (anchor `last_run_at` on run
**start** instead of finish, delete the 6h grace) does not actually fix the bug
it was reviewed for. The cron reads the clock once, before a **sequential**
sweep (`app/api/cron/run/route.ts:69`), and each project's run starts minutes
after that frozen `now` — bounded only by the 800s route ceiling, not by
anything close to instant. So even anchored on start, an exact
`now - last >= intervalDays * DAY_MS` check is short by the project's position
in the sweep at the very next tick:

```
MON 08:00:00  cron reads clock. Project #40 starts 08:06:30 -> last_run_at = 08:06:30
TUE 08:00:00  cron reads clock again. elapsed for #40 = 23h53m30s < 24h -> SKIPPED
WED 08:00:00  47h+ elapsed -> runs
```

Every daily project but the first in the sweep would fire every 48h — the exact
symptom the deleted 6h grace existed to paper over, just relocated. The actual
fix compares **whole UTC calendar days** turned over, not elapsed milliseconds:
immune to queue position, run duration, and cron jitter alike, with no magic
grace constant. See `lib/utils.ts`'s `isScheduleDue` for the implementation and
comment, and `lib/utils.test.ts` for the day-boundary tests that replace the
elapsed-ms ones. Verified live against local Postgres (four scenarios: a
21h39m-old run that crossed a day boundary correctly fires; a same-day run
correctly does not double-fire; a custom/14 project fires exactly at the
14-day boundary and not a day earlier) — see the Verification section.

## Design decisions worth reviewing

**Cadence behaviour change, ~120 live projects.** The 111 daily / 9 weekly
scheduled projects in production today were firing every *other* interval
(every 2 days / every 2 weeks), because the cron's frozen-clock sweep meant an
exact elapsed-ms check missed the very next tick for every project but the
first processed. This PR fixes that — they will now fire on the cadence they
were set to, roughly **doubling** their run count and therefore free-trial
burn for trial-funded ones. This is the correct behavior, not a regression: the
alternative (a duration-based grace window) is what produced the bug. One
edge worth knowing: a manual run late in the day makes the very next morning's
cron tick due, a few hours later rather than a full day on — accepted as the
cost of a stable day-grid.

**Scheduling removed from the Settings tab.** Per a follow-up decision, cadence
is set at onboarding and on the Runs page only; Settings no longer offers a
redundant editor for it. `POST /api/project` now writes cadence only when the
request body actually includes a `schedule` key — omitting it (as every
Settings save now does) leaves an existing project's cadence untouched, rather
than resetting it to `off` on every unrelated save.

**`POST /api/project` now 400s a malformed `intervalDays`** instead of clamping
and silently substituting 14 — the same policy `/api/onboarding/complete` and
`PATCH /api/project/schedule` already used, via the new shared
`parseCustomInterval`.

**A scheduled project with zero active prompts now advances `last_run_at`.**
Previously the zero-jobs early return in `resumeRunMeasured` left the anchor
untouched, so such a project was reported as never having run and opened a new,
empty `runs` row on every single cron tick, forever.

## Deliberately NOT in this PR

- **No `Switch`/`SegmentedControl` extraction** (comment #9). The cheap half —
  routing the days inputs through the shared `Input` and adding the missing
  `focus-visible` rings — is done. Extraction would touch `project-form.tsx`,
  `theme.tsx`, and two admin pages, and `components/ui.tsx` is explicitly
  documented as hook-free and Server-Component-safe, so a shared interactive
  home needs a new client module. Left as a follow-up; replied on the thread.
- **`/api/v1/projects` POST/PATCH still refuse `schedule`** by design — API
  callers orchestrate their own cadence, unchanged by this PR.
- **The 800s sweep ceiling and the sequential-sweep structure of
  `app/api/cron/run/route.ts` are untouched.** The day-floor fix works
  regardless of sweep duration or project ordering, so neither needed changing.

## Scope

Dashboard onboarding, Runs page schedule control, Settings (control removed),
schedule/onboarding API routes, the cron due-check, shared types/utils, tests,
README, and `supabase/schema.sql`.

## Tests

`lib/utils.test.ts` — day-boundary due-check (3 new cases replacing the
elapsed-ms ones), custom-interval parsing/normalization.
`lib/engine-budget.test.ts` — cadence anchor on run start, including the
zero-jobs branch.
`app/api/project/route.test.ts` — parser policy, plus omitted-`schedule`
leaves an existing project's cadence untouched and a new project's insert
carries no cadence keys.
`app/api/onboarding/*`, `app/api/v1/onboard/*` — cadence validation runs
before any scrape/suggestion call.
**1027 passing** (54 files). Typecheck, lint, and build clean.

## Before merge

1. **Apply the schema before merging, not after** (comment #1) — every
   onboarding insert and every project write now names
   `schedule_interval_days`; production has neither the column nor the widened
   `custom` constraint yet.