### PR TITLE
Conversions: who keeps a report on a cadence, and how often it runs

### DIFF
--- a/app/admin/conversions/page.tsx
+++ b/app/admin/conversions/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import { ArrowUpRight } from "lucide-react";
 import { requireAdmin } from "@/lib/admin";
-import { conversionsReport, type RatePoint } from "@/lib/conversions";
+import { conversionsReport, type RatePoint, type SchedulePoint } from "@/lib/conversions";
 import { periodFrom, periodLabel, type Period } from "@/lib/periods";
 import type { EmailClass } from "@/lib/growth";
 import { Badge, Card, SectionHeading, StatCard } from "@/components/ui";
@@ -44,15 +44,25 @@ function ColumnHeader({ children, className }: { children: React.ReactNode; clas
 }
 
 /**
- * Each day's connected rate on its own — that day's clickers over the signups
- * that existed by then — so a quiet day sits on the baseline and a busy one
- * stands out, instead of every day folding into a total that can only climb.
- * Same construction as Growth's RunSparkline: inline SVG, numbers in <title>
- * tooltips, colors through style because CSS var() only resolves in styles.
- * One series, so the title is the legend.
+ * A percentage per day, drawn as one filled line. Same construction as
+ * Growth's RunSparkline: inline SVG, numbers in <title> tooltips, colors
+ * through style because CSS var() only resolves in styles. One series, so the
+ * card's title is the legend.
+ *
+ * Points arrive already filtered of their null days: a day with nothing to
+ * divide by is a gap in the data, and interpolating across it would invent a
+ * number. `tint` is a color token name — both charts on this page are the same
+ * shape and differ only in hue.
  */
-function RateChart({ series }: { series: RatePoint[] }) {
-  const points = series.filter((p) => p.rate !== null) as (RatePoint & { rate: number })[];
+function DayRateChart({
+  points,
+  tint,
+  ariaLabel,
+}: {
+  points: { day: string; rate: number; title: string }[];
+  tint: string;
+  ariaLabel: string;
+}) {
   if (points.length === 0) return null;
 
   const W = 600;
@@ -76,17 +86,17 @@ function RateChart({ series }: { series: RatePoint[] }) {
       preserveAspectRatio="none"
       className="h-36 w-full"
       role="img"
-      aria-label="Connected rate over time"
+      aria-label={ariaLabel}
     >
       {/* Baseline at 0% — the one recessive gridline this needs. */}
       <line x1={0} y1={H - 4} x2={W} y2={H - 4} style={{ stroke: "rgb(var(--c-ink) / 0.12)", strokeWidth: 1 }} vectorEffect="non-scaling-stroke" />
       <polygon
         points={`0,${H - 4} ${line} ${W},${H - 4}`}
-        style={{ fill: "rgb(var(--c-mint-bright) / 0.12)" }}
+        style={{ fill: `rgb(var(--c-${tint}) / 0.12)` }}
       />
       <polyline
         points={line}
-        style={{ fill: "none", stroke: "rgb(var(--c-mint-bright))", strokeWidth: 2 }}
+        style={{ fill: "none", stroke: `rgb(var(--c-${tint}))`, strokeWidth: 2 }}
         strokeLinejoin="round"
         strokeLinecap="round"
         vectorEffect="non-scaling-stroke"
@@ -102,10 +112,52 @@ function RateChart({ series }: { series: RatePoint[] }) {
           height={H}
           fill="transparent"
         >
-          <title>{`${p.day} · ${p.rate}% connected (${p.connected} of ${p.signups} signups clicked this day) · ${p.clicks} click${p.clicks === 1 ? "" : "s"}`}</title>
+          <title>{p.title}</title>
         </rect>
       ))}
     </svg>
+  );
+}
+
+/**
+ * Each day's connected rate on its own — that day's clickers over the signups
+ * that existed by then — so a quiet day sits on the baseline and a busy one
+ * stands out, instead of every day folding into a total that can only climb.
+ */
+function RateChart({ series }: { series: RatePoint[] }) {
+  return (
+    <DayRateChart
+      tint="mint-bright"
+      ariaLabel="Connected rate over time"
+      points={series
+        .filter((p): p is RatePoint & { rate: number } => p.rate !== null)
+        .map((p) => ({
+          day: p.day,
+          rate: p.rate,
+          title: `${p.day} · ${p.rate}% connected (${p.connected} of ${p.signups} signups clicked this day) · ${p.clicks} click${p.clicks === 1 ? "" : "s"}`,
+        }))}
+    />
+  );
+}
+
+/**
+ * Scheduling by signup cohort: each day is the accounts that signed up THAT
+ * day, and the share of them running a report on a cadence today. Days nobody
+ * signed up carry no rate and drop out entirely.
+ */
+function ScheduleChart({ series }: { series: SchedulePoint[] }) {
+  return (
+    <DayRateChart
+      tint="teal"
+      ariaLabel="Share of each day's signups scheduling a report"
+      points={series
+        .filter((p): p is SchedulePoint & { rate: number } => p.rate !== null)
+        .map((p) => ({
+          day: p.day,
+          rate: p.rate,
+          title: `${p.day} · ${p.rate}% scheduling (${p.scheduled} of the ${p.signups} account${p.signups === 1 ? "" : "s"} that signed up this day)`,
+        }))}
+    />
   );
 }
 
@@ -117,10 +169,16 @@ export default async function ConversionsPage({ searchParams }: { searchParams: 
 
   const period: Period = periodFrom(searchParams.p);
   const label = periodLabel(period);
-  const { stats, keyed, series, connected, degraded } = await conversionsReport(period);
+  const { stats, keyed, scheduled, series, scheduleSeries, connected, degraded } =
+    await conversionsReport(period);
   const latest = series.filter((p) => p.rate !== null).at(-1);
   const peak = series.reduce((a, b) => ((b.rate ?? -1) > (a?.rate ?? -1) ? b : a), latest);
   const today = new Date().toISOString().slice(0, 10);
+  // Days that had signups are the only ones the cohort chart can speak about.
+  const scheduleDays = scheduleSeries.filter((p) => p.rate !== null);
+  const cadence = scheduled.byInterval
+    .map((i) => `${i.projects.toLocaleString()} ${i.schedule}`)
+    .join(" · ");
 
   return (
     <div className="space-y-10">
@@ -254,6 +312,83 @@ export default async function ConversionsPage({ searchParams }: { searchParams: 
         </div>
       </section>
 
+      {/* ---- Row 1c: the cadence rung ----------------------------------------
+          The one figure here that reads a STATE rather than an event: the
+          projects table says what the cadence is now and nothing records when
+          it became that, so the window scopes the SIGNUP COHORT, exactly as
+          the activation card above does. Onboarding has created projects on a
+          daily schedule since 2026-08-20, so for anyone newer than that this
+          rung measures "left it on", not "switched it on" — said plainly in
+          the hints, because a number near 100% otherwise reads as a triumph. */}
+      <section className="space-y-3">
+        <h3 className="text-sm font-medium uppercase tracking-wider text-ink-faint">
+          Scheduled · keeps a report running on a cadence
+        </h3>
+        <div className="grid grid-cols-2 gap-4 lg:grid-cols-3">
+          <StatCard
+            label="Scheduling rate"
+            value={scheduled.rate === null ? "—" : `${scheduled.rate}%`}
+            hint={
+              scheduled.cohortSize === 0
+                ? `nobody signed up in ${label}`
+                : `${scheduled.cohortScheduled.toLocaleString()} of the ${scheduled.cohortSize.toLocaleString()} accounts that signed up ${period === "all" ? "ever" : `in the ${label.replace("last ", "")}`} have a report on a schedule today`
+            }
+            accent="teal"
+          />
+          <StatCard
+            label="Scheduling accounts"
+            value={scheduled.allTime.toLocaleString()}
+            hint={
+              scheduled.rateAllTime === null
+                ? "nobody has signed up yet"
+                : `${scheduled.rateAllTime}% of all ${scheduled.totalUsers.toLocaleString()} signups · ${scheduled.projects.toLocaleString()} scheduled report${scheduled.projects === 1 ? "" : "s"} between them`
+            }
+            accent="mint"
+          />
+          <StatCard
+            label="Average cadence"
+            value={
+              scheduled.avgIntervalDays === null
+                ? "—"
+                : `${scheduled.avgIntervalDays} day${scheduled.avgIntervalDays === 1 ? "" : "s"}`
+            }
+            hint={
+              scheduled.avgIntervalDays === null
+                ? "nothing is scheduled yet"
+                : `mean gap between runs over ${scheduled.projects.toLocaleString()} scheduled report${scheduled.projects === 1 ? "" : "s"} · ${cadence} · all time`
+            }
+            accent="butter"
+          />
+        </div>
+      </section>
+
+      {/* ---- Row 1d: scheduling by signup cohort ------------------------------ */}
+      <Card>
+        <div className="flex flex-col px-5 pb-4 pt-5">
+          <div className="flex items-baseline justify-between gap-3">
+            <h3 className="text-sm font-semibold text-ink">Scheduling rate by signup cohort</h3>
+            <span className="text-xs text-ink-faint">{label}</span>
+          </div>
+          {scheduleDays.length === 0 ? (
+            <p className="py-8 text-sm text-ink-faint">
+              Nobody signed up {period === "all" ? "yet" : "in this period"}, so there is no
+              cohort to draw.
+            </p>
+          ) : (
+            <>
+              <div className="mt-3">
+                <ScheduleChart series={scheduleSeries} />
+              </div>
+              <p className="mt-3 text-xs tabular-nums text-ink-faint">
+                each day is that day&apos;s signups, and how many of them run a report on a
+                cadence today · hover for the counts · a low-volume day is one or two people, so
+                read the shape, not a single point
+              </p>
+            </>
+          )}
+        </div>
+      </Card>
+
       {/* ---- Row 2: the rate over time ---------------------------------------- */}
       <Card>
         <div className="flex flex-col px-5 pb-4 pt-5">
@@ -367,7 +502,14 @@ export default async function ConversionsPage({ searchParams }: { searchParams: 
         time to first key count the accounts whose first key LANDED in it. A cohort rate can
         never exceed 100%; the obvious alternative (keys added over signups in the window)
         can, because someone who signed up in March and pasted a key today belongs to only one
-        of those two sets. On all time the two definitions coincide.{" "}
+        of those two sets. On all time the two definitions coincide. Scheduling is a state and
+        not an event — projects.schedule holds today&rsquo;s cadence and nothing records when it
+        was set — so it is read through signup cohorts too, and the chart is cohorts rather than
+        the stock curve it resembles: drawing &ldquo;what share had a schedule on that day&rdquo;
+        would mean rewinding a change log that only covers the dashboard toggle, which produces a
+        smooth line that is quietly wrong. Onboarding has started new projects on a daily
+        schedule since 2026-08-20, so a high rate among recent cohorts means the default was
+        kept, not that anyone went looking for the setting.{" "}
         <Link href="/admin/growth" className="underline">
           Back to growth
         </Link>

--- a/lib/conversions.test.ts
+++ b/lib/conversions.test.ts
@@ -10,8 +10,11 @@ import {
   shapeConnectedUsers,
   shapeKeyedStats,
   shapeRateSeries,
+  shapeScheduledStats,
+  shapeScheduleSeries,
   type KeyRow,
   type OutboundClickRow,
+  type ScheduleProjectRow,
 } from "./conversions";
 import type { GrowthProfileRow } from "./growth";
 
@@ -366,5 +369,131 @@ describe("median", () => {
     expect(median([5, 1, 3])).toBe(3);
     expect(median([4, 1, 3, 2])).toBe(3);
     expect(median([])).toBeNull();
+  });
+});
+
+describe("shapeScheduledStats", () => {
+  // u1 runs two organizations, one of them weekly — so accounts and scheduled
+  // reports are deliberately different numbers. u2 is daily, u3 turned it off,
+  // u4 has no project at all.
+  const projects: ScheduleProjectRow[] = [
+    { user_id: "u1", schedule: "daily", created_at: iso(50) },
+    { user_id: "u1", schedule: "weekly", created_at: iso(40) },
+    { user_id: "u2", schedule: "daily", created_at: iso(6) },
+    { user_id: "u3", schedule: "off", created_at: iso(2) },
+  ];
+  const profiles: GrowthProfileRow[] = [
+    { id: "u1", email: "a@x.com", created_at: iso(50) },
+    { id: "u2", email: "b@x.com", created_at: iso(7) },
+    { id: "u3", email: "c@x.com", created_at: iso(3) },
+    { id: "u4", email: "d@x.com", created_at: iso(1) },
+  ];
+
+  it("counts accounts, not projects, and ignores the ones switched off", () => {
+    const stats = shapeScheduledStats(projects, profiles, null);
+    expect(stats.allTime).toBe(2);
+    expect(stats.projects).toBe(3);
+    expect(stats.rateAllTime).toBe(50);
+  });
+
+  it("rates the window's SIGNUP COHORT, so the numerator can't escape the denominator", () => {
+    // Last 7 days: u2, u3 and u4 signed up, and only u2 schedules.
+    const stats = shapeScheduledStats(projects, profiles, NOW - 7 * DAY_MS);
+    expect(stats).toMatchObject({ cohortSize: 3, cohortScheduled: 1, rate: 33.3 });
+    // The stock rate ignores the window, so it still sees u1.
+    expect(stats.allTime).toBe(2);
+  });
+
+  it("averages the cadence over scheduled reports and breaks it down", () => {
+    const stats = shapeScheduledStats(projects, profiles, null);
+    // daily + daily + weekly = (1 + 1 + 7) / 3.
+    expect(stats.avgIntervalDays).toBe(3);
+    expect(stats.byInterval).toEqual([
+      { schedule: "daily", days: 1, projects: 2 },
+      { schedule: "weekly", days: 7, projects: 1 },
+    ]);
+  });
+
+  it("treats an unknown schedule value as not scheduled rather than throwing", () => {
+    const stats = shapeScheduledStats(
+      [{ user_id: "u1", schedule: "hourly", created_at: iso(1) }],
+      profiles,
+      null,
+    );
+    expect(stats).toMatchObject({ allTime: 0, projects: 0, avgIntervalDays: null, byInterval: [] });
+  });
+
+  it("never counts a project whose owner has no profile row", () => {
+    const stats = shapeScheduledStats(
+      [{ user_id: "ghost", schedule: "daily", created_at: iso(1) }],
+      profiles,
+      null,
+    );
+    expect(stats.allTime).toBe(0);
+    expect(stats.rateAllTime).toBe(0);
+    // The report itself is still real, and still counts as one.
+    expect(stats.projects).toBe(1);
+  });
+
+  it("nulls both rates when nobody has signed up", () => {
+    expect(shapeScheduledStats([], [], null)).toMatchObject({
+      rate: null,
+      rateAllTime: null,
+      avgIntervalDays: null,
+      totalUsers: 0,
+    });
+  });
+});
+
+describe("shapeScheduleSeries", () => {
+  const projects: ScheduleProjectRow[] = [
+    { user_id: "u1", schedule: "weekly", created_at: iso(3) },
+    { user_id: "u2", schedule: "off", created_at: iso(3) },
+    { user_id: "u3", schedule: "daily", created_at: iso(2) },
+  ];
+  const profiles: GrowthProfileRow[] = [
+    { id: "u1", email: null, created_at: iso(3) },
+    { id: "u2", email: null, created_at: iso(3) },
+    { id: "u3", email: null, created_at: iso(2) },
+  ];
+
+  it("buckets by signup day and rates that day's cohort", () => {
+    const series = shapeScheduleSeries(projects, profiles, NOW - 3 * DAY_MS, NOW);
+    const days = Object.fromEntries(series.map((p) => [p.day, p]));
+    const threeDaysAgo = iso(3).slice(0, 10);
+    const twoDaysAgo = iso(2).slice(0, 10);
+    expect(days[threeDaysAgo]).toMatchObject({ signups: 2, scheduled: 1, rate: 50 });
+    expect(days[twoDaysAgo]).toMatchObject({ signups: 1, scheduled: 1, rate: 100 });
+  });
+
+  it("leaves a day nobody signed up as null rather than zero", () => {
+    const series = shapeScheduleSeries(projects, profiles, NOW - 3 * DAY_MS, NOW);
+    const yesterday = iso(1).slice(0, 10);
+    expect(series.find((p) => p.day === yesterday)).toMatchObject({
+      signups: 0,
+      scheduled: 0,
+      rate: null,
+    });
+  });
+
+  it("runs from the first signup for all-time, and is empty with no signups", () => {
+    const series = shapeScheduleSeries(projects, profiles, null, NOW);
+    expect(series[0].day).toBe(iso(3).slice(0, 10));
+    expect(series.at(-1)?.day).toBe(new Date(NOW).toISOString().slice(0, 10));
+    expect(shapeScheduleSeries(projects, [], null, NOW)).toEqual([]);
+  });
+
+  it("ignores signups from the future and unparseable timestamps", () => {
+    const series = shapeScheduleSeries(
+      projects,
+      [
+        ...profiles,
+        { id: "u4", email: null, created_at: new Date(NOW + DAY_MS).toISOString() },
+        { id: "u5", email: null, created_at: "nope" },
+      ],
+      NOW - 3 * DAY_MS,
+      NOW,
+    );
+    expect(series.reduce((n, p) => n + p.signups, 0)).toBe(3);
   });
 });

--- a/lib/conversions.ts
+++ b/lib/conversions.ts
@@ -273,6 +273,197 @@ export function shapeKeyedStats(
 }
 
 // ---------------------------------------------------------------------------
+// Put a report on a cadence
+// ---------------------------------------------------------------------------
+
+/** A project as this module reads it: who owns it and what cadence it runs on.
+ *  `schedule` is the column's own vocabulary ('off' | 'daily' | 'weekly'), kept
+ *  as a plain string so a value added to the check constraint before this file
+ *  hears about it degrades to "no interval" rather than to a crash. */
+export interface ScheduleProjectRow {
+  user_id: string;
+  schedule: string;
+  created_at: string;
+}
+
+/** Days between runs, per cadence. The map IS the definition of "scheduled":
+ *  a schedule with no entry here (today only 'off') does not count anywhere
+ *  below, so adding 'monthly' to the column means adding one line here. */
+export const SCHEDULE_INTERVAL_DAYS: Record<string, number> = {
+  daily: 1,
+  weekly: 7,
+};
+
+export interface ScheduledStats {
+  /** Accounts owning at least one project on a schedule right now, whenever
+   *  they signed up. A stock, not an event — see the note on the shaper. */
+  allTime: number;
+  /** Every account, for the all-time rate's denominator. */
+  totalUsers: number;
+  /** The window's SIGNUP COHORT rate: of the accounts created inside it, the
+   *  share that have a report on a schedule today. Same construction as the
+   *  API-key activation card, and for the same reason — the numerator has to
+   *  stay inside the denominator. One decimal. */
+  rate: number | null;
+  cohortSize: number;
+  cohortScheduled: number;
+  /** The stock rate over everyone who ever signed up. Equal to `rate` on the
+   *  all-time period, by construction. */
+  rateAllTime: number | null;
+  /** Scheduled projects, which is not the same as scheduled accounts: one
+   *  owner can run several organizations on a cadence. */
+  projects: number;
+  /** Those projects split by cadence, most frequent first — the breakdown
+   *  behind the average, since a mean of two values is only readable next to
+   *  the counts it came from. */
+  byInterval: { schedule: string; days: number; projects: number }[];
+  /** Mean days between runs across every scheduled project, one decimal.
+   *  Null when nothing is scheduled. */
+  avgIntervalDays: number | null;
+}
+
+/**
+ * How many accounts have a report running on a cadence, and how often it runs.
+ *
+ * Unlike every other figure on this page, this one reads a STATE and not an
+ * event: projects.schedule says what the cadence is now, and nothing anywhere
+ * records when it became that. So there is no "scheduled in the last 7 days"
+ * to be had — the period scopes the SIGNUP COHORT instead, exactly as the
+ * API-key activation card does, and the question it answers is "of the people
+ * who joined in this window, how many are on a cadence today".
+ *
+ * Read the number knowing that onboarding has created projects with a daily
+ * schedule since 2026-08-20, so for anyone who signed up after that this
+ * measures "did not turn it off" rather than "went and switched it on". The
+ * page says so too; a rate near 100% here is the default, not enthusiasm.
+ */
+export function shapeScheduledStats(
+  projects: ScheduleProjectRow[],
+  profiles: GrowthProfileRow[],
+  since: number | null,
+): ScheduledStats {
+  const owners = new Set<string>();
+  const byInterval = new Map<string, number>();
+  let intervalSum = 0;
+  let scheduledProjects = 0;
+
+  for (const project of projects) {
+    const days = SCHEDULE_INTERVAL_DAYS[project.schedule];
+    if (days === undefined) continue;
+    owners.add(project.user_id);
+    byInterval.set(project.schedule, (byInterval.get(project.schedule) ?? 0) + 1);
+    intervalSum += days;
+    scheduledProjects += 1;
+  }
+
+  let cohortSize = 0;
+  let cohortScheduled = 0;
+  let allTimeScheduled = 0;
+  for (const profile of profiles) {
+    const created = Date.parse(profile.created_at);
+    // A profile with an unreadable created_at can still be counted all-time —
+    // it is a real account — it just cannot be placed in a window.
+    if (owners.has(profile.id)) allTimeScheduled += 1;
+    if (!Number.isFinite(created)) continue;
+    if (since !== null && created < since) continue;
+    cohortSize += 1;
+    if (owners.has(profile.id)) cohortScheduled += 1;
+  }
+
+  const totalUsers = profiles.length;
+  return {
+    // Counted through profiles, so an orphaned project (owner deleted, or a
+    // profile the row cap cut off) can never push the rate past 100%.
+    allTime: allTimeScheduled,
+    totalUsers,
+    rate: cohortSize > 0 ? Math.round((cohortScheduled / cohortSize) * 1000) / 10 : null,
+    cohortSize,
+    cohortScheduled,
+    rateAllTime:
+      totalUsers > 0 ? Math.round((allTimeScheduled / totalUsers) * 1000) / 10 : null,
+    projects: scheduledProjects,
+    byInterval: [...byInterval.entries()]
+      .map(([schedule, count]) => ({
+        schedule,
+        days: SCHEDULE_INTERVAL_DAYS[schedule],
+        projects: count,
+      }))
+      .sort((a, b) => a.days - b.days),
+    avgIntervalDays:
+      scheduledProjects > 0 ? Math.round((intervalSum / scheduledProjects) * 10) / 10 : null,
+  };
+}
+
+export interface SchedulePoint {
+  /** UTC day accounts SIGNED UP on — not a day something was scheduled. */
+  day: string;
+  /** Of that day's signups, the share with a report on a schedule today. Null
+   *  on a day nobody signed up, which draws as a gap rather than as a zero. */
+  rate: number | null;
+  scheduled: number;
+  signups: number;
+}
+
+/**
+ * Scheduling by signup cohort: one point per UTC day, each the share of that
+ * day's signups that are on a cadence today.
+ *
+ * This deliberately is NOT "what percentage of users had a schedule on, on
+ * this day" — the curve everyone pictures. Drawing that needs the history of
+ * schedule changes, and there isn't one: the column holds only its current
+ * value, and the activity log records a change only when it came through the
+ * dashboard toggle, never when a project was born scheduled. Rewinding a
+ * partial log would produce a smooth line that is quietly wrong, so this shows
+ * the thing the data can actually support — whether newer cohorts keep a
+ * cadence more than older ones — and says so on the page.
+ */
+export function shapeScheduleSeries(
+  projects: ScheduleProjectRow[],
+  profiles: GrowthProfileRow[],
+  since: number | null,
+  now: number,
+): SchedulePoint[] {
+  const owners = new Set<string>();
+  for (const project of projects) {
+    if (SCHEDULE_INTERVAL_DAYS[project.schedule] !== undefined) owners.add(project.user_id);
+  }
+
+  const signups = profiles
+    .map((p) => ({ id: p.id, t: Date.parse(p.created_at) }))
+    .filter((p) => Number.isFinite(p.t) && p.t <= now && (since === null || p.t >= since))
+    .sort((a, b) => a.t - b.t);
+
+  const firstDay = since ?? signups[0]?.t;
+  if (firstDay === undefined) return [];
+
+  const startDay = new Date(firstDay).toISOString().slice(0, 10);
+  const series: SchedulePoint[] = [];
+  let idx = 0;
+
+  for (
+    let dayStart = Date.parse(`${startDay}T00:00:00.000Z`);
+    dayStart <= now;
+    dayStart += DAY_MS
+  ) {
+    const dayEnd = dayStart + DAY_MS;
+    let daySignups = 0;
+    let dayScheduled = 0;
+    while (idx < signups.length && signups[idx].t < dayEnd) {
+      daySignups += 1;
+      if (owners.has(signups[idx].id)) dayScheduled += 1;
+      idx += 1;
+    }
+    series.push({
+      day: new Date(dayStart).toISOString().slice(0, 10),
+      rate: daySignups > 0 ? Math.round((dayScheduled / daySignups) * 1000) / 10 : null,
+      scheduled: dayScheduled,
+      signups: daySignups,
+    });
+  }
+  return series;
+}
+
+// ---------------------------------------------------------------------------
 // The rate over time (the chart under the stat row)
 // ---------------------------------------------------------------------------
 
@@ -408,7 +599,9 @@ export function shapeConnectedUsers(
 export interface ConversionsReport {
   stats: ConversionStats;
   keyed: KeyedStats;
+  scheduled: ScheduledStats;
   series: RatePoint[];
+  scheduleSeries: SchedulePoint[];
   connected: ConnectedUser[];
   /** Set when a query failed — the page says "incomplete", never fake zero. */
   degraded: string | null;
@@ -426,7 +619,10 @@ export async function conversionsReport(
 
   // All keys, all time: the period filter applies to a user's FIRST key, which
   // can only be found by looking at every row they have.
-  const [clicksQ, profilesQ, providerKeysQ, routerKeysQ] = await Promise.all([
+  // Projects come in whole and unfiltered for the same reason: a schedule has
+  // no timestamp of its own, so the period can only be applied to the OWNER's
+  // signup date, which lives in profiles.
+  const [clicksQ, profilesQ, providerKeysQ, routerKeysQ, projectsQ] = await Promise.all([
     svc
       .from("outbound_clicks")
       .select("user_id, url, clicked_at")
@@ -435,6 +631,7 @@ export async function conversionsReport(
     svc.from("profiles").select("id, email, created_at").limit(ROWS_CAP),
     svc.from("provider_keys").select("user_id, created_at").limit(ROWS_CAP),
     svc.from("router_keys").select("user_id, created_at").limit(ROWS_CAP),
+    svc.from("projects").select("user_id, schedule, created_at").limit(ROWS_CAP),
   ]);
 
   const failed = [
@@ -442,6 +639,7 @@ export async function conversionsReport(
     profilesQ.error && "profiles",
     providerKeysQ.error && "provider_keys",
     routerKeysQ.error && "router_keys",
+    projectsQ.error && "projects",
   ].filter(Boolean);
   const clicks = (clicksQ.data ?? []) as OutboundClickRow[];
   const profiles = (profilesQ.data ?? []) as GrowthProfileRow[];
@@ -449,12 +647,15 @@ export async function conversionsReport(
     ...((providerKeysQ.data ?? []) as KeyRow[]),
     ...((routerKeysQ.data ?? []) as KeyRow[]),
   ];
+  const projects = (projectsQ.data ?? []) as ScheduleProjectRow[];
   const since = periodStart(period, now);
 
   return {
     stats: shapeConversionStats(clicks, profiles.length, since),
     keyed: shapeKeyedStats(keys, profiles, since),
+    scheduled: shapeScheduledStats(projects, profiles, since),
     series: shapeRateSeries(clicks, profiles, since, now),
+    scheduleSeries: shapeScheduleSeries(projects, profiles, since, now),
     // The table reads through the same window: destinations, counts and
     // first/latest are period-scoped, so it always agrees with the cards.
     connected: shapeConnectedUsers(clicksSince(clicks, since), profiles),


### PR DESCRIPTION
Adds a third rung to `/admin/conversions`, **Scheduled · keeps a report running on a cadence**:

- **Scheduling rate** — of the accounts that signed up in the selected period, the share with a report on a schedule today.
- **Scheduling accounts** — the all-time stock, its share of every signup, and how many scheduled reports they run between them.
- **Average cadence** — the mean gap between runs across scheduled reports (daily = 1 day, weekly = 7), with the split in the hint (`119 daily · 9 weekly`).
- **Scheduling rate by signup cohort** — one point per UTC day: that day's signups, and how many of them are on a cadence today.

## Why it's cohorts and not a stock curve

Scheduling is a **state**, not an event. `projects.schedule` holds today's cadence and nothing records when it became that — `project.created` logs no schedule, and an onboarding-created project is born `daily` with no log line at all. So there is no honest "scheduled in the last 7 days"; the period scopes the **signup cohort** instead, exactly as the API-key activation card above it does, which is also what keeps the numerator inside the denominator.

The chart follows the same rule. Drawing "what share had a schedule on that day" would mean rewinding a change log that only covers the dashboard toggle — a smooth line that is quietly wrong.

## The caveat, stated on the page

Onboarding has started new projects on a daily schedule since #143 (2026-08-20), so for anyone newer than that this measures *left it on*, not *went and switched it on*. A rate near 100% is the default working, not enthusiasm. The card hints and the page footnote say so.

## Notes

- Accounts and scheduled reports are counted separately, since one owner can run several organizations on a cadence: the rate is accounts, the average cadence is reports.
- "Scheduled" means the value has an entry in `SCHEDULE_INTERVAL_DAYS`, so a cadence added to the column's check constraint before this file hears about it reads as "no interval" rather than crashing — and adding `monthly` later is one line.
- A project whose owner has no profile row still counts as a report but never as an account, so no rate can exceed 100%.
- The page's existing SVG chart is now a shared `DayRateChart` (hue and tooltip passed in) so the two curves can't drift apart.

## Verification

- 11 new unit tests; full suite 993 passing, plus typecheck, lint and `next build`.
- Read-only probe of `conversionsReport` against the production database (read-only; corrected — an earlier version of this description said "dev", but lettertrace has a single Supabase project): all queries succeed (no `degraded`), 19.3% all time, recent daily cohorts 40–78%, average cadence 1.4 days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MQMjM2QFncNv5Pej3TKmit

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791654036&installation_model_id=431526&pr_number=181&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F181&signature=116cc663c13c8b1c680fae40bb46e6f3937d843c829c650e5f43df02b027f4c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
