### PR TITLE
Conversions: each rung's chart sits under its own numbers

### DIFF
--- a/app/admin/conversions/page.tsx
+++ b/app/admin/conversions/page.tsx
@@ -192,6 +192,31 @@ export default async function ConversionsPage({ searchParams }: { searchParams: 
         </div>
       </section>
 
+      {/* ---- Row 1a: the connected rate over time ------------------------
+          Directly under the numbers it expands on, so each rung owns its own
+          chart — the cadence rung's sits under its cards the same way. */}
+      <Card>
+        <div className="flex flex-col px-5 pb-4 pt-5">
+          <div className="flex items-baseline justify-between gap-3">
+            <h3 className="text-sm font-semibold text-ink">Connected rate over time</h3>
+            <span className="text-xs text-ink-faint">{label}</span>
+          </div>
+          {series.length === 0 || !latest ? (
+            <p className="py-8 text-sm text-ink-faint">
+              No clicks {period === "all" ? "recorded yet" : "in this period"}, so there is no
+              rate to draw.
+            </p>
+          ) : (
+            <RateChart
+              series={series}
+              caption={`${latest.day === today ? "today" : latest.day} ${latest.rate}%${
+                peak && peak.day !== latest.day ? ` · peak ${peak.rate}% on ${peak.day}` : ""
+              } · each day on its own: users who clicked that day, over signups as of that day · move along the line for daily numbers`}
+            />
+          )}
+        </div>
+      </Card>
+
       {/* ---- Row 1b: the activation rung -------------------------------------
           A rung up from a click: the trial runs on the operator's shared keys,
           so pasting your own is where an account stops costing us money. The
@@ -310,30 +335,7 @@ export default async function ConversionsPage({ searchParams }: { searchParams: 
         </div>
       </Card>
 
-      {/* ---- Row 2: the rate over time ---------------------------------------- */}
-      <Card>
-        <div className="flex flex-col px-5 pb-4 pt-5">
-          <div className="flex items-baseline justify-between gap-3">
-            <h3 className="text-sm font-semibold text-ink">Connected rate over time</h3>
-            <span className="text-xs text-ink-faint">{label}</span>
-          </div>
-          {series.length === 0 || !latest ? (
-            <p className="py-8 text-sm text-ink-faint">
-              No clicks {period === "all" ? "recorded yet" : "in this period"}, so there is no
-              rate to draw.
-            </p>
-          ) : (
-            <RateChart
-              series={series}
-              caption={`${latest.day === today ? "today" : latest.day} ${latest.rate}%${
-                peak && peak.day !== latest.day ? ` · peak ${peak.rate}% on ${peak.day}` : ""
-              } · each day on its own: users who clicked that day, over signups as of that day · move along the line for daily numbers`}
-            />
-          )}
-        </div>
-      </Card>
-
-      {/* ---- Row 3: who's connected ------------------------------------------ */}
+      {/* ---- Row 2: who's connected ------------------------------------------ */}
       <section className="space-y-3">
         <div>
           <h3 className="text-lg font-semibold text-ink">Connected users</h3>


### PR DESCRIPTION
The connected rate chart had drifted two sections down `/admin/conversions`: #181 put the cadence rung and its chart in above it, so the curve describing the *first* row of cards ended up below three other rows, reading as though it belonged to the last one.

It moves back up, directly under the connected cards it expands on — the same rule the cadence rung already follows.

Order is now:

1. Connected · clicked out to another Letter product
2. Connected rate over time
3. Activated · connected their own API key
4. Scheduled · keeps a report running on a cadence
5. Scheduling rate by signup cohort
6. Connected users

A pure move: no markup or copy inside the card changed.

## Verification

Rendered order read back from the DOM in a signed-in headless browser against the production database (read-only; corrected — an earlier version of this description said "dev", but lettertrace has a single Supabase project), matching the list above. Full suite (993), typecheck, lint and `next build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MQMjM2QFncNv5Pej3TKmit

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/letterstory/codesmith/lettertrace/pr/187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791744752&installation_model_id=431526&pr_number=187&repository=letterstory%2Flettertrace&return_to=https%3A%2F%2Fgithub.com%2Fletterstory%2Flettertrace%2Fpull%2F187&signature=05ada1f501d64c23a27e87e749995a350d6b5279686f9eb16906b7c0c8e0c113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
