### PR TITLE
Conversions: read the charts along the line, not through a tooltip

### DIFF
--- a/app/admin/conversions/day-rate-chart.tsx
+++ b/app/admin/conversions/day-rate-chart.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useRef, useState, type KeyboardEvent, type PointerEvent } from "react";
+
+/**
+ * A percentage per day, drawn as one filled line, read by moving along it.
+ *
+ * The numbers used to live in native <title> tooltips: they waited half a
+ * second, floated over the chart they were describing, and covered the very
+ * marks you were pointing at. So the readout is INLINE instead — one line
+ * directly under the chart that swaps to the day you are on and swaps back
+ * when you leave, plus a guide and a dot marking which day that is. Nothing
+ * overlaps the data, and nothing appears on a delay.
+ *
+ * The line is SVG (stretched, so a whole month fits) but the guide and dot are
+ * HTML positioned in percentages on top of it: preserveAspectRatio="none"
+ * scales x and y differently, which would squash a real <circle> into an
+ * ellipse of an aspect ratio that changes with the browser window.
+ *
+ * Points arrive already filtered of their null days: a day with nothing to
+ * divide by is a gap in the data, and interpolating across it would invent a
+ * number. `tint` is a color token name — both charts on this page are the same
+ * shape and differ only in hue.
+ */
+
+export interface DayRatePoint {
+  day: string;
+  rate: number;
+  /** The sentence shown under the chart while this day is the one being read. */
+  detail: string;
+}
+
+const W = 600;
+const H = 110;
+const PAD_TOP = 8;
+/** Where 0% sits, leaving the line room to be seen when it rests there. */
+const BASE = H - 4;
+
+export function DayRateChart({
+  points,
+  tint,
+  ariaLabel,
+  caption,
+}: {
+  points: DayRatePoint[];
+  tint: string;
+  ariaLabel: string;
+  /** What the readout says when nobody is pointing at a day — the summary of
+   *  the whole series. */
+  caption: string;
+}) {
+  const [active, setActive] = useState<number | null>(null);
+  const frame = useRef<HTMLDivElement>(null);
+
+  if (points.length === 0) return null;
+
+  const max = Math.max(0.1, ...points.map((p) => p.rate));
+  const x = (i: number) => (points.length === 1 ? W / 2 : (i / (points.length - 1)) * W);
+  const y = (rate: number) => BASE - (rate / max) * (BASE - PAD_TOP);
+  // One point can't make a line, so it becomes a flat one edge to edge — and
+  // the fill reuses these same coordinates so it always sits under the line.
+  const linePoints =
+    points.length === 1
+      ? [`0,${y(points[0].rate).toFixed(1)}`, `${W},${y(points[0].rate).toFixed(1)}`]
+      : points.map((p, i) => `${x(i).toFixed(1)},${y(p.rate).toFixed(1)}`);
+  const line = linePoints.join(" ");
+
+  /** Nearest day to a screen x. Points are evenly spaced by index, so this is
+   *  a fraction of the width and needs none of the SVG's own geometry. */
+  function read(clientX: number) {
+    const rect = frame.current?.getBoundingClientRect();
+    if (!rect || rect.width === 0) return;
+    const fraction = (clientX - rect.left) / rect.width;
+    const nearest = Math.round(fraction * (points.length - 1));
+    setActive(Math.min(points.length - 1, Math.max(0, nearest)));
+  }
+
+  function step(event: KeyboardEvent) {
+    const keys: Record<string, number | undefined> = {
+      ArrowLeft: -1,
+      ArrowRight: 1,
+      Home: -points.length,
+      End: points.length,
+    };
+    if (event.key === "Escape") {
+      setActive(null);
+      return;
+    }
+    const delta = keys[event.key];
+    if (delta === undefined) return;
+    event.preventDefault();
+    // Arriving by keyboard starts at the latest day, which is the one the
+    // caption is already talking about.
+    const from = active ?? points.length - 1;
+    setActive(Math.min(points.length - 1, Math.max(0, from + delta)));
+  }
+
+  const current = active === null ? null : points[active];
+  const markerLeft = current === null ? 0 : (x(active as number) / W) * 100;
+  const markerTop = current === null ? 0 : (y(current.rate) / H) * 100;
+
+  return (
+    <div className="mt-3">
+      <div
+        ref={frame}
+        tabIndex={0}
+        role="img"
+        aria-label={ariaLabel}
+        onPointerMove={(event: PointerEvent<HTMLDivElement>) => read(event.clientX)}
+        onPointerLeave={() => setActive(null)}
+        onBlur={() => setActive(null)}
+        onKeyDown={step}
+        className="relative touch-none rounded-sm outline-none ring-offset-2 ring-offset-surface focus-visible:ring-1 focus-visible:ring-ink/30"
+      >
+        <svg
+          viewBox={`0 0 ${W} ${H}`}
+          preserveAspectRatio="none"
+          className="block h-36 w-full"
+          aria-hidden
+        >
+          {/* Baseline at 0% — the one recessive gridline this needs. */}
+          <line
+            x1={0}
+            y1={BASE}
+            x2={W}
+            y2={BASE}
+            style={{ stroke: "rgb(var(--c-ink) / 0.12)", strokeWidth: 1 }}
+            vectorEffect="non-scaling-stroke"
+          />
+          <polygon
+            points={`0,${BASE} ${line} ${W},${BASE}`}
+            style={{ fill: `rgb(var(--c-${tint}) / 0.12)` }}
+          />
+          <polyline
+            points={line}
+            style={{ fill: "none", stroke: `rgb(var(--c-${tint}))`, strokeWidth: 2 }}
+            strokeLinejoin="round"
+            strokeLinecap="round"
+            vectorEffect="non-scaling-stroke"
+          />
+        </svg>
+
+        {current && (
+          <>
+            {/* Guide down to the baseline, and the dot on the line itself. */}
+            <span
+              aria-hidden
+              className="pointer-events-none absolute w-px bg-ink/20"
+              style={{
+                left: `${markerLeft}%`,
+                top: `${(PAD_TOP / H) * 100}%`,
+                bottom: `${((H - BASE) / H) * 100}%`,
+              }}
+            />
+            <span
+              aria-hidden
+              className="pointer-events-none absolute h-[7px] w-[7px] -translate-x-1/2 -translate-y-1/2 rounded-full border border-surface"
+              style={{
+                left: `${markerLeft}%`,
+                top: `${markerTop}%`,
+                backgroundColor: `rgb(var(--c-${tint}))`,
+              }}
+            />
+          </>
+        )}
+      </div>
+
+      {/* One fixed-height line so swapping the summary for a day's numbers
+          never nudges the rest of the card, and polite so a screen reader
+          hears the day it lands on rather than every day it passes over. */}
+      <p
+        aria-live="polite"
+        className="mt-3 flex min-h-[2.25rem] items-start text-xs tabular-nums text-ink-faint"
+      >
+        {current ? (
+          <span className="text-ink-soft">{current.detail}</span>
+        ) : (
+          <span>{caption}</span>
+        )}
+      </p>
+    </div>
+  );
+}

--- a/app/admin/conversions/page.tsx
+++ b/app/admin/conversions/page.tsx
@@ -9,6 +9,7 @@ import type { EmailClass } from "@/lib/growth";
 import { Badge, Card, SectionHeading, StatCard } from "@/components/ui";
 import { duration, timeAgo } from "@/lib/utils";
 import { PeriodSelect } from "../period-select";
+import { DayRateChart } from "./day-rate-chart";
 
 export const dynamic = "force-dynamic";
 export const metadata = { robots: { index: false, follow: false } };
@@ -44,97 +45,22 @@ function ColumnHeader({ children, className }: { children: React.ReactNode; clas
 }
 
 /**
- * A percentage per day, drawn as one filled line. Same construction as
- * Growth's RunSparkline: inline SVG, numbers in <title> tooltips, colors
- * through style because CSS var() only resolves in styles. One series, so the
- * card's title is the legend.
- *
- * Points arrive already filtered of their null days: a day with nothing to
- * divide by is a gap in the data, and interpolating across it would invent a
- * number. `tint` is a color token name — both charts on this page are the same
- * shape and differ only in hue.
- */
-function DayRateChart({
-  points,
-  tint,
-  ariaLabel,
-}: {
-  points: { day: string; rate: number; title: string }[];
-  tint: string;
-  ariaLabel: string;
-}) {
-  if (points.length === 0) return null;
-
-  const W = 600;
-  const H = 110;
-  const PAD_TOP = 8;
-  const max = Math.max(0.1, ...points.map((p) => p.rate));
-  const x = (i: number) => (points.length === 1 ? W / 2 : (i / (points.length - 1)) * W);
-  const y = (rate: number) => H - 4 - (rate / max) * (H - 4 - PAD_TOP);
-  // One point can't make a line, so it becomes a flat one edge to edge — and
-  // the fill reuses these same coordinates so it always sits under the line.
-  const linePoints =
-    points.length === 1
-      ? [`0,${y(points[0].rate).toFixed(1)}`, `${W},${y(points[0].rate).toFixed(1)}`]
-      : points.map((p, i) => `${x(i).toFixed(1)},${y(p.rate).toFixed(1)}`);
-  const line = linePoints.join(" ");
-  const bandW = W / points.length;
-
-  return (
-    <svg
-      viewBox={`0 0 ${W} ${H}`}
-      preserveAspectRatio="none"
-      className="h-36 w-full"
-      role="img"
-      aria-label={ariaLabel}
-    >
-      {/* Baseline at 0% — the one recessive gridline this needs. */}
-      <line x1={0} y1={H - 4} x2={W} y2={H - 4} style={{ stroke: "rgb(var(--c-ink) / 0.12)", strokeWidth: 1 }} vectorEffect="non-scaling-stroke" />
-      <polygon
-        points={`0,${H - 4} ${line} ${W},${H - 4}`}
-        style={{ fill: `rgb(var(--c-${tint}) / 0.12)` }}
-      />
-      <polyline
-        points={line}
-        style={{ fill: "none", stroke: `rgb(var(--c-${tint}))`, strokeWidth: 2 }}
-        strokeLinejoin="round"
-        strokeLinecap="round"
-        vectorEffect="non-scaling-stroke"
-      />
-      {/* Invisible per-day bands: hit targets wider than the marks, carrying
-          the native tooltip with the numbers for that day. */}
-      {points.map((p, i) => (
-        <rect
-          key={p.day}
-          x={x(i) - bandW / 2}
-          y={0}
-          width={bandW}
-          height={H}
-          fill="transparent"
-        >
-          <title>{p.title}</title>
-        </rect>
-      ))}
-    </svg>
-  );
-}
-
-/**
  * Each day's connected rate on its own — that day's clickers over the signups
  * that existed by then — so a quiet day sits on the baseline and a busy one
  * stands out, instead of every day folding into a total that can only climb.
  */
-function RateChart({ series }: { series: RatePoint[] }) {
+function RateChart({ series, caption }: { series: RatePoint[]; caption: string }) {
   return (
     <DayRateChart
       tint="mint-bright"
       ariaLabel="Connected rate over time"
+      caption={caption}
       points={series
         .filter((p): p is RatePoint & { rate: number } => p.rate !== null)
         .map((p) => ({
           day: p.day,
           rate: p.rate,
-          title: `${p.day} · ${p.rate}% connected (${p.connected} of ${p.signups} signups clicked this day) · ${p.clicks} click${p.clicks === 1 ? "" : "s"}`,
+          detail: `${p.day} · ${p.rate}% connected · ${p.connected} of ${p.signups} signups clicked this day · ${p.clicks} click${p.clicks === 1 ? "" : "s"}`,
         }))}
     />
   );
@@ -145,17 +71,18 @@ function RateChart({ series }: { series: RatePoint[] }) {
  * day, and the share of them running a report on a cadence today. Days nobody
  * signed up carry no rate and drop out entirely.
  */
-function ScheduleChart({ series }: { series: SchedulePoint[] }) {
+function ScheduleChart({ series, caption }: { series: SchedulePoint[]; caption: string }) {
   return (
     <DayRateChart
       tint="teal"
       ariaLabel="Share of each day's signups scheduling a report"
+      caption={caption}
       points={series
         .filter((p): p is SchedulePoint & { rate: number } => p.rate !== null)
         .map((p) => ({
           day: p.day,
           rate: p.rate,
-          title: `${p.day} · ${p.rate}% scheduling (${p.scheduled} of the ${p.signups} account${p.signups === 1 ? "" : "s"} that signed up this day)`,
+          detail: `${p.day} · ${p.rate}% scheduling · ${p.scheduled} of the ${p.signups} account${p.signups === 1 ? "" : "s"} that signed up this day run a report on a cadence`,
         }))}
     />
   );
@@ -375,16 +302,10 @@ export default async function ConversionsPage({ searchParams }: { searchParams: 
               cohort to draw.
             </p>
           ) : (
-            <>
-              <div className="mt-3">
-                <ScheduleChart series={scheduleSeries} />
-              </div>
-              <p className="mt-3 text-xs tabular-nums text-ink-faint">
-                each day is that day&apos;s signups, and how many of them run a report on a
-                cadence today · hover for the counts · a low-volume day is one or two people, so
-                read the shape, not a single point
-              </p>
-            </>
+            <ScheduleChart
+              series={scheduleSeries}
+              caption="each day is that day's signups, and how many of them run a report on a cadence today · move along the line for the counts · a low-volume day is one or two people, so read the shape, not a single point"
+            />
           )}
         </div>
       </Card>
@@ -402,17 +323,12 @@ export default async function ConversionsPage({ searchParams }: { searchParams: 
               rate to draw.
             </p>
           ) : (
-            <>
-              <div className="mt-3">
-                <RateChart series={series} />
-              </div>
-              <p className="mt-3 text-xs tabular-nums text-ink-faint">
-                {latest.day === today ? "today" : latest.day} {latest.rate}%
-                {peak && peak.day !== latest.day ? ` · peak ${peak.rate}% on ${peak.day}` : ""} · each
-                day on its own: users who clicked that day, over signups as of that day · hover for
-                daily numbers
-              </p>
-            </>
+            <RateChart
+              series={series}
+              caption={`${latest.day === today ? "today" : latest.day} ${latest.rate}%${
+                peak && peak.day !== latest.day ? ` · peak ${peak.rate}% on ${peak.day}` : ""
+              } · each day on its own: users who clicked that day, over signups as of that day · move along the line for daily numbers`}
+            />
           )}
         </div>
       </Card>


### PR DESCRIPTION
The day-by-day numbers on `/admin/conversions` lived in native `<title>` tooltips: they waited half a second, floated over the chart they were describing, and covered the very marks you were pointing at.

They move **inline**. One line under the chart carries the summary of the series, swaps to the day you are on as you move along the line, and swaps back when you leave — with a guide and a dot marking which day that is. Nothing overlaps the data, nothing waits, and the readout's height is fixed so the swap never nudges the rest of the card.

That makes the chart interactive, so it becomes a client component (`day-rate-chart.tsx`) and picks up what a tooltip never had: it takes focus, arrow keys step day by day (starting at the latest — the day the summary is already talking about), Home/End jump to the ends, Escape lets go, and the readout is `aria-live` so a screen reader hears the day it lands on rather than every day it passes through.

The guide and dot are HTML positioned in percentages rather than SVG marks: the chart stretches with `preserveAspectRatio="none"`, which would squash a real `<circle>` into an ellipse whose shape changes with the browser window.

Both charts on the page share the one component, as before.

## Verification

Signed-in headless browser against the production database (read-only; corrected — an earlier version of this description said "dev", but lettertrace has a single Supabase project), both charts, pointer and keyboard — plus the full suite (993), typecheck, lint and `next build`.

**Pointer, on the scheduling chart**

`2026-08-21 · 83.3% scheduling · 5 of the 6 accounts that signed up this day run a report on a cadence`

**Resting, on the connected chart**

`today 0.33% · peak 1.04% on 2026-09-01 · each day on its own: users who clicked that day, over signups as of that day · move along the line for daily numbers`

**Keyboard**: focus ring on the chart, four ArrowLefts from the latest day, readout at `2026-09-06 · 40% scheduling · 2 of the 5 accounts that signed up this day run a report on a cadence`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MQMjM2QFncNv5Pej3TKmit

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791655716&installation_model_id=431526&pr_number=182&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F182&signature=ff8f2e1b689fb060ded6a4f01da82a2096cc18a462b2b434525b81ac95751501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
